### PR TITLE
test_state_scripts: Remove old test section and improve logging.

### DIFF
--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -632,7 +632,6 @@ class TestStateScripts(MenderTesting):
         "ArtifactFailure_Error_55", # Error for this state doesn't exist, should never run.
     ]
 
-    @pytest.mark.skip(reason="MEN-1522")
     @MenderTesting.slow
     @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
     @pytest.mark.parametrize("test_set", TEST_SETS)

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -762,15 +762,16 @@ class TestStateScripts(MenderTesting):
                 ]
                 attempts = 0
                 while attempts < 60:
-                    try:
+                    with settings(warn_only=True):
                         attempts = attempts + 1
-                        run("grep Error /data/test_state_scripts.log")
-                        # If it succeeds, stop.
-                        break
-                    except subprocess.CalledProcessError:
-                        fetch_info(info_query)
-                        time.sleep(10)
-                        continue
+                        result = run("grep Error /data/test_state_scripts.log")
+                        if result.succeeded:
+                            # If it succeeds, stop.
+                            break
+                        else:
+                            fetch_info(info_query)
+                            time.sleep(10)
+                            continue
                 else:
                     info = fetch_info(info_query)
                     pytest.fail('Waited too long for "Error" to appear in log:\n%s' % info)

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -749,14 +749,12 @@ class TestStateScripts(MenderTesting):
                         run("grep Error /data/test_state_scripts.log")
                         # If it succeeds, stop.
                         break
-                    except:
+                    except subprocess.CalledProcessError:
                         time.sleep(10)
                         continue
                 else:
-                    # TODO REMOVE
-                    if True in ["Error" in state for state in test_set['ScriptOrder']]:
-                        output = run("cat /data/test_state_scripts.log")
-                        assert False, 'Waited too long for "Error" to appear in log:\n%s' % output
+                    output = run("cat /data/test_state_scripts.log 1>&2")
+                    assert False, 'Waited too long for "Error" to appear in log:\n%s' % output
             else:
                 deploy.check_expected_statistics(deployment_id, test_set['ExpectedStatus'], 1)
 


### PR DESCRIPTION
The TODO was there because previously the Error case did not work. Now
it does. And the logging change is done because Jenkins only gives us
stderr in the log, not stdout, for unknown reasons.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>