### PR TITLE
Fix "AttributeError: 'NoneType' object has no attribute 'text'"

### DIFF
--- a/tests/MenderAPI/admission.py
+++ b/tests/MenderAPI/admission.py
@@ -52,10 +52,7 @@ class Admission():
                 assert len(devices.json()) == expected_devices
                 break
             except AssertionError:
-                if getattr(devices, "text"):
-                    logger.info("fail to get devices (payload: %s), will try #%d times" % (devices.text, tries-c-1))
-                else:
-                    logger.info("failed to get devices, will try #%d times" % (tries-c-1))
+                logger.info("failed to get devices, will try #%d times" % (tries-c-1))
                 continue
         else:
             assert False, "Not able to get devices"


### PR DESCRIPTION
'devices' is guaranteed to be None at that point. It's just debug
code, so remove it.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>