### PR TITLE
Remove 'MAPPED_PORT' from environment.

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -17,11 +17,6 @@ services:
             mender:
                 aliases:
                     - docker.mender.io
-        # nginx doesn't know the actual outside port
-        # could be solved with introspection (mapping daemon socket + 'docker ps')
-        # the easier way is an env var
-        environment:
-            MAPPED_PORT: 8080
         volumes:
             - ./certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.crt
             - ./certs/api-gateway/private.key:/var/www/mendersoftware/cert/private.key

--- a/extra/cluster-setup.md
+++ b/extra/cluster-setup.md
@@ -414,7 +414,6 @@ docker service create --with-registry-auth \
  --name mender-api-gateway \
  --network cluster-mender \
  -p 8080:443 \
- --env 'MAPPED_PORT=8080' \
  --restart-max-attempts 2 \
  --replicas 1 \
  mendersoftware/api-gateway:latest

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -35,9 +35,6 @@ services:
             - "443:443"
         networks:
             - mender
-        # the outside port must be made known to API gateway
-        environment:
-            MAPPED_PORT: 443
         volumes:
             - ./template/keys-generated/certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.crt:ro
             - ./template/keys-generated/certs/api-gateway/private.key:/var/www/mendersoftware/cert/private.key:ro


### PR DESCRIPTION
'MAPPED_PORT' environment variable is no longer used.

@bboozzoo @maciejmrowiec @mchalski 