### PR TITLE
compose, template: set mender-inventory command to `server --automigrate`

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -14,6 +14,9 @@ services:
     mender-device-adm:
         command: server --automigrate
 
+    mender-inventory:
+        command: server --automigrate
+
     mender-api-gateway:
         ports:
             - "443:443"

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -40,6 +40,7 @@ services:
                 max-size: "50m"
 
     mender-inventory:
+        command: server --automigrate
         logging:
             options:
                 max-file: "10"


### PR DESCRIPTION


Ensure that inventory service starts in daemon mode and automatically applies DB
migrations.


goes along with https://github.com/mendersoftware/inventory/pull/95

@mendersoftware/rndity @maciejmrowiec 