### PR TITLE
[DO NOT MERGE] POC for detecting API host address for mender-gui ran via VM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,10 @@ services:
             - "8081:80"
         networks:
             - mender
+        # when run via ./up, this env var will contain the host's IP
+        # the app serving the js must pick it up and override its default config value
+        environment:
+            - DOCKER_HOST_IP
 
     #
     # mender-api-gateway

--- a/up
+++ b/up
@@ -1,0 +1,8 @@
+#!/bin/sh
+# wraps 'docker-compose up', first setting the
+# env vars important for dev environments on OSX
+
+# using docker-machine, assuming just one vm is started through it
+export DOCKER_HOST_IP=$(docker-machine ip)
+
+sudo -E docker-compose up


### PR DESCRIPTION
use ./up instead of docker-compose up:
- this will set the DOCKER_HOST_IP env var without user intervention
- ...and pass it to docker

the application inside the container must override its default config with this value,
and serve the modified js.

Signed-off-by: mchalczynski marcin.chalczynski@open-rnd.pl
