### PR TITLE
docker-compose: api-gateway: publish non-SSL port to local 8090

### DIFF
--- a/docker-compose.no-ssl.yml
+++ b/docker-compose.no-ssl.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+
+    mender-api-gateway:
+        ports:
+            - "8090:80"


### PR DESCRIPTION
A follow-up of https://github.com/mendersoftware/mender-api-gateway-docker/pull/39

Add separate compose file that exposes a non-SSL port on API gateway. This warrants an entry in README, but I'll wait for #74 to get merged first just to avoid conflicts in README.md.

To publish a port, one has to explicitlyl include `docker-compose.no-ssl.yml` in `docker-compose .. up` command.

@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano

