### PR TITLE
Integrate docker-compose into test framework itself.

### DIFF
--- a/tests/MenderAPI/__init__.py
+++ b/tests/MenderAPI/__init__.py
@@ -2,7 +2,6 @@ import os
 import logging
 
 api_version = os.getenv("MENDER_API_VERSION", "0.1")
-gateway = os.getenv("GATEWAY_IP_PORT", "127.0.0.1:8080")
 
 logger = logging.getLogger()
 
@@ -10,41 +9,15 @@ logger.setLevel(logging.DEBUG)
 #logging.getLogger("paramiko").setLevel(logging.DEBUG)
 
 logging.info("Setting api_version as: " + api_version)
-logging.info("Setting gateway as: " + gateway)
 
+import authentication
 import admission
 import deployments
 import artifacts
 import inventory
 
-import requests
-from requests.auth import HTTPBasicAuth
-
-def get_auth_token():
-    email = "admin@admin.net"
-    password = "averyverystrongpasswordthatyouwillneverguess!haha!"
-
-    def get_header(t):
-        return {"Authorization": "Bearer " + str(t)}
-
-    r = requests.post("https://%s/api/management/%s/useradm/auth/login" % (gateway, api_version), verify=False)
-    auth_header = get_header(r.text)
-
-    if r.status_code == 200:
-        auth_header = get_header(r.text)
-        r = requests.post("https://%s/api/management/%s/useradm/users/initial" % (gateway, api_version), headers=auth_header, verify=False, json={"email": email, "password": password})
-        assert r.status_code == 201
-
-    r = requests.post("https://%s/api/management/%s/useradm/auth/login" % (gateway, api_version), verify=False, auth=HTTPBasicAuth(email, password))
-    assert r.status_code == 200
-
-    auth_header = get_header(r.text)
-    logging.info("Using Authorization headers: " + str(r.text))
-    return auth_header
-
-auth_header = get_auth_token()
-
-adm = admission.Admission(auth_header)
-deploy = deployments.Deployments(auth_header)
+auth = authentication.Authentication()
+adm = admission.Admission(auth)
+deploy = deployments.Deployments(auth)
 image = artifacts.Artifacts()
-inv = inventory.Inventory(auth_header)
+inv = inventory.Inventory(auth)

--- a/tests/MenderAPI/authentication.py
+++ b/tests/MenderAPI/authentication.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+# Copyright 2016 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import requests
+import logging
+
+from common_docker import *
+from MenderAPI import api_version
+
+class Authentication:
+    auth_header = None
+
+    def get_auth_token(self):
+        if self.auth_header is not None:
+            return self.auth_header
+
+        email = "admin@admin.net"
+        password = "averyverystrongpasswordthatyouwillneverguess!haha!"
+
+        def get_header(t):
+            return {"Authorization": "Bearer " + str(t)}
+
+        r = requests.post("https://%s/api/management/%s/useradm/auth/login" % (get_mender_gateway(), api_version), verify=False)
+        self.auth_header = get_header(r.text)
+
+        if r.status_code == 200:
+            self.auth_header = get_header(r.text)
+            r = requests.post("https://%s/api/management/%s/useradm/users/initial" % (get_mender_gateway(), api_version), headers=self.auth_header, verify=False, json={"email": email, "password": password})
+            assert r.status_code == 201
+
+        r = requests.post("https://%s/api/management/%s/useradm/auth/login" % (get_mender_gateway(), api_version), verify=False, auth=HTTPBasicAuth(email, password))
+        assert r.status_code == 200
+
+        self.auth_header = get_header(r.text)
+        logging.info("Using Authorization headers: " + str(r.text))
+        return self.auth_header
+
+
+    def reset_auth_token(self):
+        self.auth_header = None

--- a/tests/MenderAPI/inventory.py
+++ b/tests/MenderAPI/inventory.py
@@ -20,15 +20,19 @@ import json
 from fabric.api import *
 import time
 import pytest
-from MenderAPI import gateway, api_version, logger, admission
+from common_docker import *
+from MenderAPI import api_version, logger, admission
 
 class Inventory():
