### PR TITLE
extra/travis-testing: improve teardown in run-test-environment

### DIFF
--- a/extra/travis-testing/run-test-environment
+++ b/extra/travis-testing/run-test-environment
@@ -68,6 +68,6 @@ shift
 }
 
 # fold everything
-[ -z "$NO_CLEANUP" ] && $COMPOSE_CMD down && $COMPOSE_CMD rm || true
+[ -z "$NO_CLEANUP" ] && $COMPOSE_CMD -f $TESTS_COMPOSE_PATH down && $COMPOSE_CMD -f $TESTS_COMPOSE_PATH rm || true
 
 exit $failed


### PR DESCRIPTION
include the $TEST_COMPOSE_PATH in the teardown command.

this is important e.g. for tenantadm, which is not included in
our default compose files that make up the $COMPOSE_CMD. the test
compose defines it as a completely new service.

the result is that after teardown, any new service in the test compose
is not killed (orphaned containers). a secondary effect is that the coverage
report is never generated/sent.

this fix is also important for other closed features/services.

Issues: MEN-1075

Changelog: None

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@GregorioDiStefano @mendersoftware/rndity 