### PR TITLE
testing: kill docker-compose logs if they still exist after downing backend

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.12.0
 pytest>=3.0
 Fabric>=1.13.0
 filelock>=2.0
+psutil


### PR DESCRIPTION
Changelog: none
Signed-off-by: Greg Di Stefano <greg.distefano+github@gmail.com>