### PR TITLE
compose/demo, template/prod: run deviceadm with automigrations

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -10,6 +10,9 @@ services:
         volumes:
             - ./keys/deviceauth/private.key:/etc/deviceauth/rsa/private.pem
 
+    mender-device-adm:
+        command: server --automigrate
+
     mender-api-gateway:
         ports:
             - "443:443"

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -45,6 +45,7 @@ services:
                 max-size: "50m"
 
     mender-device-adm:
+        command: server --automigrate
         logging:
             options:
                 max-file: "10"


### PR DESCRIPTION
By default, deviceauth will not run migrations, only check the db
version.
Ensure migrations are ran via the new 'server --automigrate' command.