-    auth_header = None
-    def __init__(self, auth_header):
-        self.auth_header = auth_header
-        self.inv_base_path = "https://%s/api/management/%s/inventory/" % (gateway, api_version)
+    auth = None
+
+    def __init__(self, auth):
+        self.auth = auth
+
+    def get_inv_base_path(self):
+        return "https://%s/api/management/%s/inventory/" % (get_mender_gateway(), api_version)
 
     def get_devices(self):
-        devices = requests.get(self.inv_base_path + "devices", headers=self.auth_header, verify=False)
+        devices = requests.get(self.get_inv_base_path() + "devices", headers=self.auth.get_auth_token(), verify=False)
         assert devices.status_code == requests.status_codes.codes.ok
         return devices.json()

--- a/tests/common_docker.py
+++ b/tests/common_docker.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+# Copyright 2016 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+from fabric.api import *
+import pytest
+import subprocess
+
+import conftest
+from common import *
+
+
+COMPOSE_FILES = [
+    "../docker-compose.yml",
+    "../docker-compose.client.yml",
+    "../docker-compose.demo.yml"
+]
+
+def docker_compose_cmd(arg_list):
+    files_args = ""
+    for file in COMPOSE_FILES:
+        files_args += " -f %s" % file
+
+    subprocess.check_call("docker-compose %s %s" % (files_args, arg_list), shell=True)
+
+
+def stop_docker_compose():
+    docker_compose_cmd("down -v")
+
+    set_setup_type(None)
+
+
+def start_docker_compose():
+    docker_compose_cmd("up -d")
+    docker_compose_cmd("logs -f &")
+
+    ssh_is_opened()
+
+    set_setup_type(ST_OneClient)
+
+
+def restart_docker_compose():
+    stop_docker_compose()
+    start_docker_compose()
+
+
+def docker_get_ip_of(image):
+    # Returns newline separated list of IPs
+    output = subprocess.check_output("docker ps --filter='ancestor=%s' --format='{{.ID}}' | xargs -r docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'" % image, shell=True)
+
+    # Return as list.
+    return output.split()
+
+
+def get_mender_clients():
+    return [ip + ":8822" for ip in docker_get_ip_of("mendersoftware/mender-client-qemu")]
+
+
+def get_mender_gateway():
+    return docker_get_ip_of("mendersoftware/api-gateway")[0]
+
+
+def ssh_is_opened():
+    execute(ssh_is_opened_impl, hosts=get_mender_clients())
+
+
+@parallel
+def ssh_is_opened_impl(cmd="true", wait=60):
+    count = 0
+
+    while count < wait:
+        try:
+            # no point in printing this with each test
+            with quiet():
+                return run(cmd)
+        except BaseException:
+            time.sleep(1)
+            count += 1
+            continue
+        else:
+            break
+
+    if count >= 60:
+        logging.fail("Unable to connect to host: ", env.host_string)

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+# Copyright 2016 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import pytest
+
+from MenderAPI import auth, adm
+from common import *
+from common_docker import *
+
+@pytest.fixture(scope="function")
+def standard_setup_one_client():
+    if setup_type() == ST_OneClient:
+        return
+
+    restart_docker_compose()
+    auth.reset_auth_token()
+
+    set_setup_type(ST_OneClient)
+
+
+def setup_set_client_number(clients):
+    docker_compose_cmd("scale mender-client=%d" % clients)
+    ssh_is_opened()
+
+    set_setup_type(None)
+
+
+@pytest.fixture(scope="function")
+def standard_setup_one_client_bootstrapped():
+    if setup_type() == ST_OneClientBootstrapped:
+        return
+
+    restart_docker_compose()
+    auth.reset_auth_token()
+    adm.accept_devices(1)
+
+    set_setup_type(ST_OneClientBootstrapped)
+
+
+@pytest.fixture(scope="function")
+def standard_setup_two_clients_bootstrapped():
+    if setup_type() == ST_TwoClientsBootstrapped:
+        return
+
+    restart_docker_compose()
+    auth.reset_auth_token()
+    setup_set_client_number(2)
+    adm.accept_devices(2)
+
+    set_setup_type(ST_TwoClientsBootstrapped)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,10 +28,6 @@ except:
     pass
 
 def pytest_addoption(parser):
