### PR TITLE
tests/test_deployment_abort: fix test criteria

### DIFF
--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -48,7 +48,7 @@ class TestDeploymentAborting(MenderTesting):
 
         deploy.check_expected_status(deployment_id, abort_step, len(get_mender_clients()))
         deploy.abort(deployment_id)
-        deploy.check_expected_status(deployment_id, "finished", len(get_mender_clients()))
+        deploy.check_expected_status(deployment_id, "aborted", len(get_mender_clients()))
 
         # no deployment logs are sent by the client, is this expected?
         for d in adm.get_devices():


### PR DESCRIPTION
while a deployment with all 'aborted' device-deployments
will report status 'finished' - the individual devs will appear
in the stats as 'aborted'.

in other words, the masking 'aborted'->'finished' happens at the
deployment status level, not stats/devices level.

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>