### PR TITLE
Reintroduce unintentionally disabled reject_bootstrap test.

### DIFF
--- a/tests/tests/common_update.py
+++ b/tests/tests/common_update.py
@@ -19,7 +19,7 @@ from MenderAPI import adm, deploy, image, logger
 import random
 
 
-def common_update_proceduce(install_image, name, regnerate_image_id=True, device_type="vexpress-qemu", checksum="abc123", broken_image=False):
+def common_update_procedure(install_image, name, regnerate_image_id=True, device_type="vexpress-qemu", checksum="abc123", broken_image=False):
 
     if broken_image:
         artifact_id = "broken_image_" + str(random.randint(0, 999999))

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -19,7 +19,7 @@ import time
 from common import *
 from common_setup import *
 from helpers import Helpers
-from common_update import common_update_proceduce
+from common_update import common_update_procedure
 from MenderAPI import adm, deploy, image
 from mendertesting import MenderTesting
 
@@ -44,7 +44,7 @@ class TestBasicIntegration(MenderTesting):
             return
 
         previous_inactive_part = Helpers.get_passive_partition()
-        deployment_id, expected_image_id = common_update_proceduce(install_image,
+        deployment_id, expected_image_id = common_update_procedure(install_image,
                                                                    name,
                                                                    regnerate_image_id)
 
@@ -78,7 +78,7 @@ class TestBasicIntegration(MenderTesting):
 
 
         previous_active_part = Helpers.get_active_partition()
-        deployment_id, _ = common_update_proceduce(install_image, name, broken_image=True)
+        deployment_id, _ = common_update_procedure(install_image, name, broken_image=True)
 
         Helpers.verify_reboot_performed()
         assert Helpers.get_active_partition() == previous_active_part

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -21,7 +21,7 @@ from common_docker import *
 from common_setup import *
 from helpers import Helpers
 from MenderAPI import auth, adm, deploy, image, logger
-from common_update import common_update_proceduce
+from common_update import common_update_procedure
 from mendertesting import MenderTesting
 
 
@@ -68,7 +68,7 @@ class TestBootstrapping(MenderTesting):
         adm.check_expected_status("rejected", len(get_mender_clients()))
 
         try:
-            deployment_id, _ = common_update_proceduce(install_image=conftest.get_valid_image(), name=None)
+            deployment_id, _ = common_update_procedure(install_image=conftest.get_valid_image(), name=None)
         except AssertionError:
             logging.info("Failed to deploy upgrade to rejected device.")
             Helpers.verify_reboot_not_performed()

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -25,11 +25,11 @@ from common_update import common_update_procedure
 from mendertesting import MenderTesting
 
 
-@MenderTesting.fast
 class TestBootstrapping(MenderTesting):
     slow = pytest.mark.skipif(not pytest.config.getoption("--runslow"),
                               reason="need --runslow option to run")
 
+    @MenderTesting.fast
     @pytest.mark.usefixtures("standard_setup_one_client")
     def test_bootstrap(self):
         """Simply make sure we are able to bootstrap a device"""

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -20,7 +20,7 @@ from common import *
 from common_setup import *
 from helpers import Helpers
 from MenderAPI import adm, deploy, image, logger
-from common_update import common_update_proceduce
+from common_update import common_update_procedure
 from mendertesting import MenderTesting
 
 @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
@@ -40,7 +40,7 @@ class TestFaultTolerance(MenderTesting):
                     install_image=install_image)
             return
 
-        deployment_id, _ = common_update_proceduce(install_image, name=None)
+        deployment_id, _ = common_update_procedure(install_image, name=None)
         Helpers.verify_reboot_performed() # since the network is broken, two reboots will be performed, and the last one will be detected
         deploy.check_expected_status(deployment_id, "failure", len(get_mender_clients()))
 
@@ -60,7 +60,7 @@ class TestFaultTolerance(MenderTesting):
         installed_yocto_id = Helpers.yocto_id_installed_on_machine()
 
         inactive_part = Helpers.get_passive_partition()
-        deployment_id, _ = common_update_proceduce(install_image, name=None)
+        deployment_id, _ = common_update_procedure(install_image, name=None)
         active_part = Helpers.get_active_partition()
 
         for i in range(60):
@@ -97,7 +97,7 @@ class TestFaultTolerance(MenderTesting):
             return
 
         Helpers.gateway_connectivity(False)
-        deployment_id, expected_yocto_id = common_update_proceduce(install_image, name=None)
+        deployment_id, expected_yocto_id = common_update_procedure(install_image, name=None)
         time.sleep(60)
 
         for i in range(5):

--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -20,7 +20,7 @@ from common import *
 from common_setup import *
 from helpers import Helpers
 from MenderAPI import adm, deploy, image, logger
-from common_update import common_update_proceduce
+from common_update import common_update_procedure
 from mendertesting import MenderTesting
 
 @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
@@ -38,7 +38,7 @@ class TestFailures(MenderTesting):
 
         previous_inactive_part = Helpers.get_passive_partition()
 
-        deployment_id, expected_image_id = common_update_proceduce(install_image, name, True)
+        deployment_id, expected_image_id = common_update_procedure(install_image, name, True)
         Helpers.verify_reboot_performed()
 
         devices_accepted_id = [device["id"] for device in adm.get_devices_status("accepted")]
@@ -55,6 +55,6 @@ class TestFailures(MenderTesting):
             execute(self.test_large_update_image, hosts=get_mender_clients())
             return
 
-        deployment_id, _ = common_update_proceduce(install_image="large_image.dat", name=None, regnerate_image_id=False, broken_image=True)
+        deployment_id, _ = common_update_procedure(install_image="large_image.dat", name=None, regnerate_image_id=False, broken_image=True)
         deploy.check_expected_status(deployment_id, "failure", len(get_mender_clients()))
         Helpers.verify_reboot_not_performed()


### PR DESCRIPTION
fast and slow at the same time means that neither will be executed.