### PR TITLE
Storage proxy config: use proxy_http_version 1.1

### DIFF
--- a/storage-proxy/nginx.conf
+++ b/storage-proxy/nginx.conf
@@ -91,6 +91,7 @@ http {
             }
             client_max_body_size 0;
             proxy_request_buffering off;
+            proxy_http_version 1.1;
 
             proxy_set_header Host s3.docker.mender.io:9000;
             proxy_pass http://minio_backend;


### PR DESCRIPTION
Using proxy_http_version 1.1 prevents storage proxy from buffering
uploaded data.