### PR TITLE
force shell to bash

### DIFF
--- a/up
+++ b/up
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # wraps 'docker-compose up', first setting the
 # env vars important for dev environments on OSX
 # using docker-machine, assuming just one vm is started through it


### PR DESCRIPTION
'set -e -o pipefail' is bash-specific, and causes errors e.g. on Ubuntu 16.04,
since 'dash' has a different syntax

Signed-off-by: mchalczynski marcin.chalczynski@rndity.com

@maciejmrowiec @bboozzoo @kjaskiewiczz 
