### PR TITLE
api gateway: map port 443 instead of 80 as part of a switch to SSL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     mender-api-gateway:
         image: mendersoftware/api-gateway:latest
         ports:
-            - "9080:80"
+            - "9080:443"
         networks:
             mender:
                 aliases:


### PR DESCRIPTION
must be merged together with:
https://github.com/mendersoftware/mender-api-gateway-docker/pull/10
