### PR TITLE
tests: integration: adapt to admission/device authentication API changes

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -29,12 +29,16 @@ if [[ -n "$BUILDDIR" ]]; then
 else
     # Download what we need.
     mkdir -p downloaded-tools
-    curl "https://d25phv8h0wbwru.cloudfront.net/${TEST_BRANCH}/tip/mender-artifact" -o downloaded-tools/mender-artifact
+    curl "https://d25phv8h0wbwru.cloudfront.net/${TEST_BRANCH}/tip/mender-artifact" \
+         -o downloaded-tools/mender-artifact \
+         -z downloaded-tools/mender-artifact
 
     chmod +x downloaded-tools/mender-artifact
     export PATH=$PWD/downloaded-tools:$PATH
 
-    curl -o core-image-full-cmdline-vexpress-qemu.ext4 "https://s3.amazonaws.com/mender/temp_${TEST_BRANCH}/core-image-full-cmdline-vexpress-qemu.ext4"
+    curl "https://s3.amazonaws.com/mender/temp_${TEST_BRANCH}/core-image-full-cmdline-vexpress-qemu.ext4" \
+         -o core-image-full-cmdline-vexpress-qemu.ext4 \
+         -z core-image-full-cmdline-vexpress-qemu.ext4
 fi
 
 

--- a/tests/tests/common_update.py
+++ b/tests/tests/common_update.py
@@ -41,7 +41,7 @@ def common_update_proceduce(install_image,
 
     if created:
         deploy.upload_image("artifact.mender")
-        devices_accepted_id = [device["id"] for device in adm.get_devices_status("accepted")]
+        devices_accepted_id = list(set([device["device_id"] for device in adm.get_devices_status("accepted")]))
         deployment_id = deploy.trigger_deployment(name="New valid update",
                                                   artifact_name=artifact_id,
                                                   devices=devices_accepted_id)
@@ -77,7 +77,7 @@ def update_image_successful(install_image=conftest.get_valid_image(), regnerate_
     deploy.check_expected_statistics(deployment_id, "success", len(get_mender_clients()))
 
     for d in adm.get_devices():
-        deploy.get_logs(d["id"], deployment_id, expected_status=404)
+        deploy.get_logs(d["device_id"], deployment_id, expected_status=404)
 
     Helpers.verify_reboot_not_performed()
     assert Helpers.yocto_id_installed_on_machine() == expected_image_id
@@ -104,7 +104,7 @@ def update_image_failed(install_image="broken_update.ext4"):
     deploy.check_expected_statistics(deployment_id, "failure", len(devices_accepted))
 
     for d in adm.get_devices():
-        assert "running rollback image" in deploy.get_logs(d["id"], deployment_id)
+        assert "running rollback image" in deploy.get_logs(d["device_id"], deployment_id)
 
     assert Helpers.yocto_id_installed_on_machine() == original_image_id
     Helpers.verify_reboot_not_performed()

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -52,7 +52,7 @@ class TestDeploymentAborting(MenderTesting):
 
         # no deployment logs are sent by the client, is this expected?
         for d in adm.get_devices():
-            deploy.get_logs(d["id"], deployment_id, expected_status=404)
+            deploy.get_logs(d["device_id"], deployment_id, expected_status=404)
 
         if not mender_performs_reboot:
             Helpers.verify_reboot_not_performed()

--- a/tests/tests/test_inventory.py
+++ b/tests/tests/test_inventory.py
@@ -38,7 +38,7 @@ class TestInventory(MenderTesting):
                 inv_json = inv.get_devices()
                 adm_json = adm.get_devices()
 
-                adm_ids = [device['id'] for device in adm_json]
+                adm_ids = [device['device_id'] for device in adm_json]
 
                 assert(len(inv_json) > 0)
 


### PR DESCRIPTION
Device admission does not list devices, but device authentication data
sets (each with a distinct ID). Auth data set ID is not the same as device ID.
However device ID (the one that owns given auth set) is available as device_id
field in objects returned by the API.

@GregorioDiStefano @mendersoftware/rndity 