### PR TITLE
Set specific minio version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     # minio
     #
     minio:
-        image: minio/minio
+        image: minio/minio:RELEASE.2016-10-07T01-16-39Z
         ports:
             - "9000:9000"
         networks:


### PR DESCRIPTION
Current integration with latest 'stable' version of minio does not start, printing cli help and exit status 0. For now, let's get latest release version, which works fine.

@kjaskiewiczz