### PR TITLE
Make it an error to provide build dir that doesn't contain what we need

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 *.pyc
 
 tags
+
 tests/.cache/
 tests/broken_update.ext4
 tests/core-image-full-cmdline-vexpress-qemu-broken-network.ext4
 tests/core-image-full-cmdline-vexpress-qemu.ext4
 tests/large_image.dat
 tests/results.xml
-tests/mender-artifact
+tests/downloaded-tools

--- a/tests/MenderAPI/artifacts.py
+++ b/tests/MenderAPI/artifacts.py
@@ -18,7 +18,7 @@ import pytest
 from MenderAPI import logger
 
 class Artifacts():
-    artifacts_tool_path = "./mender-artifact"
+    artifacts_tool_path = "mender-artifact"
 
     def make_artifact(self, image, device_type, artifact_name, artifact_file_created):
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -5,33 +5,39 @@ if [[ ! -f large_image.dat ]]; then
     dd if=/dev/zero of=large_image.dat bs=200M count=0 seek=1
 fi
 
-if [[ ! -f mender-artifact ]]; then
-    if [ -n "$BUILDDIR" ] && [ -f $BUILDDIR/tmp/sysroots/x86_64-linux/usr/bin/mender-artifact ]; then
-        cp $BUILDDIR/tmp/sysroots/x86_64-linux/usr/bin/mender-artifact .
-    else
-        curl "https://d25phv8h0wbwru.cloudfront.net/master/tip/mender-artifact" -o mender-artifact
-    fi
-    chmod +x mender-artifact
-fi
+if [[ -n "$BUILDDIR" ]]; then
+    # Get the necessary path directly from the build.
 
-if [[ ! -f core-image-full-cmdline-vexpress-qemu.ext4 ]] ; then
-    if [ -n "$BUILDDIR" ] && [ -f $BUILDDIR/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 ]; then
-        echo "!! WARNING: core-image-file-cmdline-vexpress-qemu.ext4 was not found in the current working directory, grabbing from BUILDDIR !!"
-        cp $BUILDDIR/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 .
+    # On branches without recipe specific sysroots, the next step will fail
+    # because the prepare_recipe_sysroot task doesn't exist. Use that failure
+    # to fall back to the old generic sysroot path.
+    if ( cd $BUILDDIR && bitbake -c prepare_recipe_sysroot mender-test-dependencies ); then
+        eval `cd $BUILDDIR && bitbake -e mender-test-dependencies | grep '^export PATH='`
     else
-        echo "!! WARNING: core-image-file-cmdline-vexpress-qemu.ext4 was not found in the current working directory, will download the latest !!"
+        eval `cd $BUILDDIR && bitbake -e core-image-minimal | grep '^export PATH='`
+    fi
+
+    cp -f $BUILDDIR/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 .
+else
+    # Download what we need.
+
+    mkdir -p downloaded-tools
+    if [[ ! -f downloaded-tools/mender-artifact ]]; then
+        curl "https://d25phv8h0wbwru.cloudfront.net/master/tip/mender-artifact" -o downloaded-tools/mender-artifact
+    fi
+    chmod +x downloaded-tools/mender-artifact
+    export PATH=$PWD/downloaded-tools:$PATH
+
+    if [[ ! -f core-image-full-cmdline-vexpress-qemu.ext4 ]] ; then
+        echo "!! WARNING: core-image-file-cmdline-vexpress-qemu.ext4 was not found, will download the latest !!"
         curl -o core-image-full-cmdline-vexpress-qemu.ext4 "https://s3.amazonaws.com/mender/temp/core-image-full-cmdline-vexpress-qemu.ext4"
     fi
 fi
 
-if [[ ! -f core-image-full-cmdline-vexpress-qemu-broken-network.ext4 ]]; then
-    cp core-image-full-cmdline-vexpress-qemu.ext4 core-image-full-cmdline-vexpress-qemu-broken-network.ext4
-    e2rm core-image-full-cmdline-vexpress-qemu-broken-network.ext4:/lib/systemd/systemd-networkd
-fi
+cp -f core-image-full-cmdline-vexpress-qemu.ext4 core-image-full-cmdline-vexpress-qemu-broken-network.ext4
+e2rm core-image-full-cmdline-vexpress-qemu-broken-network.ext4:/lib/systemd/systemd-networkd
 
-if [[ ! -f broken_update.ext4 ]]; then
-    dd if=/dev/urandom of=broken_update.ext4 bs=10M count=5
-fi
+dd if=/dev/urandom of=broken_update.ext4 bs=10M count=5
 
 if [ $# -eq 0 ]; then
     py.test --maxfail=1 -s --tb=short --verbose --junitxml=results.xml --runfast --runslow


### PR DESCRIPTION
It's important not to fall back to downloading in this case, because
this can lead to subtle and difficult-to-reproduce errors because the
version differs from what is expected.

With this patch we grab everything from the build if the BUILDDIR is
specified, and we fail if this does not work. Only if the variable is
not set do we resort to downloading. In both cases we expect to find
executables in the path, rather than in the current directory.

Also do some of the preparation steps regardless of whether the files
already exist. It's not an expensive operation, and it's better to be
sure they are up to date.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>