### PR TITLE
Changelog: Update conductor to 1.7.7

### DIFF
--- a/conductor/server/config/config.properties
+++ b/conductor/server/config/config.properties
@@ -9,7 +9,7 @@ db=dynomite
 
 # Dynomite Cluster details.
 # format is host:port:rack separated by semicolon
-workflow.dynomite.cluster.hosts=mender-dynomite:8102:dummyregion
+workflow.dynomite.cluster.hosts=mender-dynomite:8102:us-east-1b
 
 # Dynomite cluster name
 workflow.dynomite.cluster.name=mender-dynomite
@@ -36,4 +36,4 @@ workflow.elasticsearch.url=mender-elasticsearch:9300
 workflow.elasticsearch.index.name=conductor
 
 # For single node dynomite, must be the same as 'rack'
-EC2_AVAILABILITY_ZONE=dummyregion
+EC2_AVAILABILITY_ZONE=us-east-1b

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,7 @@ services:
                     - mongo-useradm
 
     mender-conductor:
-        image: mendersoftware/conductor:1.7.0
+        image: mendersoftware/conductor:1.7.7
         depends_on:
             - mender-elasticsearch
             - mender-dynomite

--- a/extra/conductor-ui.yml
+++ b/extra/conductor-ui.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     mender-conductor-ui:
-        image: mendersoftware/conductor-ui:1.7.0
+        image: mendersoftware/conductor-ui:1.7.7
         environment:
             - WF_SERVER=http://mender-conductor:8080/api/
         depends_on:


### PR DESCRIPTION
Region in config has now validation, needed to switch to correct AWS region instead "dummy".

New 1.7.7 images are pushed to docker hub.