-    parser.addoption("--clients", action="store",
-                     help="Comma-seperate mender hosts, example: 10.100.10.11:8822, 10.100.10.12:8822")
-    parser.addoption("--gateway", action="store", default="127.0.0.1:8080",
-                     help="Host of mender gateway")
     parser.addoption("--api", action="store", default="0.1", help="API version used in HTTP requests")
     parser.addoption("--image", action="store_true", default="core-image-full-cmdline-vexpress-qemu.ext4", help="Valid update image")
     parser.addoption("--runslow", action="store_true", help="run slow tests")
@@ -39,8 +35,6 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    env.clients = [ip.strip() for ip in config.getoption("clients").split(",")]
-    env.mender_gateway = config.getoption("gateway")
     env.api_version = config.getoption("api")
     env.valid_image = config.getoption("image")
 
@@ -72,8 +66,9 @@ def pytest_configure(config):
     env.banner_timeout = 60
 
 
-def get_mender_clients():
-    return env.clients
+def pytest_unconfigure():
+    from common_docker import stop_docker_compose
+    stop_docker_compose()
 
 
 def get_valid_image():

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -5,37 +5,20 @@ set -x -e
 # local hard drive.
 
 run_slow_tests () {
-    py.test --maxfail=1 -s --tb=short --runslow --gateway "${GATEWAY_IP_PORT}" --clients "${CLIENT_IP_PORT}" --verbose --junitxml=results.xml tests/{test_basic_integration.py,test_image_update_failures.py,test_fault_tolerance.py}
+    py.test --maxfail=1 -s --tb=short --runslow --verbose --junitxml=results.xml
 }
 
 run_fast_tests() {
-    py.test --maxfail=1 -s --tb=short --runfast --gateway "${GATEWAY_IP_PORT}" --clients "${CLIENT_IP_PORT}" --verbose --junitxml=results.xml tests/{test_bootstrapping.py,test_basic_integration.py,test_image_update_failures.py,test_fault_tolerance.py}
+    py.test --maxfail=1 -s --tb=short --runfast --verbose --junitxml=results.xml
 }
-
-if [[ $INSIDE_DOCKER -eq 1 ]]; then
-    # will assume if running inside docker, you are testing with the docker-compose setup
-    DOCKER_GATEWAY=$(/sbin/ip route|awk '/default/ { print $3 }')
-    CLIENT_IP_PORT="mender-client:8822"
-    GATEWAY_IP_PORT=$DOCKER_GATEWAY":8080"
-
-    # remove cached file and setup fakes3 hack
-    find . -iname '*.pyc' -delete || true
-    echo "${DOCKER_GATEWAY}" "mender-artifact-storage.s3.docker.mender.io" | tee -a /etc/hosts >/dev/null
-else
-    while [ ! $(docker ps | grep mender-client | wc -l) -eq 1 ]; do echo "Mender docker container not running.." && sleep 10; done
-    CLIENT_IP_PORT=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps | grep "mender-client" | awk '{ print $1 }')):8822
-    GATEWAY_IP_PORT=${GATEWAY_IP_PORT:-"127.0.0.1:8080"}
-fi
-
-export GATEWAY_IP_PORT
 
 if [[ ! -f large_image.dat ]]; then
     dd if=/dev/zero of=large_image.dat bs=200M count=0 seek=1
 fi
 
 if [[ ! -f mender-artifact ]]; then
-    if [ -f /mnt/build/tmp/sysroots/x86_64-linux/usr/bin/mender-artifact ]; then
-        cp /mnt/build/tmp/sysroots/x86_64-linux/usr/bin/mender-artifact .
+    if [ -n "$BUILDDIR" ] && [ -f $BUILDDIR/tmp/sysroots/x86_64-linux/usr/bin/mender-artifact ]; then
+        cp $BUILDDIR/tmp/sysroots/x86_64-linux/usr/bin/mender-artifact .
     else
         curl "https://d25phv8h0wbwru.cloudfront.net/master/tip/mender-artifact" -o mender-artifact
     fi
@@ -43,9 +26,9 @@ if [[ ! -f mender-artifact ]]; then
 fi
 
 if [[ ! -f core-image-full-cmdline-vexpress-qemu.ext4 ]] ; then
