### PR TITLE
compose/demo: add mongo data volume mounts

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -68,3 +68,19 @@ services:
         environment:
             # enable demo mode for UI ["true"/"false"]
             DEMO: "true"
+
+    mender-mongo-deployments:
+        volumes:
+            - /var/mender/data:/data:rw
+    mender-mongo-device-adm:
+        volumes:
+            - /var/mender/data:/data:rw
+    mender-mongo-device-auth:
+        volumes:
+            - /var/mender/data:/data:rw
+    mender-mongo-inventory:
+        volumes:
+            - /var/mender/data:/data:rw
+    mender-mongo-useradm:
+        volumes:
+            - /var/mender/data:/data:rw


### PR DESCRIPTION
we already have them in prod.yml, but it's useful to also have them in demo -
the user might be trying out the system and recreating containers along the
way. it would be unexpected to lose whatever data was already there.

Issues: MEN-879

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@maciejmrowiec @mendersoftware/rndity 