### PR TITLE
storage-proxy: propagate the Host header to minio

### DIFF
--- a/storage-proxy/nginx.conf
+++ b/storage-proxy/nginx.conf
@@ -93,7 +93,7 @@ http {
             proxy_request_buffering off;
             proxy_http_version 1.1;
 
-            proxy_set_header Host s3.docker.mender.io:9000;
+            proxy_set_header Host $http_host;
             proxy_pass http://minio_backend;
         }
     }


### PR DESCRIPTION
proxy fills out the Host header with vanilla nginx $http_host.
the address mapping of proxy and minio is the same, so this will
always yield correct results.

(note that a different approach was considered first - use env vars
and lua, but it's unnecessary)

Issues: MEN-948

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano 
