### PR TITLE
docker-compose.yml: fix mongo version (3.4)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
             - mender-mongo-deployments
 
     mender-mongo-deployments:
-        image: mongo:latest
+        image: mongo:3.4
         networks:
             mender:
                 aliases:
@@ -130,7 +130,7 @@ services:
             - mender-mongo-device-auth
 
     mender-mongo-device-auth:
-        image: mongo:latest
+        image: mongo:3.4
         networks:
             mender:
                 aliases:
@@ -150,7 +150,7 @@ services:
             - mender-mongo-device-adm
 
     mender-mongo-device-adm:
-        image: mongo:latest
+        image: mongo:3.4
         networks:
             mender:
                 aliases:
@@ -170,7 +170,7 @@ services:
             - mender-mongo-inventory
 
     mender-mongo-inventory:
-        image: mongo:latest
+        image: mongo:3.4
         networks:
             mender:
                 aliases:
@@ -190,7 +190,7 @@ services:
             - mender-mongo-useradm
 
     mender-mongo-useradm:
-        image: mongo:latest
+        image: mongo:3.4
         networks:
             mender:
                 aliases:


### PR DESCRIPTION
there are a couple tags we could fix on -
'3.4.1', '3.4', '3' and 'latest' all point to the same image.

decided to fix on the minor version - this way we'll
automagically get patches for 3.4 as they come.

Issues: MEN-905

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@mendersoftware/rndity @maciejmrowiec 