### PR TITLE
compose/demo, template/prod: run deviceauth with automigrations

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -6,6 +6,7 @@ services:
             - ./keys/useradm/private.key:/etc/useradm/rsa/private.pem
 
     mender-device-auth:
+        command: server --automigrate
         volumes:
             - ./keys/deviceauth/private.key:/etc/deviceauth/rsa/private.pem
 

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -30,6 +30,7 @@ services:
                 max-size: "50m"
 
     mender-device-auth:
+        command: server --automigrate
         volumes:
             - ./template/keys-generated/keys/deviceauth/private.key:/etc/deviceauth/rsa/private.pem:ro
         logging:


### PR DESCRIPTION
by default, deviceauth will not run migrations, only check the db version.
ensure migrations are ran via the new 'server --automigrate' command.

Issues: MEN-1243

Changelog: None

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@maciejmrowiec @mendersoftware/rndity 

@GregorioDiStefano this will have to be ran against https://github.com/mendersoftware/deviceauth/pull/142 
in jenkins