### PR TITLE
added device decommissioning test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,19 +34,6 @@ script:
     # Check commit compliance.
     - mendertesting/check_commits.sh
 
-    - if [ "$JOB_TYPE" = compile_and_integration_tests_fast ]; then ( cd tests && bash run.sh --runfast ); fi
-
-    - if [ "$JOB_TYPE" = compile_and_integration_tests_slow ]; then
-        ( cd tests && bash run.sh --runslow );
-      fi
-
-    - if [[ "$JOB_TYPE" = compile_and_integration_tests_amz_s3 ]] && [[ -n $AWS_ACCESS_KEY_ID ]] && [[ -n $AWS_SECRET_ACCESS_KEY ]]; then
-        ( cd tests && bash run.sh --runs3 );
-      fi
-
-    # CRON JOB SECTION
-    - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then ( cd tests && bash run.sh --runnightly ); fi
-
 notifications:
     slack:
         secure: l831fv7p5iskdhG082XVdi5UBhYXEZyRn0ZgEfPWqLfqCj5FyxC36KaYiQo+vp8BS9vX0JFEOuZ4PiKjG3+jSEsJIk0Lx/1fjCg1zi13xfzI2ke1BWGuBT5tuz+nKj3TujfnHM0KE8Ix8GkwnamR388DO0FtgJrhEMBylo33zVV5ZESBa3B2bwUfWgfFF7VeUeqtDnOiHFDqsu2A4lOmMMJPp8k+71x0qvUsUStswrG11S0UhDReuuH1+siy3/bDEnrZIwEBvSM8DxdLLWC/SmCiCMdCU95GfzFRJsZN+2+KavCN8kXxvOG8rYrr8EhOLF4BbGDTJI9Dw+4H4OKOD/Bf+hr1OqYxpGtJxKzGWVlds1MwjjxklWlXopgIfwIZtmgC2RynLEw7LYHMcmBmr2+zjbvl0LZqWto1/G+la3J45rNaXawJtwY2RJ+c5jkm13BoYbOpUAg2SZ7WwW6frW6XdObiegpBfObSapAIEwMHeCSYvZbDPfhv0PFgGS9BQwJ+bz0PY1xoY45EaglnLt8zhcG3pfzXMo7jHFwIcP9/NGi7SO71lL4uhmcYn29PhRoIBMg/gjq7doycCfBWyUQrjGBOhDHzpq01TazxakDussWCSQ534ZwWrksI1d9ONMyikNOFXBkSHsqihYrNF+sLAtGEtHg0Ww7qRc0P/R0=

--- a/tests/MenderAPI/__init__.py
+++ b/tests/MenderAPI/__init__.py
@@ -15,9 +15,11 @@ import admission
 import deployments
 import artifacts
 import inventory
+import device_authentication
 
 auth = authentication.Authentication()
 adm = admission.Admission(auth)
 deploy = deployments.Deployments(auth)
 image = artifacts.Artifacts()
 inv = inventory.Inventory(auth)
+deviceauth = device_authentication.DeviceAuthentication(auth)

--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -125,7 +125,7 @@ class Deployments(object):
                 continue
 
         if time.time() > timeout:
-            pytest.fail("Never found status: %s for %s" % (expected_status, deployment_id))
+            pytest.fail("Never found status: %s for %s after %d seconds" % (expected_status, deployment_id, max_wait))
 
 
     def check_expected_statistics(self, deployment_id, expected_status, expected_count, max_wait=600, polling_frequency=.2):
@@ -143,7 +143,7 @@ class Deployments(object):
             continue
 
         if time.time() > timeout:
-            pytest.fail("Never found: %s:%s, only seen: %s" % (expected_status, expected_count, str(seen)))
+            pytest.fail("Never found: %s:%s, only seen: %s after %d seconds" % (expected_status, expected_count, str(seen), max_wait))
 
     def abort(self, deployment_id):
         deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (deployment_id)

--- a/tests/MenderAPI/device_authentication.py
+++ b/tests/MenderAPI/device_authentication.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+# Copyright 2016 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+import requests
+from fabric.api import *
+from common import *
+from common_docker import *
+from MenderAPI import api_version
+
+
+class DeviceAuthentication(object):
+    auth = None
+
+    def __init__(self, auth):
+        self.auth = auth
+
+    def get_deviceauth_base_path(self):
+        return "https://%s/api/management/%s/devauth/devices/" % (get_mender_gateway(), api_version)
+
+    def decommission(self, deviceID, expected_http_code=204):
+        decommission_path_url = self.get_deviceauth_base_path() + str(deviceID)
+        r = requests.delete(decommission_path_url,
+                            verify=False,
+                            headers=self.auth.get_auth_token())
+        print(decommission_path_url, r.status_code)
+        assert r.status_code == expected_http_code

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -19,8 +19,8 @@ from common import *
 from common_docker import *
 
 @pytest.fixture(scope="function")
-def standard_setup_one_client():
-    if setup_type() == ST_OneClient:
+def standard_setup_one_client(request):
+    if getattr(request, 'param', False) and request.param != "force_new" and setup_type() == ST_OneClient:
         return
 
     restart_docker_compose()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -127,7 +127,7 @@ class Helpers:
             logging.info("Exception while messing with network connectivity: " + e)
 
     @staticmethod