-    if [ -f /mnt/build/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 ]; then
-        echo "!! WARNING: core-image-file-cmdline-vexpress-qemu.ext4 was not found in the current working directory, grabbing from mounted volume !!"
-        cp /mnt/build/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 .
+    if [ -n "$BUILDDIR" ] && [ -f $BUILDDIR/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 ]; then
+        echo "!! WARNING: core-image-file-cmdline-vexpress-qemu.ext4 was not found in the current working directory, grabbing from BUILDDIR !!"
+        cp $BUILDDIR/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 .
     else
         echo "!! WARNING: core-image-file-cmdline-vexpress-qemu.ext4 was not found in the current working directory, will download the latest !!"
         curl -o core-image-full-cmdline-vexpress-qemu.ext4 "https://s3.amazonaws.com/mender/temp/core-image-full-cmdline-vexpress-qemu.ext4"

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -17,12 +17,13 @@ from fabric.api import *
 import pytest
 import time
 from common import *
+from common_setup import *
 from helpers import Helpers
 from common_update import common_update_proceduce
 from MenderAPI import adm, deploy, image
 from mendertesting import MenderTesting
 
-@pytest.mark.usefixtures("bootstrapped_successfully", "ssh_is_opened")
+@pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
 class TestBasicIntegration(MenderTesting):
 
     @MenderTesting.fast
@@ -36,7 +37,7 @@ class TestBasicIntegration(MenderTesting):
         """
         if not env.host_string:
             execute(self.test_update_image_successful,
-                    hosts=conftest.get_mender_clients(),
+                    hosts=get_mender_clients(),
                     install_image=install_image,
                     name=name,
                     regnerate_image_id=regnerate_image_id)
@@ -49,7 +50,7 @@ class TestBasicIntegration(MenderTesting):
 
         Helpers.verify_reboot_performed()
         assert Helpers.get_active_partition() == previous_inactive_part
-        deploy.check_expected_status(deployment_id, "success", len(conftest.get_mender_clients()))
+        deploy.check_expected_status(deployment_id, "success", len(get_mender_clients()))
 
         for d in adm.get_devices():
             deploy.get_logs(d["id"], deployment_id, expected_status=404)
@@ -67,12 +68,12 @@ class TestBasicIntegration(MenderTesting):
         """
         if not env.host_string:
             execute(self.test_update_image_failed,
-                    hosts=conftest.get_mender_clients(),
+                    hosts=get_mender_clients(),
                     install_image=install_image,
                     name=name)
             return
 
-        devices_accepted = conftest.get_mender_clients()
+        devices_accepted = get_mender_clients()
         original_image_id = Helpers.yocto_id_installed_on_machine()
 
 
@@ -97,7 +98,7 @@ class TestBasicIntegration(MenderTesting):
 
         if not env.host_string:
             execute(self.test_double_update,
-                                    hosts=conftest.get_mender_clients())
+                                    hosts=get_mender_clients())
             return
 
         self.test_update_image_successful()
@@ -110,7 +111,7 @@ class TestBasicIntegration(MenderTesting):
 
         if not env.host_string:
             execute(self.test_failed_updated_and_valid_update,
-                    hosts=conftest.get_mender_clients())
+                    hosts=get_mender_clients())
             return
 
         self.test_update_image_failed()

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -17,25 +17,28 @@ from fabric.api import *
 import pytest
 import time
 from common import *
+from common_docker import *
+from common_setup import *
 from helpers import Helpers
-from MenderAPI import adm, deploy, image, logger
+from MenderAPI import auth, adm, deploy, image, logger
 from common_update import common_update_proceduce
 from mendertesting import MenderTesting
 
 
 @MenderTesting.fast
-@pytest.mark.usefixtures("ssh_is_opened")
 class TestBootstrapping(MenderTesting):
     slow = pytest.mark.skipif(not pytest.config.getoption("--runslow"),
                               reason="need --runslow option to run")
 
+    @pytest.mark.usefixtures("standard_setup_one_client")
     def test_bootstrap(self):
         """Simply make sure we are able to bootstrap a device"""
-        if not env.host_string:
-            execute(self.test_bootstrap, hosts=conftest.get_mender_clients())
-            return
 
