### PR TITLE
compose: demo: template: use a single mongo instance for all services

### DIFF
--- a/demo
+++ b/demo
@@ -9,4 +9,4 @@ exec docker-compose \
      -f docker-compose.storage.minio.yml \
      -f docker-compose.demo.yml \
      $CLIENT \
-     $*
+     "$@"

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -4,10 +4,22 @@ services:
     mender-useradm:
         volumes:
             - ./keys/useradm/private.key:/etc/useradm/rsa/private.pem
+        depends_on:
+            - mongo-common
 
     mender-device-auth:
         volumes:
             - ./keys/deviceauth/private.key:/etc/deviceauth/rsa/private.pem
+        depends_on:
+            - mongo-common
+
+    mender-inventory:
+        depends_on:
+            - mongo-common
+
+    mender-device-adm:
+        depends_on:
+            - mongo-common
 
     mender-api-gateway:
         ports:
@@ -48,6 +60,8 @@ services:
             DEPLOYMENTS_AWS_AUTH_KEY: minio
             DEPLOYMENTS_AWS_AUTH_SECRET: minio123
             DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io:9000
+        depends_on:
+            - mongo-common
 
     minio:
         networks:
@@ -62,3 +76,23 @@ services:
         environment:
             # enable demo mode for UI ["true"/"false"]
             DEMO: "true"
+
+    #
+    # single mongo instance for all services, extend as required
+    # during deployment
+    #
+    mongo-common:
+        image: mongo:3.4
+        networks:
+            mender:
+                aliases:
+                    - mongo-deployments
+                    - mongo-device-adm
+                    - mongo-device-auth
+                    - mongo-inventory
+                    - mongo-useradm
+                    - mender-mongo-deployments
+                    - mender-mongo-device-adm
+                    - mender-mongo-device-auth
+                    - mender-mongo-inventory
+                    - mender-mongo-useradm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,6 @@ services:
             service: mender-base
         networks:
             - mender
-        depends_on:
-            - mender-mongo-deployments
-
-    mender-mongo-deployments:
-        image: mongo:3.4
-        networks:
-            mender:
-                aliases:
-                    - mongo-deployments
 
     #
     # mender-gui
@@ -59,15 +50,6 @@ services:
             service: mender-base
         networks:
             - mender
-        depends_on:
-            - mender-mongo-device-auth
-
-    mender-mongo-device-auth:
-        image: mongo:3.4
-        networks:
-            mender:
-                aliases:
-                    - mongo-device-auth
 
     #
     # mender-device-adm
@@ -79,15 +61,6 @@ services:
             service: mender-base
         networks:
             - mender
-        depends_on:
-            - mender-mongo-device-adm
-
-    mender-mongo-device-adm:
-        image: mongo:3.4
-        networks:
-            mender:
-                aliases:
-                    - mongo-device-adm
 
     #
     # mender-inventory
@@ -99,15 +72,6 @@ services:
             service: mender-base
         networks:
             - mender
-        depends_on:
-            - mender-mongo-inventory
-
-    mender-mongo-inventory:
-        image: mongo:3.4
-        networks:
-            mender:
-                aliases:
-                    - mongo-inventory
 
     #
     # mender-useradm
@@ -119,15 +83,6 @@ services:
             service: mender-base
         networks:
             - mender
-        depends_on:
-            - mender-mongo-useradm
-
-    mender-mongo-useradm:
-        image: mongo:3.4
-        networks:
-            mender:
-                aliases:
-                    - mongo-useradm
 
 networks:
     mender:

--- a/migration/dump-1.0-db
+++ b/migration/dump-1.0-db
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+SELFDIR=$(dirname $(readlink -f $0))
+SCRIPT=${SCRIPT:=./run}
+
+SERVICES="\
+  mender-inventory \
+  mender-useradm \
+  mender-device-auth \
+  mender-device-adm \
+  mender-deployments \
+"
+DB_SERVICES="\
+  mender-mongo-useradm \
+  mender-mongo-inventory \
+  mender-mongo-device-adm \
+  mender-mongo-device-auth \
+  mender-mongo-deployments \
+"
+
+# stop service that are using DBs
+${SCRIPT} stop ${SERVICES}
+
+# dump DB
+${SCRIPT} -f ${SELFDIR}/migration-helper.yml \
+          run \
+          --rm \
+          -e DB_SERVICES="${DB_SERVICES}" \
+          mongo-helper \
+          sh -c 'for s in ${DB_SERVICES}; do mongodump -h "$s" --out /srv/db-dump; done'

