### PR TITLE
no-ssl: export minio on non-SSL port

### DIFF
--- a/docker-compose.no-ssl.yml
+++ b/docker-compose.no-ssl.yml
@@ -4,3 +4,12 @@ services:
     mender-api-gateway:
         ports:
             - "8090:80"
+
+    mender-deployments:
+        environment:
+            DEPLOYMENTS_AWS_URI: http://minio.s3.docker.mender.io:9001
+
+    minio:
+        ports:
+            - "9001:9001"
+        command: server --address ":9001" /export


### PR DESCRIPTION
Change minio's command line to start listening on port 9001. Avoids conflict
with storage-proxy which is already listening on 9000.

Override mender-deployments env and point it to minio.s3.docker.mender.io:9001.

@mendersoftware/rndity @maciejmrowiec 