-        adm.check_expected_status("pending", len(conftest.get_mender_clients()))
+        execute(self.accept_devices, hosts=get_mender_clients())
+
+
+    def accept_devices(self):
+        adm.check_expected_status("pending", len(get_mender_clients()))
 
         # iterate over devices and accept them
         for d in adm.get_devices():
@@ -43,18 +46,18 @@ class TestBootstrapping(MenderTesting):
             logging.info("Accepting DeviceID: %s" % d["id"])
 
         # make sure all devices are accepted
-        adm.check_expected_status("accepted", len(conftest.get_mender_clients()))
+        adm.check_expected_status("accepted", len(get_mender_clients()))
 
         # print all device ids
         for device in adm.get_devices_status("accepted"):
             logging.info("Accepted DeviceID: %s" % device["id"])
 
     @MenderTesting.slow
-    @pytest.mark.usefixtures("bootstrapped_successfully")
+    @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
     def test_reject_bootstrap(self):
         """Make sure a rejected device does not perform an upgrade, and that it gets it's auth token removed"""
         if not env.host_string:
-            execute(self.test_reject_bootstrap, hosts=conftest.get_mender_clients())
+            execute(self.test_reject_bootstrap, hosts=get_mender_clients())
             return
 
         # iterate over devices and reject them
@@ -62,7 +65,7 @@ class TestBootstrapping(MenderTesting):
             adm.set_device_status(device["id"], "rejected")
             logging.info("Rejecting DeviceID: %s" % device["id"])
 
-        adm.check_expected_status("rejected", len(conftest.get_mender_clients()))
+        adm.check_expected_status("rejected", len(get_mender_clients()))
 
         try:
             deployment_id, _ = common_update_proceduce(install_image=conftest.get_valid_image(), name=None)

--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -17,12 +17,13 @@ from fabric.api import *
 import pytest
 import time
 from common import *
+from common_setup import *
 from helpers import Helpers
 from MenderAPI import adm, deploy, image, logger
 from common_update import common_update_proceduce
 from mendertesting import MenderTesting
 
-@pytest.mark.usefixtures("ssh_is_opened", "bootstrapped_successfully")
+@pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
 class TestFailures(MenderTesting):
 
     @MenderTesting.slow
@@ -31,7 +32,7 @@ class TestFailures(MenderTesting):
 
         if not env.host_string:
             execute(self.test_update_image_id_already_installed,
-                    hosts=conftest.get_mender_clients(),
+                    hosts=get_mender_clients(),
                     install_image=install_image)
             return
 
@@ -45,15 +46,15 @@ class TestFailures(MenderTesting):
                                                        artifact_name=name,
                                                        devices=devices_accepted_id)
 
-        deploy.check_expected_status(deployment_id, "already-installed", len(conftest.get_mender_clients()))
+        deploy.check_expected_status(deployment_id, "already-installed", len(get_mender_clients()))
 
     @MenderTesting.fast
     def test_large_update_image(self):
         """Installing an image larger than the passive/active parition size should result in a failure."""
         if not env.host_string:
-            execute(self.test_large_update_image, hosts=conftest.get_mender_clients())
+            execute(self.test_large_update_image, hosts=get_mender_clients())
             return
 
         deployment_id, _ = common_update_proceduce(install_image="large_image.dat", name=None, regnerate_image_id=False, broken_image=True)
-        deploy.check_expected_status(deployment_id, "failure", len(conftest.get_mender_clients()))
+        deploy.check_expected_status(deployment_id, "failure", len(get_mender_clients()))
         Helpers.verify_reboot_not_performed()


### PR DESCRIPTION
```
The motivation for this is to have different setups for different
tests. Most will use the standard setup with one bootstrapped client,
but other setups involving more clients are possible.

To do this, we have to make docker-compose part of the py.test
fixtures. Python was annoyingly strict about the order of loading
things, so I had to split it up quite a bit, into this dependency:

common
  ^
  |
  |\----------------+
  |                 |
common_docker   MenderAPI
  ^                 ^
  |                 |
  |/----------------+
  |
common_setup

Some other things changed:

* User authentication now has to be done after every docker-compose
  restart, so this has been moved to its own authentication module.

* We are now using docker-compose to query for node IPs.

* Tests are not order dependent anymore, so run them in default order.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
```