### PR TITLE
Mender client related fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
         networks:
             - mender
         ports:
-            - "8822"
+            - "8822:8822"
 
 networks:
     mender:


### PR DESCRIPTION
The first patch aliases API gateway as mender.io inside the container network. This is needed for mender-client, as it's set up to reach out to https://mender.io in the configuration.

The second patch exposes mender-client port 8822/tcp  on localhost:8822. Previously the port would get exposed locally on some random port.

@kacf @GregorioDiStefano
