### PR TITLE
production template: more updates

### DIFF
--- a/template/prod.yml
+++ b/template/prod.yml
@@ -51,8 +51,8 @@ services:
                 aliases:
                     # change the alias to DNS name that storage will be
                     # available on, for instance if devices will access storage
-                    # using https://s3.acme.com:9000, then set this to
-                    # s3.acme.com
+                    # using https://s3.acme.org:9000, then set this to
+                    # s3.acme.org
                     - set-my-alias-here.com
         environment:
 
@@ -79,8 +79,8 @@ services:
 
             # deployments service uses signed URLs, hence it needs to access
             # storage-proxy using exactly the same name as devices will; if
-            # devices will access storage using https://s3.acme.com:9000, then
-            # set this to https://s3.acme.com:9000
+            # devices will access storage using https://s3.acme.org:9000, then
+            # set this to https://s3.acme.org:9000
             DEPLOYMENTS_AWS_URI: https://set-my-alias-here.com
 
     minio:

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -93,9 +93,50 @@ services:
             # mounts a docker volume named `mender-artifacts` as /export directory
             - mender-artifacts:/export:rw
 
+    mender-mongo-deployments:
+        volumes:
+            - mender-deployments-db:/data:rw
+    mender-mongo-device-adm:
+        volumes:
+            - mender-deviceadm-db:/data:rw
+    mender-mongo-device-auth:
+        volumes:
+            - mender-deviceauth-db:/data:rw
+    mender-mongo-inventory:
+        volumes:
+            - mender-inventory-db:/data:rw
+    mender-mongo-useradm:
+        volumes:
+            - mender-useradm-db:/data:rw
+
 volumes:
-    # define `mender-artifacts` volume
+    # mender artifacts storage
     mender-artifacts:
       external:
           # use external volume created manually
           name: mender-artifacts
+    # deployments service database
+    mender-deployments-db:
+      external:
+          # use external volume created manually
+          name: mender-deployments-db
+    # user administration service database
+    mender-useradm-db:
+      external:
+          # use external volume created manually
+          name: mender-useradm-db
+    # inventory service database
+    mender-inventory-db:
+      external:
+          # use external volume created manually
+          name: mender-inventory-db
+    # device authentication service database
+    mender-deviceauth-db:
+      external:
+          # use external volume created manually
+          name: mender-deviceauth-db
+    # device admission service database
+    mender-deviceadm-db:
+      external:
+          # use external volume created manually
+          name: mender-deviceadm-db

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -23,11 +23,11 @@ services:
 
     mender-useradm:
         volumes:
-            - ./template/keys-generated/useradm/private.key:/etc/useradm/rsa/private.pem:ro
+            - ./template/keys-generated/keys/useradm/private.key:/etc/useradm/rsa/private.pem:ro
 
     mender-device-auth:
         volumes:
-            - ./template/keys-generated/deviceauth/private.key:/etc/deviceauth/rsa/private.pem:ro
+            - ./template/keys-generated/keys/deviceauth/private.key:/etc/deviceauth/rsa/private.pem:ro
 
     mender-api-gateway:
         ports:
@@ -39,8 +39,8 @@ services:
         environment:
             MAPPED_PORT: 443
         volumes:
-            - ./template/keys-generated/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.pem:ro
-            - ./template/keys-generated/api-gateway/private.key:/var/www/mendersoftware/cert/key.pem:ro
+            - ./template/keys-generated/certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.pem:ro
+            - ./template/keys-generated/certs/api-gateway/private.key:/var/www/mendersoftware/cert/key.pem:ro
 
     storage-proxy:
         ports:
@@ -64,12 +64,12 @@ services:
             DOWNLOAD_SPEED: 1m
             MAX_CONNECTIONS: 100
         volumes:
-            - ./template/keys-generated/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt:ro
-            - ./template/keys-generated/storage-proxy/private.key:/var/www/storage-proxy/cert/key.pem:ro
+            - ./template/keys-generated/certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt:ro
+            - ./template/keys-generated/certs/storage-proxy/private.key:/var/www/storage-proxy/cert/key.pem:ro
 
     mender-deployments:
         volumes:
-            - ./template/keys-generated/storage-proxy/cert.crt:/etc/ssl/certs/storage-proxy.crt:ro
+            - ./template/keys-generated/certs/storage-proxy/cert.crt:/etc/ssl/certs/storage-proxy.crt:ro
         environment:
             STORAGE_BACKEND_CERT: /etc/ssl/certs/storage-proxy.crt
             # access key, the same value as MINIO_ACCESS_KEY

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -39,8 +39,8 @@ services:
         environment:
             MAPPED_PORT: 443
         volumes:
-            - ./template/keys-generated/certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.pem:ro
-            - ./template/keys-generated/certs/api-gateway/private.key:/var/www/mendersoftware/cert/key.pem:ro
+            - ./template/keys-generated/certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.crt:ro
+            - ./template/keys-generated/certs/api-gateway/private.key:/var/www/mendersoftware/cert/private.key:ro
 
     storage-proxy:
         ports:
@@ -65,7 +65,7 @@ services:
             MAX_CONNECTIONS: 100
         volumes:
             - ./template/keys-generated/certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt:ro
-            - ./template/keys-generated/certs/storage-proxy/private.key:/var/www/storage-proxy/cert/key.pem:ro
+            - ./template/keys-generated/certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key:ro
 
     mender-deployments:
         volumes:

--- a/template/run
+++ b/template/run
@@ -1,8 +1,8 @@
-#!/bin/bash -x
+#!/bin/bash
 
 
 exec docker-compose \
-     -p '' \
+     -p 'menderproduction'\
      -f ../docker-compose.yml \
      -f ../docker-compose.storage.minio.yml \
      -f ./prod.yml \


### PR DESCRIPTION
Explicitly specify project name instead of letting docker-compose name it after the directory the files were in.

Note that `mender-production` becomes `menderproduction` when `docker-compose` creates networks and containers.

@maciejmrowiec @mendersoftware/rndity 