### PR TITLE
update readme to common template + related changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,146 +1,157 @@
-# Integration
+Mender: Integration
+==============================================
 
-This project provides a Docker-based environment allowing to run all Mender
-backend services as a single system.
+Mender is an open source over-the-air (OTA) software updater for embedded Linux
+devices. Mender comprises a client running at the embedded device, as well as
+a server that manages deployments across many devices.
 
-##Requirements
+This repository contains a Docker-based environment allowing to run all Mender backend services as a single system. Each service has a dedicated Dockerhub repository, where tagged Docker builds are stored. Images are pulled and started in a coordinated fashion via `docker-compose` and the associated `docker-compose.yml` file.
+
+Requirements:
 
 * docker-engine 1.10
 * docker-compose 1.7
 
-##Overview
 
-The solution is based on the following assumptions:
+![Mender logo](https://mender.io/user/pages/04.resources/_logos/logoS.png)
 
-* each service has a dedicated Dockerfile, typically living in the service's
-  github repo
-* for each service, Travis automatically builds a docker image and pushes it to
-  a dedicated Dockerhub repo
-* coordinated pulling/running of all Docker containers is performed by
-  `docker-compose` via the master `docker-compose.yml` file
-* common service configuration is included in `common.yml/mender-base`, which
-  can be extended by any new service
 
-##Basic Usage
+## Getting started
 
-Run the environment:
+To start using Mender, we recommend that you begin with the Getting started
+section in [the Mender documentation](https://docs.mender.io/).
 
-```
-bash up
-```
 
-At this point all services should be up and running, which can be verified by:
+## Services
 
-```
-sudo docker-compose ps
+The integration environment brings together the following services:
 
-       Name               Command         State           Ports
-------------------------------------------------------------------------
-mender-api-gateway   ./dummy-entrypoint   Up
-mender-artifacts     ./artifacts          Up      0.0.0.0:8080->8080/tcp
-mender-device-auth   ./deviceauth         Up
-...
+- [Mender Device Admission Service](https://github.com/mendersoftware/deviceadm)
+- [Mender Device Authentication Service](https://github.com/mendersoftware/deviceauth)
+- [Mender Deployment Service](https://github.com/mendersoftware/deployments)
+- [Mender Device Inventory Service](https://github.com/mendersoftware/inventory)
+- [Mender API Gateway](https://github.com/mendersoftware/mender-api-gateway-docker)
+- [fake-s3](https://github.com/lphoward/fake-s3)
 
-```
-
-A couple of important points to notice:
-
-* dockerized services join a common network, where they can access each other
-  via their service names (e.g. `http://mender-artifacts:8080`)
-* a service can also be accessed from the Docker host (localhost) via its mapped
-  ports (`ports` directive in `docker-compose.yml`)
-* if necessary, a service can access the Docker host via the host's address on
-  the `docker0` interface, e.g.:
-
-```
-ip a
-
-...
-8: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
-    link/ether 02:42:31:dd:6e:6c brd ff:ff:ff:ff:ff:ff
-    inet 172.17.0.1/16 scope global docker0
-       valid_lft forever preferred_lft forever
-...
-```
-
-##Integrating a new service
+## Integrating a new service
 
 Adding a new service to the setup involves:
 
 * creating a dedicated Dockerfile
-* setting up a Dockerhub repo + Travis image build
+* setting up a Dockerhub repository and a CI build pipeline
 * adding the service's config under `docker-compose.yml`
 
-Guidelines/things to consider:
+Guidelines and things to consider:
 
 * assign the service a name that is unique within `docker-compose.yml`
-* extend the service `mender-common/common.yml`
-* include a port mapping to make the service available via `localhost`
-    * important in development for quick requests via curl/DHC/etc.
-* mount log destinations to Docker host's folder, e.g.:
+* add the service to the `mender` network
+* setup the correct routing and authentication for the new service in the
+[Mender API Gateway](https://github.com/mendersoftware/mender-api-gateway-docker)
+* extend the common service `mender-common/common.yml`
 
-```
-    myservice:
-        ...
-        volumes:
-            - /var/log/myservice:/var/log/myservice
-        ...
-```
+## How to use in development
 
-##How to use in development
-
-The simple build & run procedure sets up a complete system of services in their
-latest versions. As such it can readily be used for testing, staging or production
-environments.
+Running the integration setup brings up a complete system of services; as such
+it can readily be used for testing, staging or production environments.
 
 In development scenarios however some additional strategies apply, described in
 the following sections.
 
 ### Developing a new service
-When developing a new service (not included in `docker-compose` yet) against an
-existing system:
 
-* build and run the environment
-* temporarily use `localhost` and exposed/mapped service ports to access
-  existing services
+The default approach to integrating a service, involving the full build pipeline, is not conducive to
+quick develop/build/test cycles. Therefore, when prototyping a new service against an existing system,
+it can be useful to:
 
-### Troubleshooting/developing an existing service
-It's important to note that for every docker image, the embedded binaries and
-configs can be overriden by mounting a local version in their place, e.g.:
+* create a dedicated Dockerfile for your service and build it locally:
+```
+cd FOLDER_WITH_DOCKERFILE
+docker build -t MY_DOCKER_TAG  .
+```
 
+* include the service as usual in `docker-compose.yml`, paying attention to the image tag you just created:
+```
+    #
+    # myservice
+    #
+    myservice:
+        image: MY_DOCKER_TAG
+```
+
+* add any number of [volumes](https://docs.docker.com/compose/compose-file/#/volumes-volume-driver) to your service,
+to mount your local binaries and config files into the Docker container, e.g.:
 ```
     myservice:
+        ...
         volumes:
-            - /some/localhost/folder/config.yaml:/usr/bin/config.yaml
-            - /some/localhost/folder/mybinary:/usr/bin/mybinary
+             /some/localhost/folder/myconfig.yaml:/usr/bin/myconfig.yaml
+             /some/localhost/folder/mybinary:/usr/bin/mybinary
+            ...
 ```
-The primary strategy of developing existing services should be:
-* make the necessary local modifications
-* compile the service
-* mount the compiled binary
-* run the environemt as usual via ```docker-compose up```
 
-An alternative, but more complex approach:
-* disable the service in `docker-compose` (comment the relevant section)
-* modify the service and run it from its binary
-* all other services should be temporarily configured to access the developed
-  one via `localhost`'s `docker0` address
-* as above, the service under dev should access other services via ports exposed
-  on `localhost`
+When you run the setup, your new service will be a part of it; also, it will be running
+binaries from your local machine, which means you can quickly recompile them and restart `integration`
+for changes to take effect.
 
-## Configuration management
-* currently some default configuration is embedded in built images
-* eventually configuration will be managed by etcd, so services should gradually
-migrate to use it instead
+Note that the correct routing and auth still have to be set up in the Mender API Gateway for the service
+to be accessible from the outside. To experiment with new configuration:
+* copy the [Gateway's main config file](https://github.com/mendersoftware/mender-api-gateway-docker/blob/master/nginx.conf) locally
+* in `docker-compose.yml`, again mount your local version inside the Gateway container:
+```
+    #
+    # mender-api-gateway
+    #
+    mender-api-gateway:
+        ...
+        /some/localhost/folder/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
+```
+Your changes will take effect when you restart the whole setup.
 
-## Helpers & `/etc/hosts`
+### Troubleshooting/developing an existing service
 
-Script `up` can be used to automate augmenting `/etc/hosts` with required
-entries (as needed) and running `docker-compose` in one shot.
+For troubleshooting and debugging, a similar approach involving Docker `volumes`
+can be used. Assuming that a given service's image has been pulled to your local
+machine, mount your local binaries and config files via `docker-compose.yml`:
 
-...note
+```
+    service:
+        ...
+        volumes:
+             /some/localhost/folder/myconfig.yaml:/usr/bin/config.yaml
+             /some/localhost/folder/mybinary:/usr/bin/service-binary
+            ...
+```
 
-    `up` script modifies `/etc/hosts`, thus it requires root privileges to run
+To obtain the locations of both binaries and config files, refer the service's
+dedicated Dcokerfile.
 
-Running `up -n` will only update `/etc/hosts`, without starting docker
-environment.
+Again, recompiling your local binary and restarting `integration` will make
+your changes take effect. Note that the correct API Gateway config is probably already
+set up for an existing service; if not, refer the previous section on how to modify it.
+
+## Contributing
+
+We welcome and ask for your contribution. If you would like to contribute to Mender, please read our guide on how to best get started [contributing code or
+documentation](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md).
+
+## License
+
+Mender is licensed under the Apache License, Version 2.0. See
+[LICENSE](https://github.com/mendersoftware/integration/blob/master/LICENSE) for the
+full license text.
+
+## Security disclosure
+
+We take security very seriously. If you come across any issue regarding
+security, please disclose the information by sending an email to
+[security@mender.io](security@mender.io). Please do not create a new public
+issue. We thank you in advance for your cooperation.
+
+## Connect with us
+
+* Join our [Google
+  group](https://groups.google.com/a/lists.mender.io/forum/#!forum/mender)
+* Follow us on [Twitter](https://twitter.com/mender_io?target=_blank). Please
+  feel free to tweet us questions.
+* Fork us on [Github](https://github.com/mendersoftware)
+* Email us at [contact@mender.io](mailto:contact@mender.io)

--- a/up
+++ b/up
@@ -50,7 +50,7 @@ rundocker() {
 
 showhelp() {
     echo "usage: $(basename $0) [-n] [-h]"
-    echo "   -n   do run start docker-compose"
+    echo "   -n   do not run docker-compose"
     echo "   -h   show help"
 }
 


### PR DESCRIPTION
'integration' is probably the only repo which requires a slightly more elaborate readme, so I took the liberty of extending the template slightly. I still tried to keep it short and sweet, and transferred some interesting but advanced topics to a HACKING.md file. There's also a small fix in the 'up' script itself.

@eysteins 