--- a/migration/migration-helper.yml
+++ b/migration/migration-helper.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+
+    #
+    # mongo migration helper service
+    #
+    mongo-helper:
+        image: mongo:3.4
+        networks:
+            - mender
+        volumes:
+          - .:/srv

--- a/migration/restore-db
+++ b/migration/restore-db
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+SELFDIR=$(dirname $(readlink -f $0))
+SCRIPT=${SCRIPT:=./run}
+
+SERVICES="\
+  mender-inventory \
+  mender-useradm \
+  mender-device-auth \
+  mender-device-adm \
+  mender-deployments \
+"
+
+# stop service that are using DBs
+${SCRIPT} stop ${SERVICES}
+
+# dump DB
+${SCRIPT} -f ${SELFDIR}/migration-helper.yml \
+          run \
+          --rm \
+          mongo-helper \
+          sh -c 'mongorestore -h mongo-common --drop /srv/db-dump; done'

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -118,51 +118,23 @@ services:
             # mounts a docker volume named `mender-artifacts` as /export directory
             - mender-artifacts:/export:rw
 
-    mender-mongo-deployments:
+    mongo-common:
         image: mongo:3.4
         networks:
             mender:
                 aliases:
                     - mongo-deployments
-        volumes:
-            - mender-deployments-db:/data:rw
-
-    mender-mongo-device-adm:
-        image: mongo:3.4
-        networks:
-        networks:
-            mender:
-                aliases:
                     - mongo-device-adm
-        volumes:
-            - mender-deviceadm-db:/data:rw
-
-    mender-mongo-device-auth:
-        image: mongo:3.4
-        networks:
-            mender:
-                aliases:
                     - mongo-device-auth
-        volumes:
-            - mender-deviceauth-db:/data:rw
-
-    mender-mongo-inventory:
-        image: mongo:3.4
-        networks:
-            mender:
-                aliases:
                     - mongo-inventory
-        volumes:
-            - mender-inventory-db:/data:rw
-
-    mender-mongo-useradm:
-        image: mongo:3.4
-        networks:
-            mender:
-                aliases:
                     - mongo-useradm
+                    - mender-mongo-deployments
+                    - mender-mongo-device-adm
+                    - mender-mongo-device-auth
+                    - mender-mongo-inventory
+                    - mender-mongo-useradm
         volumes:
-            - mender-useradm-db:/data:rw
+            - mender-mongo-data:/data:rw
 
 volumes:
     # mender artifacts storage
@@ -171,27 +143,7 @@ volumes:
           # use external volume created manually
           name: mender-artifacts
     # deployments service database
-    mender-deployments-db:
+    mender-mongo-data:
       external:
           # use external volume created manually
-          name: mender-deployments-db
-    # user administration service database
-    mender-useradm-db:
-      external:
-          # use external volume created manually
-          name: mender-useradm-db
-    # inventory service database
-    mender-inventory-db:
-      external:
-          # use external volume created manually
-          name: mender-inventory-db
-    # device authentication service database
-    mender-deviceauth-db:
-      external:
-          # use external volume created manually
-          name: mender-deviceauth-db
-    # device admission service database
-    mender-deviceadm-db:
-      external:
-          # use external volume created manually
-          name: mender-deviceadm-db
+          name: mender-mongo-data

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -119,18 +119,48 @@ services:
             - mender-artifacts:/export:rw
 
     mender-mongo-deployments:
+        image: mongo:3.4
+        networks:
+            mender:
+                aliases:
+                    - mongo-deployments
         volumes:
             - mender-deployments-db:/data:rw
+
     mender-mongo-device-adm:
+        image: mongo:3.4
+        networks:
+        networks:
+            mender:
+                aliases:
+                    - mongo-device-adm
         volumes:
             - mender-deviceadm-db:/data:rw
+
     mender-mongo-device-auth:
+        image: mongo:3.4
+        networks:
+            mender:
+                aliases:
+                    - mongo-device-auth
         volumes:
             - mender-deviceauth-db:/data:rw
+
     mender-mongo-inventory:
+        image: mongo:3.4
+        networks:
+            mender:
+                aliases:
+                    - mongo-inventory
         volumes:
             - mender-inventory-db:/data:rw
+
     mender-mongo-useradm:
+        image: mongo:3.4
+        networks:
+            mender:
+                aliases:
+                    - mongo-useradm
         volumes:
             - mender-useradm-db:/data:rw
 


### PR DESCRIPTION
Change the baseline docker-compose file to not include any mongo service
definitions.

Use a single mongo instance in demo setup.

Production template changed to use separate mongo for each service. Ultimately
in single host deployments we could also go with only one mongo instance.

@mendersoftware/rndity @maciejmrowiec 

Let's discuss options.