### PR TITLE
tesing: make it possible to specify yoctoid

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -52,8 +52,13 @@ class Helpers(object):
 
 
     @staticmethod
-    def yocto_id_randomize(install_image):
-        imageid = "core-image-full-cmdline-%s" % str(random.randint(0,99999999))
+    def yocto_id_randomize(install_image, specific_image_id=None):
+
+        if specific_image_id:
+            imageid = specific_image_id
+        else:
+            imageid = "core-image-full-cmdline-%s" % str(random.randint(0,99999999))
+
         config_file = r"""------------------------
 Mender device manifest:|
 ------------------------


### PR DESCRIPTION
@pasinskim 

this why i can just import helpers and modify the image for testing using the already existing python function
