### PR TITLE
tests: Split reboot detection in two to avoid race conditions. 

### DIFF
--- a/tests/tests/common_update.py
+++ b/tests/tests/common_update.py
@@ -73,10 +73,12 @@ def update_image_successful(install_image, regenerate_image_id=True, signed=Fals
     """
 
     previous_inactive_part = Helpers.get_passive_partition()
+    token = Helpers.place_reboot_token()
     deployment_id, expected_image_id = common_update_procedure(install_image,
                                                                regenerate_image_id,
                                                                signed=signed)
-    Helpers.verify_reboot_performed()
+    token.verify_reboot_performed()
+    token = Helpers.place_reboot_token()
 
     try:
         assert Helpers.get_active_partition() == previous_inactive_part
@@ -94,7 +96,7 @@ def update_image_successful(install_image, regenerate_image_id=True, signed=Fals
         deploy.get_logs(d["device_id"], deployment_id, expected_status=404)
 
     if not skip_reboot_verification:
-        Helpers.verify_reboot_not_performed()
+        token.verify_reboot_not_performed()
 
     assert Helpers.yocto_id_installed_on_machine() == expected_image_id
 
@@ -119,9 +121,11 @@ def update_image_failed(install_image="broken_update.ext4", expected_mender_clie
     original_image_id = Helpers.yocto_id_installed_on_machine()
 
     previous_active_part = Helpers.get_active_partition()
+    token = Helpers.place_reboot_token()
     deployment_id, _ = common_update_procedure(install_image, broken_image=True)
 
-    Helpers.verify_reboot_performed()
+    token.verify_reboot_performed()
+    token = Helpers.place_reboot_token()
     assert Helpers.get_active_partition() == previous_active_part
 
     deploy.check_expected_statistics(deployment_id, "failure", expected_mender_clients)
@@ -130,6 +134,6 @@ def update_image_failed(install_image="broken_update.ext4", expected_mender_clie
         assert "running rollback image" in deploy.get_logs(d["device_id"], deployment_id)
 
     assert Helpers.yocto_id_installed_on_machine() == original_image_id
-    Helpers.verify_reboot_not_performed()
+    token.verify_reboot_not_performed()
 
     deploy.check_expected_status("finished", deployment_id)

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -71,11 +71,12 @@ class TestBootstrapping(MenderTesting):
 
         adm.check_expected_status("rejected", len(get_mender_clients()))
 
+        token = Helpers.place_reboot_token()
         try:
             deployment_id, _ = common_update_procedure(install_image=conftest.get_valid_image())
         except AssertionError:
             logging.info("Failed to deploy upgrade to rejected device.")
-            Helpers.verify_reboot_not_performed()
+            token.verify_reboot_not_performed()
 
         else:
             # use assert to fail, so we can get backend logs

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -44,6 +44,7 @@ class TestDeploymentAborting(MenderTesting):
         install_image=conftest.get_valid_image()
         expected_partition = Helpers.get_active_partition()
         expected_image_id = Helpers.yocto_id_installed_on_machine()
+        token = Helpers.place_reboot_token()
         deployment_id, _ = common_update_procedure(install_image, verify_status=False)
 
         if abort_step is not None:
@@ -56,10 +57,10 @@ class TestDeploymentAborting(MenderTesting):
             deploy.get_logs(d["device_id"], deployment_id, expected_status=404)
 
         if not mender_performs_reboot:
-            Helpers.verify_reboot_not_performed()
+            token.verify_reboot_not_performed()
             run("( sleep 10 ; reboot ) 2>/dev/null >/dev/null &")
 
-        Helpers.verify_reboot_performed()
+        token.verify_reboot_performed()
 
         assert Helpers.get_active_partition() == expected_partition
         assert Helpers.yocto_id_installed_on_machine() == expected_image_id
@@ -90,9 +91,10 @@ class TestDeploymentAborting(MenderTesting):
             return
 
         install_image = conftest.get_valid_image()
+        token = Helpers.place_reboot_token()
         deployment_id, _ = common_update_procedure(install_image)
 
-        Helpers.verify_reboot_performed()
+        token.verify_reboot_performed()
 
         deploy.check_expected_statistics(deployment_id, "success", len(get_mender_clients()))
         deploy.abort_finished_deployment(deployment_id)

--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -36,8 +36,9 @@ class TestFailures(MenderTesting):
                     install_image=install_image)
             return
 
+        token = Helpers.place_reboot_token()
         deployment_id, expected_image_id = common_update_procedure(install_image, True)
-        Helpers.verify_reboot_performed()
+        token.verify_reboot_performed()
 
         devices_accepted_id = [device["device_id"] for device in adm.get_devices_status("accepted")]
         deployment_id = deploy.trigger_deployment(name="New valid update",
@@ -54,7 +55,8 @@ class TestFailures(MenderTesting):
             execute(self.test_large_update_image, hosts=get_mender_clients())
             return
 
+        token = Helpers.place_reboot_token()
         deployment_id, _ = common_update_procedure(install_image="large_image.dat", regenerate_image_id=False, broken_image=True)
         deploy.check_expected_statistics(deployment_id, "failure", len(get_mender_clients()))
-        Helpers.verify_reboot_not_performed()
+        token.verify_reboot_not_performed()
         deploy.check_expected_status("finished", deployment_id)


### PR DESCRIPTION
By placing a file in /tmp before we do any action that can cause a
reboot, we guarantee that the reboot doesn't accidentally start before
we get to place the file. This relies on /tmp being cleaned at boot.

Changelog: none

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>