### PR TITLE
compose: set ALLOWED HOSTS

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -19,6 +19,8 @@ services:
         volumes:
             - ./certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.crt
             - ./certs/api-gateway/private.key:/var/www/mendersoftware/cert/private.key
+        environment:
+            ALLOWED_HOSTS: docker.mender.io
 
     storage-proxy:
         ports:

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -62,6 +62,8 @@ services:
             options:
                 max-file: "10"
                 max-size: "50m"
+        environment:
+            ALLOWED_HOSTS: my-gateway-dns-name
 
     storage-proxy:
         ports:


### PR DESCRIPTION
the user will have to substitute this value with the DNS name he allocates
for the gateway.

the gateway's docker entrypoint will pick up this env var and modify the Host
whitelist in nginx.conf.

related to host header injection hardening.

Issues: MEN-1262

Changelog: None

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>