### PR TITLE
integration tests: fix test_deployment_abortion_success

### DIFF
--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -159,3 +159,8 @@ class Deployments(object):
         deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (deployment_id)
         r = requests.put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "aborted"})
         assert r.status_code == requests.status_codes.codes.no_content
+
+    def abort_finished_deployment(self, deployment_id):
+        deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (deployment_id)
+        r = requests.put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "aborted"})
+        assert r.status_code == requests.status_codes.codes.unprocessable_entity

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -92,6 +92,6 @@ class TestDeploymentAborting(MenderTesting):
         Helpers.verify_reboot_performed()
 
         deploy.check_expected_statistics(deployment_id, "success", len(get_mender_clients()))
-        deploy.abort(deployment_id)
+        deploy.abort_finished_deployment(deployment_id)
         deploy.check_expected_statistics(deployment_id, "success", len(get_mender_clients()))
         deploy.check_expected_status("finished", deployment_id)


### PR DESCRIPTION
Aborting deployment which is already finished should result in 422
response, not 204.

@GregorioDiStefano 