### PR TITLE
Fix the name of the `mem_total` inventory parameter in tests.

### DIFF
--- a/tests/tests/test_inventory.py
+++ b/tests/tests/test_inventory.py
@@ -60,7 +60,7 @@ class TestInventory(MenderTesting):
                             "hostname",
                             "network_interfaces",
                             "cpu_model",
-                            "mem_total",
+                            "mem_total_kB",
                             "device_type",
                             "ipv4_eth0",
                             "mac_eth0",


### PR DESCRIPTION
`mem_total` was changed to `mem_total_kB` in the example inventory
script.

Signed-off-by: Marcin Pasinski <marcin.pasinski@cfengine.com>