-    def verify_reboot_performed(max_wait=60*15):
+    def verify_reboot_performed(max_wait=60*30):
         successful_connections = 0
         tfile = "/tmp/mender-testing.%s" % (random.randint(1, 999999))
         cmd = "touch %s" % (tfile)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -76,6 +76,11 @@ if ! pip list |grep -e pytest-xdist >/dev/null 2>&1; then
 else
     # run all tests when running in parallel
     MAX_FAIL_ARG=""
+
+    # allow you to run something else besides -n auto
+    if [[ -n $XDIST_PARALLEL_ARG ]]; then
+        XDIST_ARGS="-n $XDIST_PARALLEL_ARG"
+    fi
 fi
 
 if ! pip list|grep -e pytest-html >/dev/null 2>&1; then

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -49,6 +49,9 @@ class TestBootstrapping(MenderTesting):
         # make sure all devices are accepted
         adm.check_expected_status("accepted", len(get_mender_clients()))
 
+        # make sure mender-store contains authtoken
+        run("strings /data/mender/mender-store | grep -q 'authtoken'")
+
         # print all device ids
         for device in adm.get_devices_status("accepted"):
             logging.info("Accepted DeviceID: %s" % device["id"])
@@ -74,11 +77,11 @@ class TestBootstrapping(MenderTesting):
             logging.info("Failed to deploy upgrade to rejected device.")
             Helpers.verify_reboot_not_performed()
 
-            # authtoken has been removed
-            assert not exists("/data/mender/authtoken")
+            # authtoken has been removed from mender-store
+            run("strings /data/mender/mender-store | grep -q 'authtoken' || false")
 
         else:
-            raise("No error while trying to deploy to rejected device")
+            pytest.fail("No error while trying to deploy to rejected device")
 
         # re-accept device after test is done
         adm.accept_devices(1)

--- a/tests/tests/test_decommission.py
+++ b/tests/tests/test_decommission.py
@@ -22,16 +22,17 @@ from common_update import common_update_procedure
 from MenderAPI import inv, adm, deploy, deviceauth
 from mendertesting import MenderTesting
 
-@pytest.mark.usefixtures("standard_setup_one_client")
+# ugly way of passing a the "true" parameter to "standard_setup_one_client"
+@pytest.mark.parametrize("standard_setup_one_client", ["force_new"], indirect=True)
 class TestDeviceDecommissioning(MenderTesting):
 
 
     @MenderTesting.fast
-    def test_device_decommissioning(self):
+    def test_device_decommissioning(self, standard_setup_one_client):
         """ Decommission a device successfully """
 
         if not env.host_string:
-            execute(self.test_device_decommissioning, hosts=get_mender_clients())
+            execute(self.test_device_decommissioning, standard_setup_one_client, hosts=get_mender_clients())
             return
 
         adm.check_expected_status("pending", len(get_mender_clients()))

--- a/tests/tests/test_decommission.py
+++ b/tests/tests/test_decommission.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# Copyright 2016 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from fabric.api import *
+import pytest
+from common import *
+from common_setup import *
+from helpers import Helpers
+from common_update import common_update_procedure
+from MenderAPI import inv, adm, deploy, deviceauth
+from mendertesting import MenderTesting
+
+@pytest.mark.usefixtures("standard_setup_one_client")
+class TestDeviceDecommissioning(MenderTesting):
+
+
+    @MenderTesting.fast
+    def test_device_decommissioning(self):
+        """ Decommission a device successfully """
+
+        if not env.host_string:
+            execute(self.test_device_decommissioning, hosts=get_mender_clients())
+            return
+
+        adm.check_expected_status("pending", len(get_mender_clients()))
+        adm_id = adm.get_devices()[0]["id"]
+        device_id = adm.get_devices()[0]["device_id"]
+
+        adm.set_device_status(adm_id, "accepted")
+
+        # wait until inventory is populated
+        timeout = time.time() + (60 * 5)
+        while time.time() < timeout:
+            inventoryJSON = inv.get_devices()
+            if "attributes" in inventoryJSON[0]:
+                break
+            time.sleep(.5)
+        else:
+            pytest.fail("never got inventory")
+
+        # decommission actual device
+        deviceauth.decommission(device_id)
+
+        # now check that the device no longer exists in admissions
+        timeout = time.time() + (60 * 5)
+        while time.time() < timeout:
+                newAdmissions = adm.get_devices()[0]
+                if device_id != newAdmissions["device_id"] \
+                   and adm_id != newAdmissions["id"]:
+                       break
+                time.sleep(.5)
+        else:
+            pytest.fail("decommissioned device still available in admissions")
+
+        # make sure a deployment to the decommissioned device fails
+        try:
+            deployment_id, _ = common_update_procedure(install_image=conftest.get_valid_image(),
+                                                       devices=[device_id])
+        except AssertionError:
+            logging.info("Failed to deploy upgrade to rejected device")
+            # authtoken has been removed
+            run("strings /data/mender/mender-store | grep -q 'authtoken' || false")
+        else:
+            pytest.fail("No error while trying to deploy to rejected device")
+
+
+        """
+            at this point, the device will re-appear, since it's actually still
+            online, and not actually decomissioned
+        """
+        adm.check_expected_status("pending", len(get_mender_clients()))
+
+        # make sure inventory is empty as well
+        assert len(inv.get_devices()) == 0


### PR DESCRIPTION
@kjaskiewiczz @maciejmrowiec 

can you think of anything else that should be added here?

i'm aware that decommissioning a device after it's made a deployment, should include a decommissioned device, but was hoping that will be added to the acceptance tests, so I don't have to perform an actual deployment here.