### PR TITLE
docker engine and compose version check

### DIFF
--- a/reset
+++ b/reset
@@ -2,6 +2,12 @@
 # Removes any state from server to start clean.
 # Mostly for demo purposes, be careful in production!
 
+./verify-docker-versions
+
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 sudo docker-compose ps | grep -q Up
 
 if [ $? -eq 0 ]; then

--- a/stop
+++ b/stop
@@ -2,4 +2,6 @@
 # Stops the server, while preserving state.
 set -e -o pipefail
 
+./verify-docker-versions
+
 sudo ./demo stop

--- a/template/run
+++ b/template/run
@@ -1,5 +1,7 @@
 #!/bin/bash
+set -e
 
+../verify-docker-versions
 
 exec docker-compose \
      -p 'menderproduction'\

--- a/up
+++ b/up
@@ -4,6 +4,8 @@
 # using docker-machine, assuming just one vm is started through it
 set -e -o pipefail
 
+./verify-docker-versions
+
 # host entries we need to add
 REQHOSTS="s3.docker.mender.io docker.mender.io"
 

--- a/verify-docker-versions
+++ b/verify-docker-versions
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -o pipefail
+
+# Assuming docker minor and patch version backward-compatibility,
+# but not major version compatibility (require 1.X.*).
+
+VERSION_MINOR_MIN_DOCKER_ENGINE="11"
+VERSION_MINOR_MIN_DOCKER_COMPOSE="6"
+
+compare_versions() {
+  VERSION_ACTUAL=$1
+  VERSION_MINIMUM=$2
+
+  if [[ -z $VERSION_ACTUAL ]]; then
+    echo "ERROR: Actual version is empty (hint: is it installed, or version format change?)."
+    return 1
+  fi
+
+  if [ "$VERSION_ACTUAL" -lt "$VERSION_MINIMUM" ]; then
+    echo "ERROR: Actual version installed ($VERSION_ACTUAL) is smaller than minimum requirement ($VERSION_MINIMUM)."
+    return 1
+  fi
+
+  return 0
+}
+
+
+# test Docker Engine version
+
+DOCKER_ENGINE_VERSION_REGEX_MINOR_BACKREF="Docker version 1\.([0-9]+)\.[0-9]+, build [0-9a-f]+"
+
+DOCKER_ENGINE_VERSION_STRING=$(docker --version 2>/dev/null | head -n1)
+DOCKER_ENGINE_VERSION_MINOR=$(echo $DOCKER_ENGINE_VERSION_STRING | sed -rn "s/$DOCKER_ENGINE_VERSION_REGEX_MINOR_BACKREF/\1/p")
+
+compare_versions "$DOCKER_ENGINE_VERSION_MINOR" "$VERSION_MINOR_MIN_DOCKER_ENGINE"
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: Docker Engine must be on version 1.$VERSION_MINOR_MIN_DOCKER_ENGINE or larger, but found version 1.$DOCKER_ENGINE_VERSION_MINOR installed."
+  echo "DOCKER_ENGINE_VERSION_STRING=$DOCKER_ENGINE_VERSION_STRING"
+  exit 1
+fi
+
+
+# test Docker Compose version
+
+DOCKER_COMPOSE_VERSION_REGEX_MINOR_BACKREF="docker-compose version 1\.([0-9]+)\.[0-9]+, build [0-9a-f]+"
+
+DOCKER_COMPOSE_VERSION_STRING=$(docker-compose version 2>/dev/null | head -n1)
+DOCKER_COMPOSE_VERSION_MINOR=$(echo $DOCKER_COMPOSE_VERSION_STRING | sed -rn "s/$DOCKER_COMPOSE_VERSION_REGEX_MINOR_BACKREF/\1/p")
+
+compare_versions "$DOCKER_COMPOSE_VERSION_MINOR" "$VERSION_MINOR_MIN_DOCKER_COMPOSE"
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: Docker Compose must be on version 1.$VERSION_MINOR_MIN_DOCKER_COMPOSE or larger, but found version 1.$DOCKER_COMPOSE_VERSION_MINOR installed."
+  echo "DOCKER_COMPOSE_VERSION_STRING=$DOCKER_COMPOSE_VERSION_STRING"
+  exit 1
+fi
+
+exit 0

--- a/verify-docker-versions
+++ b/verify-docker-versions
@@ -27,9 +27,8 @@ compare_versions() {
 
 # test Docker Engine version
 
-DOCKER_ENGINE_VERSION_REGEX_MINOR_BACKREF="Docker version 1\.([0-9]+)\.[0-9]+, build [0-9a-f]+"
-
-DOCKER_ENGINE_VERSION_STRING=$(docker --version 2>/dev/null | head -n1)
+DOCKER_ENGINE_VERSION_REGEX_MINOR_BACKREF="1\.([0-9]+)\.[0-9]+"
+DOCKER_ENGINE_VERSION_STRING=$(sudo docker info -f '{{.ServerVersion}}')
 DOCKER_ENGINE_VERSION_MINOR=$(echo $DOCKER_ENGINE_VERSION_STRING | sed -rn "s/$DOCKER_ENGINE_VERSION_REGEX_MINOR_BACKREF/\1/p")
 
 compare_versions "$DOCKER_ENGINE_VERSION_MINOR" "$VERSION_MINOR_MIN_DOCKER_ENGINE"
@@ -43,9 +42,8 @@ fi
 
 # test Docker Compose version
 
-DOCKER_COMPOSE_VERSION_REGEX_MINOR_BACKREF="docker-compose version 1\.([0-9]+)\.[0-9]+, build [0-9a-f]+"
-
-DOCKER_COMPOSE_VERSION_STRING=$(docker-compose version 2>/dev/null | head -n1)
+DOCKER_COMPOSE_VERSION_REGEX_MINOR_BACKREF="1\.([0-9]+)\.[0-9]+"
+DOCKER_COMPOSE_VERSION_STRING=$(docker-compose version --short)
 DOCKER_COMPOSE_VERSION_MINOR=$(echo $DOCKER_COMPOSE_VERSION_STRING | sed -rn "s/$DOCKER_COMPOSE_VERSION_REGEX_MINOR_BACKREF/\1/p")
 
 compare_versions "$DOCKER_COMPOSE_VERSION_MINOR" "$VERSION_MINOR_MIN_DOCKER_COMPOSE"


### PR DESCRIPTION
Some users got unexpected behavior due to too old version of docker and docker-compose.
Minimum required is aligned with docs.