### PR TITLE
storage-proxy: storage proxy with rate and connection limiting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     #
     minio:
         image: minio/minio:RELEASE.2016-12-13T17-19-42Z
-        ports:
-            - "9000:9000"
         networks:
             mender:
                 aliases:
@@ -16,11 +14,38 @@ services:
                     # running the 'up' script (found in this dir.) will add the required entry to /etc/hosts
                     - mender-artifact-storage.localhost
                     - mender-artifact-storage.s3.docker.mender.io
-                    - s3.docker.mender.io
+                    - minio.s3.docker.mender.io
         environment:
             MINIO_ACCESS_KEY: minio
             MINIO_SECRET_KEY: minio123
         command: server /export
+
+    #
+    # storage backend proxy used in conjunction with minio, applies
+    # rate & connection limiting
+    #
+    storage-proxy:
+        image: openresty/openresty:alpine
+        ports:
+            - "9000:9000"
+        networks:
+            mender:
+                aliases:
+                    - s3.docker.mender.io
+        environment:
+
+            # use nginx syntax for rate limiting, see
+            # https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate
+            # Examples:
+            #   1m - 1MB/s
+            #   512k - 512kB/s
+            DOWNLOAD_SPEED: 1m
+            MAX_CONNECTIONS: 100
+        volumes:
+            - ./storage-proxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
+        depends_on:
+            - minio
+
     #
     # mender-deployments
     #

--- a/storage-proxy/nginx.conf
+++ b/storage-proxy/nginx.conf
@@ -1,0 +1,96 @@
+worker_processes  auto;
+
+error_log  /dev/stdout warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+env DOWNLOAD_SPEED;
+env MAX_CONNECTIONS;
+
+http {
+
+    init_by_lua_block {
+        ngx.log(ngx.WARN, "download speed limit: " .. (os.getenv("DOWNLOAD_SPEED") or "not set"))
+        ngx.log(ngx.WARN, "max connections: " .. (os.getenv("MAX_CONNECTIONS") or "not set"))
+    }
+
+    upstream minio_backend {
+        server minio:9000 max_fails=0;
+    }
+
+    lua_shared_dict my_limit_conn_store 100m;
+
+    server {
+
+        proxy_max_temp_file_size 0;
+
+        listen 9000;
+
+        location / {
+            access_by_lua_block {
+                -- rate and connection limiting is applied only to GET requests
+                if ngx.req.get_method() == "GET" then
+
+                   local max_connections = tonumber(os.getenv("MAX_CONNECTIONS"))
+                   if max_connections ~= nil then
+                      local limit_conn = require "resty.limit.conn"
+
+                      local lim, err = limit_conn.new("my_limit_conn_store", max_connections, 0, 1)
+                      if not lim then
+                         ngx.log(ngx.ERR,
+                                 "failed to instantiate a resty.limit.conn object: ", err)
+                         return ngx.exit(500)
+                      end
+
+                      local key = ngx.var.binary_remote_addr
+                      local delay, err = lim:incoming(key, true)
+                      if not delay and err ~= "rejected" then
+                         ngx.log(ngx.ERR, "failed to limit req: ", err)
+                         return ngx.exit(500)
+                      elseif not delay or delay > 0 then
+                         ngx.log(ngx.WARN, "connection rejected")
+                         return ngx.exit(503)
+                      end
+
+                      if lim:is_committed() then
+                         local ctx = ngx.ctx
+                         ctx.limit_conn = lim
+                         ctx.limit_conn_key = key
+                         ctx.limit_conn_delay = delay
+                      end
+                   end
+
+                   local download_speed = os.getenv("DOWNLOAD_SPEED")
+                   if download_speed ~= nil then
+                      ngx.var.limit_rate = download_speed
+                   end
+                end
+            }
+
+            log_by_lua_block {
+                local ctx = ngx.ctx
+                local lim = ctx.limit_conn
+                if lim then
+                    local latency = tonumber(ngx.var.request_time)
+                    local key = ctx.limit_conn_key
+                    assert(key)
+                    local conn, err = lim:leaving(key, latency)
+                    if not conn then
+                        ngx.log(ngx.ERR,
+                                "failed to record the connection leaving ",
+                                "request: ", err)
+                        return
+                    end
+                end
+            }
+            client_max_body_size 0;
+            proxy_request_buffering off;
+
+            proxy_set_header Host s3.docker.mender.io:9000;
+            proxy_pass http://minio_backend;
+        }
+    }
+}


### PR DESCRIPTION
Add a storage proxy that applies download rate and connection limiting to
incoming GET requests.

The service is implemented using openresty and Lua extensions. When connection
limit is hit, a 503 Service Temporarily Unavailable is returned.

Minio is hidden behing storage proxy for all requests, i.e. internal requests
from Deployments Service will also go through storage proxy. This is required
because of signed request in S3, which the target host name is a part of.

The default limits are:
- download rate: 1MB/s
- max connections: 100

@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano 