### PR TITLE
tests/run.sh: whitelist all IPs/DNS names in the gateway for tests

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -76,6 +76,8 @@ fi
 sed -e '/9000:9000/d' -e '/443:443/d' -e '/ports:/d' ../docker-compose.demo.yml > ../docker-compose.testing.yml
 # disable download speed limits
 sed -e 's/DOWNLOAD_SPEED/#DOWNLOAD_SPEED/' -i ../docker-compose.testing.yml
+# whitelist *all* IPs/DNS names in the gateway (will be accessed via dynamically assigned IP in tests)
+sed -e 's/ALLOWED_HOSTS: docker.mender.io/ALLOWED_HOSTS: ~./' -i ../docker-compose.testing.yml
 # disable dynomite logs, NOTE indentation is important in this one
 cat <<EOF  >> ../docker-compose.testing.yml
     mender-dynomite:


### PR DESCRIPTION
tests access the gateway via IP, not a well-defined alias like docker.mender.io.
now that we have a host whitelist (server_name: ...) in the gateway, we have to
set it - so set it to a catchall regex because we don't know anything in advance.
otherwise pretty much everything fails with a nasty connection termination error.

btw '*' doesn't work here, yaml doesn't allow it (nginx doesn't allow it either for that matter). 

Issues: MEN-1262

Changelog: None

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

this is a followup to a previous PR to `integration` that we force merged to make https://github.com/mendersoftware/mender-api-gateway-docker/pull/65 green (but it was not enough obviously). @GregorioDiStefano can we force a merge here too if need be? (EDIT - the build is green so no need to force, but please have a look regardless).

@mendersoftware/rndity @maciejmrowiec 