### PR TITLE
Make sure there is a way to reset API objects between tests.

### DIFF
--- a/tests/MenderAPI/__init__.py
+++ b/tests/MenderAPI/__init__.py
@@ -30,6 +30,16 @@ deploy = deployments.Deployments(auth, adm)
 image = artifacts.Artifacts()
 inv = inventory.Inventory(auth)
 deviceauth = device_authentication.DeviceAuthentication(auth)
+# -- When adding something here, also add a reset method and add it below --
+
+def reset_mender_api():
+    auth.reset()
+    adm.reset()
+    deploy.reset()
+    image.reset()
+    inv.reset()
+    deviceauth.reset()
+reset_mender_api()
 
 logger = logging.getLogger('mender')
 logger.info("Setting api_version as: " + api_version)

--- a/tests/MenderAPI/admission.py
+++ b/tests/MenderAPI/admission.py
@@ -20,7 +20,12 @@ class Admission():
     auth = None
 
     def __init__(self, auth):
+        self.reset()
         self.auth = auth
+
+    def reset(self):
+        # Reset all temporary values.
+        pass
 
     def get_admission_base_path(self):
         return "https://%s/api/management/%s/admission/" % (get_mender_gateway(), api_version)

--- a/tests/MenderAPI/artifacts.py
+++ b/tests/MenderAPI/artifacts.py
@@ -19,6 +19,10 @@ from MenderAPI import *
 class Artifacts():
     artifacts_tool_path = "mender-artifact"
 
+    def reset(self):
+        # Reset all temporary values.
+        pass
+
     def make_artifact(self, image, device_type, artifact_name, artifact_file_created, signed=False, scripts=[]):
         signed_arg = ""
 

--- a/tests/MenderAPI/authentication.py
+++ b/tests/MenderAPI/authentication.py
@@ -18,17 +18,27 @@ from MenderAPI import *
 class Authentication:
     auth_header = None
 
-    username = ""
-    email = ""
-    password = ""
+    username = "admin"
+    email = "admin@admin.net"
+    password = "averyverystrongpasswordthatyouwillneverguess!haha!"
 
     multitenancy = False
     current_tenant = {}
 
-    def __init__(self, username="admin", email="admin@admin.net", password="averyverystrongpasswordthatyouwillneverguess!haha!"):
+    def __init__(self, username=username, email=password, password=password):
+        self.reset()
         self.username = username
         self.email = email
         self.password = password
+
+    def reset(self):
+        # Reset all temporary values.
+        self.auth_header = Authentication.auth_header
+        self.username = Authentication.username
+        self.email = Authentication.email
+        self.password = Authentication.password
+        self.multitenancy = Authentication.multitenancy
+        self.current_tenant = Authentication.current_tenant
 
     def set_tenant(self, username, password):
         return self.new_tenant(username, password)

--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -19,10 +19,16 @@ class Deployments(object):
     # track the last statistic for a deployment id
     last_statistic = {}
     auth = None
+    adm = None
 
     def __init__(self, auth, adm):
+        self.reset()
         self.auth = auth
         self.adm = adm
+
+    def reset(self):
+        # Reset all temporary values.
+        self.last_statistic = Deployments.last_statistic
 
     def get_deployments_base_path(self):
         return "https://%s/api/management/%s/deployments/" % (get_mender_gateway(), api_version)

--- a/tests/MenderAPI/device_authentication.py
+++ b/tests/MenderAPI/device_authentication.py
@@ -19,7 +19,12 @@ class DeviceAuthentication(object):
     auth = None
 
     def __init__(self, auth):
+        self.reset()
         self.auth = auth
+
+    def reset(self):
+        # Reset all temporary values.
+        pass
 
     def get_deviceauth_base_path(self):
         return "https://%s/api/management/%s/devauth/devices/" % (get_mender_gateway(), api_version)

--- a/tests/MenderAPI/inventory.py
+++ b/tests/MenderAPI/inventory.py
@@ -19,7 +19,12 @@ class Inventory():
     auth = None
 
     def __init__(self, auth):
+        self.reset()
         self.auth = auth
+
+    def reset(self):
+        # Reset all temporary values.
+        pass
 
     def get_inv_base_path(self):
         return "https://%s/api/management/%s/inventory/" % (get_mender_gateway(), api_version)

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -13,7 +13,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 import pytest
-from MenderAPI import auth, adm
+from MenderAPI import auth, adm, reset_mender_api
 from common import *
 from common_docker import *
 import conftest
@@ -24,7 +24,7 @@ def standard_setup_one_client(request):
         return
 
     restart_docker_compose()
-    auth.reset_auth_token()
+    reset_mender_api()
 
     set_setup_type(ST_OneClient)
 
@@ -45,7 +45,7 @@ def standard_setup_one_client_bootstrapped():
         return
 
     restart_docker_compose()
-    auth.reset_auth_token()
+    reset_mender_api()
     adm.accept_devices(1)
 
     set_setup_type(ST_OneClientBootstrapped)
@@ -57,7 +57,7 @@ def standard_setup_two_clients_bootstrapped():
         return
 
     restart_docker_compose(2)
-    auth.reset_auth_token()
+    reset_mender_api()
     adm.accept_devices(2)
 
     set_setup_type(ST_TwoClientsBootstrapped)
@@ -68,6 +68,7 @@ def standard_setup_one_client_bootstrapped_with_s3():
         return
 
     stop_docker_compose()
+    reset_mender_api()
 
     docker_compose_cmd("-f ../docker-compose.client.yml \
                         -f ../docker-compose.storage.s3.yml \
@@ -90,6 +91,7 @@ def standard_setup_without_client():
         return
 
     stop_docker_compose()
+    reset_mender_api()
 
     docker_compose_cmd("-f ../docker-compose.yml \
                         -f ../docker-compose.storage.minio.yml \
@@ -105,6 +107,7 @@ def standard_setup_with_signed_artifact_client(request):
         return
 
     stop_docker_compose()
+    reset_mender_api()
 
     docker_compose_cmd("-f ../extra/signed-artifact-client-testing/docker-compose.signed-client.yml up -d")
 
@@ -120,6 +123,7 @@ def standard_setup_with_short_lived_token():
         return
 
     stop_docker_compose()
+    reset_mender_api()
 
     docker_compose_cmd("-f ../docker-compose.yml \
                         -f ../docker-compose.client.yml \
@@ -136,6 +140,8 @@ def standard_setup_with_short_lived_token():
 @pytest.fixture(scope="function")
 def running_custom_production_setup(request):
     conftest.production_setup_lock.acquire()
+
+    reset_mender_api()
 
     # since we are starting a manual instance of the backend,
     # let the script know the instance is called "testprod"
@@ -157,6 +163,8 @@ def multitenancy_setup_without_client():
         return
 
     stop_docker_compose()
+    reset_mender_api()
+
     docker_compose_cmd("-f ../docker-compose.yml \
                         -f ../docker-compose.storage.minio.yml \
                         -f ../docker-compose.testing.yml \


### PR DESCRIPTION
Multitenancy tests modify the way that the server is accessed, and
hence need to reset this before the next test starts.

Changelog: none

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>