### PR TITLE
remove port 8080, use 443 as standard now

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ services:
         |                                       |    +-------------------------+
         |        +-----------------------+      |    |                         |
    port |        |                       |      +--->|  Device Admission       |
-   8080 | <----> |  API Gateway          |      |    |  (mender-device-adm)    |
+    443 | <----> |  API Gateway          |      |    |  (mender-device-adm)    |
         |        |  (mender-api-gateway) |<-----+    +-------------------------+
         |        +-----------------------+      |    |                         |
         |                                       +--->|  Inventory              |

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -11,7 +11,6 @@ services:
 
     mender-api-gateway:
         ports:
-            - "8080:443"
             - "443:443"
         networks:
             mender:


### PR DESCRIPTION
@bboozzoo @maciejmrowiec  pls review - any reason we redirected 8080 to 443?