### PR TITLE
Add --docker-compose-file flag to py.test, to tweak compose setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_install:
 
 script:
     - if [ "$JOB_TYPE" = compile_and_integration_tests_fast ]; then
-        ( cd tests && bash run.sh fast );
+        ( cd tests && bash run.sh --runfast );
       fi
 
     - if [ "$JOB_TYPE" = compile_and_integration_tests_slow ]; then
-        ( cd tests && bash run.sh slow );
+        ( cd tests && bash run.sh --runslow );
       fi

--- a/tests/common_docker.py
+++ b/tests/common_docker.py
@@ -27,8 +27,12 @@ COMPOSE_FILES = [
 ]
 
 def docker_compose_cmd(arg_list):
+    extra_files = pytest.config.getoption("--docker-compose-file")
+    if extra_files is None:
+        extra_files = []
+
     files_args = ""
-    for file in COMPOSE_FILES:
+    for file in COMPOSE_FILES + extra_files:
         files_args += " -f %s" % file
 
     subprocess.check_call("docker-compose %s %s" % (files_args, arg_list), shell=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def pytest_addoption(parser):
     parser.addoption("--image", action="store_true", default="core-image-full-cmdline-vexpress-qemu.ext4", help="Valid update image")
     parser.addoption("--runslow", action="store_true", help="run slow tests")
     parser.addoption("--runfast", action="store_true", help="run fast tests")
+    parser.addoption("--docker-compose-file", action="append", help="Additional docker-compose files to use for test")
 
 
 def pytest_configure(config):

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -x -e
 
-# Tip: use "docker run -v $BUILDDIR:/mnt/build" to get build artifacts from
-# local hard drive.
-
 run_slow_tests () {
     py.test --maxfail=1 -s --tb=short --runslow --verbose --junitxml=results.xml
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 set -x -e
 
-run_slow_tests () {
-    py.test --maxfail=1 -s --tb=short --runslow --verbose --junitxml=results.xml
-}
-
-run_fast_tests() {
-    py.test --maxfail=1 -s --tb=short --runfast --verbose --junitxml=results.xml
-}
-
 if [[ ! -f large_image.dat ]]; then
     dd if=/dev/zero of=large_image.dat bs=200M count=0 seek=1
 fi
@@ -41,15 +33,4 @@ if [[ ! -f broken_update.ext4 ]]; then
     dd if=/dev/urandom of=broken_update.ext4 bs=10M count=5
 fi
 
-if [[ $1 = "slow" ]]; then
-    run_slow_tests
-    exit
-fi
-
-if [[ $1 = "fast" ]]; then
-    run_fast_tests
-    exit
-fi
-
-run_slow_tests
-run_fast_tests
+py.test --maxfail=1 -s --tb=short --verbose --junitxml=results.xml "$@"


### PR DESCRIPTION
```
commit d2b8c3fd660ff8a4622e3a53d3a1f3035a90d405
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Fri Jan 6 10:44:18 2017

    Remove now incorrect comment.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit 0ae021887e7f5d9f9a18295a9233238e5ddd884a
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Fri Jan 6 10:46:30 2017

    Make it possible to pass any flag to py.test, not just designated ones.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit c32048deba7bbe4694749f9a3458b0b72346fe84
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Fri Jan 6 10:57:30 2017

    Add --docker-compose-file flag to py.test, to tweak compose setup.
    
    Use it to pass in extra docker-compose files.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
```