### PR TITLE
conductor: do not publish conductor ports in production template by default

### DIFF
--- a/template/prod.yml
+++ b/template/prod.yml
@@ -127,8 +127,6 @@ services:
         entrypoint: /srv/start_conductor.sh
         environment:
             - CONFIG_PROP=config.properties
-        ports:
-            - "8080:8080"
 
     mender-mongo-deployments:
         volumes:


### PR DESCRIPTION
Fixes: https://tracker.mender.io/browse/MEN-1240

@maciejmrowiec @GregorioDiStefano @mendersoftware/rndity 
