### PR TITLE
tests: integration: deployments: increase deployment status wait time

### DIFF
--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -94,7 +94,7 @@ class Deployments(object):
 
         return json.loads(r.text)
 
-    def check_expected_status(self, deployment_id, expected_status, expected_count, max_wait=120, polling_frequency=0.2):
+    def check_expected_status(self, deployment_id, expected_status, expected_count, max_wait=180, polling_frequency=1):
         timeout = time.time() + max_wait
         seen = set()
 


### PR DESCRIPTION
Applying updates takes a while, and since we've increased a number of jobs run
in parallel timeouts in MenderAPI.deployments.check_expected_status() are
popping up more frequently that desired. Increse the wait time to 180s and
reduce poll frequency to 1/s.

@mendersoftware/rndity @GregorioDiStefano @kacf @maciejmrowiec 