### PR TITLE
make mender-api-gateway depend on mender-useradm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
             - mender-device-adm
             - mender-deployments
             - mender-gui
+            - mender-useradm
 
     #
     # mender-device-auth


### PR DESCRIPTION
without this - gateway is likely to fail ('upstream host not found')