### PR TITLE
remove useless --docker-compose-file argument from pytest

### DIFF
--- a/tests/common_docker.py
+++ b/tests/common_docker.py
@@ -31,14 +31,10 @@ log_files = []
 
 
 def docker_compose_cmd(arg_list, use_common_files=True):
-    extra_files = pytest.config.getoption("--docker-compose-file")
-    if extra_files is None:
-        extra_files = []
-
     files_args = ""
 
     if use_common_files:
-        for file in COMPOSE_FILES + extra_files:
+        for file in COMPOSE_FILES:
             files_args += " -f %s" % file
 
     with conftest.docker_lock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,6 @@ def pytest_addoption(parser):
     parser.addoption("--runfast", action="store_true", help="run fast tests")
     parser.addoption("--runnightly", action="store_true", help="run nightly (very slow) tests")
     parser.addoption("--runs3", action="store_true", help="run fast tests")
-
     parser.addoption("--upgrade-from", action="store", help="perform upgrade test", default="")
     parser.addoption("--docker-compose-file", action="append", help="Additional docker-compose files to use for test")
     parser.addoption("--no-teardown", action="store_true", help="Don't tear down environment after tests are run")


### PR DESCRIPTION
Changelog: none
Signed-off-by: greg <greg.distefano+github@gmail.com>