### PR TITLE
MEN-665: Remove setting DOCKER_HOST_IP and GATEWAY_IP env variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,11 +76,6 @@ services:
         image: mendersoftware/gui:latest
         networks:
             - mender
-        # when run via ./up, this env var will contain the host's IP
-        # the app serving the js must pick it up and override its default config value
-        environment:
-            GATEWAY_IP: ${DOCKER_HOST_IP}
-            GATEWAY_PORT: 8080
 
     #
     # mender-api-gateway

--- a/up
+++ b/up
@@ -46,8 +46,8 @@ setuphosts() {
 }
 
 rundocker() {
-    sudo -E DOCKER_HOST_IP=$DOCKER_HOST_IP docker-compose scale mender-client=3
-    sudo -E DOCKER_HOST_IP=$DOCKER_HOST_IP docker-compose up
+    sudo -E docker-compose scale mender-client=3
+    sudo -E docker-compose up
 }
 
 showhelp() {


### PR DESCRIPTION
not used anymore by gui, related to https://github.com/mendersoftware/gui/pull/79

@michaelatmender @mchalski 
