### PR TITLE
tests/MenderAPI/deployments: fix abort()

### DIFF
--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -114,5 +114,5 @@ class Deployments(object):
 
     def abort(self, deployment_id):
         deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (deployment_id)
-        r = requests.put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "finished"})
+        r = requests.put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "aborted"})
         assert r.status_code == requests.status_codes.codes.no_content


### PR DESCRIPTION
by properly setting the destination status to 'aborted'.

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>