### PR TITLE
Add docker-compose file for client development.

### DIFF
--- a/docker-compose.client-dev.yml
+++ b/docker-compose.client-dev.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+
+    #
+    # mender-client: For local development using BUILDDIR for images.
+    #
+    mender-client:
+        volumes:
+            - ${BUILDDIR}:/mnt/build:ro


### PR DESCRIPTION
With it you can use your build dir as input instead of the image.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>