### PR TITLE
docker-compose: make the gateway depend on inventory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
             - mender-deployments
             - mender-gui
             - mender-useradm
+            - mender-inventory
         #mount production SSL cert/key from selected location
         #volumes:
         #    - /path/to/ssl/cert:/var/www/mendersoftware/cert/cert.pem


### PR DESCRIPTION
caught by accident when testing migration to alpine linux.

the gateway would fail consistently, even though inventory was definitely up. the usual 'upstream server mender-inventory not found' was emitted.

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@bboozzoo @GregorioDiStefano 