### PR TITLE
Fix incorrect writing of file into ext4 using debugfs.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -73,7 +73,9 @@ class Helpers:
             output = subprocess.check_output(cmd, shell=True).strip()
             logging.info("Running: " + cmd + " returned: " + output)
 
-            cmd = "debugfs -w -R 'write %s %s' %s" % (tfile.name, self.artifact_info_file, install_image)
+            cmd = ("printf 'cd %s\nwrite %s %s\n' | debugfs -w %s"
+                   % (os.path.dirname(self.artifact_info_file),
+                      tfile.name, os.path.basename(self.artifact_info_file), install_image))
             output = subprocess.check_output(cmd, shell=True).strip()
             logging.info("Running: " + cmd + " returned: " + output)
 

--- a/tests/modify_ext4.sh
+++ b/tests/modify_ext4.sh
@@ -9,4 +9,4 @@ sed -i 's/.*UpdatePollIntervalSeconds.*/\  "UpdatePollIntervalSeconds\": 2,/g' "
 sed -i 's/.*InventoryPollIntervalSeconds.*/\  "InventoryPollIntervalSeconds\": 2,/g' "$TEMPFILE"
 
 debugfs -w -R "rm $MENDER_CONF" "$IMAGE_TO_EDIT"
-debugfs -w -R "write $TEMPFILE $MENDER_CONF" "$IMAGE_TO_EDIT"
+printf 'cd %s\nwrite %s %s\n' `dirname $MENDER_CONF` "$TEMPFILE" `basename $MENDER_CONF` | debugfs -w "$IMAGE_TO_EDIT"


### PR DESCRIPTION
Debugfs really deserves its name, "debug": Writing into a file name,
"/etc/hosts", will create a literal file with that name, including
slashes and everything, in the root! The slash is not a valid
filesystem character, so this corrupts the filesystem, and certainly
the file won't be found in the correct place.

Work around this by using the debugfs "cd" feature to get to the
correct directory first. Unfortunately you can't pass more than one -R
parameter, so we need to pipe the commands into it instead.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>