### PR TITLE
[DON'T MERGE] POC of conductor tasks/workers

### DIFF
--- a/conductor-workers/Dockerfile
+++ b/conductor-workers/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+
+RUN apt-get -y update && apt-get -y install git python3 python3-setuptools curl dnsutils
+
+RUN git clone https://github.com/Netflix/conductor.git
+
+RUN cd conductor/client/python && \
+       python3 setup.py install
+
+RUN mkdir -p /usr/bin/mender/prepare_welcome_email && \
+    mkdir -p /usr/bin/mender/send_email
+
+COPY prepare_welcome_email/* /usr/bin/mender/prepare_welcome_email/
+COPY send_email/* /usr/bin/mender/send_email/
+
+COPY entrypoint.sh /usr/bin/mender
+
+ENTRYPOINT ["/usr/bin/mender/entrypoint.sh"]

--- a/conductor-workers/entrypoint.sh
+++ b/conductor-workers/entrypoint.sh
@@ -1,0 +1,10 @@
+#!bin/sh
+
+# we have 2 binaries to run simultaneously
+# move 1 of them  to the background
+
+# background
+python3 /usr/bin/mender/send_email/main.py &
+
+# foreground
+python3 /usr/bin/mender/prepare_welcome_email/main.py

--- a/conductor-workers/prepare_welcome_email/main.py
+++ b/conductor-workers/prepare_welcome_email/main.py
@@ -1,0 +1,41 @@
+import time
+import logging
+
+from conductor.ConductorWorker import ConductorWorker
+
+logging.getLogger().setLevel(logging.INFO)
+
+# conductor input:
+#   tenant_name
+#   username
+def prepare_welcome_email(task):
+        logging.info('prepare_welcome_email')
+        tenant = task['inputData']['tenant_name']
+        user = task['inputData']['username']
+
+        title = 'Welcome to Mender'
+        body = 'Your organization {} has been created, your login: {}'.format(tenant, user)
+
+        # GOTCHA must return all these fields
+        # on errors: return 'status: FAILED'
+        return {'status': 'COMPLETED',
+                'output': {
+                    'email': user,
+                    'title': title,
+                    'body': body
+                    },
+                'logs': []}
+
+def main():
+    logging.info('starting prepare_welcome_email worker')
+    cc = ConductorWorker('http://mender-conductor:8080/api', 1, 0.1)
+
+    # this actually just starts polling for work - this is *not* starting a task, see ConductorWorker.py
+    cc.start('prepare_welcome_email', prepare_welcome_email, True)
+
+if __name__ == '__main__':
+    # GOTCHA conductor takes a looong time to actually start
+    # ('depends_on' doesn't help much)
+    time.sleep(20)
+
+    main()

--- a/conductor-workers/send_email/main.py
+++ b/conductor-workers/send_email/main.py
@@ -1,0 +1,33 @@
+import time
+import logging
+
+from conductor.ConductorWorker import ConductorWorker
+
+logging.getLogger().setLevel(logging.INFO)
+
+# conductor input:
+#   email
+#   title
+#   body
+def send_email(task):
+    logging.info('send_email')
+    logging.info('sending to %s:', task['inputData']['email'])
+    logging.info('title %s:', task['inputData']['title'])
+    logging.info('body %s:', task['inputData']['body'])
+
+    # GOTCHA must return all these fields
+    return {'status': 'COMPLETED', 'output': {}, 'logs': []}
+
+def main():
+    logging.info('starting send_email worker')
+    cc = ConductorWorker('http://mender-conductor:8080/api', 1, 0.1)
+
+    # this actually just starts polling for work - this is *not* starting a task, see ConductorWorker.py
+    cc.start('send_email', send_email, True)
+
+if __name__ == '__main__':
+    # GOTCHA conductor takes a looong time to actually start
+    # ('depends_on' doesn't help much)
+    time.sleep(20)
+
+    main()

--- a/conductor/server/tasks/prepare_welcome_email.json
+++ b/conductor/server/tasks/prepare_welcome_email.json
@@ -1,0 +1,11 @@
+[
+    {
+        "name": "prepare_welcome_email",
+        "retryCount": 3,
+        "timeoutSeconds": 1200,
+        "timeoutPolicy": "TIME_OUT_WF",
+        "retryLogic": "FIXED",
+        "retryDelaySeconds": 600,
+        "responseTimeoutSeconds": 3600
+    }
+]

--- a/conductor/server/tasks/send_email.json
+++ b/conductor/server/tasks/send_email.json
@@ -1,0 +1,11 @@
+[
+    {
+        "name": "send_email",
+        "retryCount": 3,
+        "timeoutSeconds": 1200,
+        "timeoutPolicy": "TIME_OUT_WF",
+        "retryLogic": "FIXED",
+        "retryDelaySeconds": 600,
+        "responseTimeoutSeconds": 3600
+    }
+]

--- a/conductor/server/workflows/create-organization
+++ b/conductor/server/workflows/create-organization
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 tenant_name username password"
+    exit 1
+fi
+
+curl -v -H "Content-Type: application/json" -X POST -d '{"tenant_name": "'"$1"'", "username": "'"$2"'", "password": "'"$3"'"}' http://localhost:8080/api/workflow/create_organization

--- a/conductor/server/workflows/create_organization.json
+++ b/conductor/server/workflows/create_organization.json
@@ -1,0 +1,31 @@
+{
+    "name": "create_organization",
+    "version": 2,
+    "tasks": [
+        {
+            "name": "prepare_welcome_email",
+            "taskReferenceName": "prepare_welcome_emailx",
+            "type": "SIMPLE",
+            "inputParameters": {
+                "tenant_name": "${workflow.input.tenant_name}",
+                "username": "${workflow.input.username}"
+            }
+        },
+        {
+            "name": "send_email",
+            "taskReferenceName": "send_welcome_email",
+            "type": "SIMPLE",
+            "inputParameters": {
+                "email": "${prepare_welcome_emailx.output.email}",
+                "title": "${prepare_welcome_emailx.output.title}",
+                "body": "${prepare_welcome_emailx.output.body}"
+            }
+        }
+    ],
+    "schemaVersion": 2,
+    "inputParameters":[
+        "tenant_name",
+        "username",
+        "password"
+    ]
+}

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -83,3 +83,14 @@ services:
         entrypoint: /srv/start_conductor.sh
         environment:
             - CONFIG_PROP=config.properties
+
+    mender-conductor-workers:
+        build: ./conductor-workers
+        extends:
+            file: common.yml
+            service: mender-base
+        depends_on:
+            - mender-conductor
+            - mender-dynomite
+        networks:
+            - mender

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -83,6 +83,17 @@ services:
         entrypoint: /srv/start_conductor.sh
         environment:
             - CONFIG_PROP=config.properties
+        ports:
+            - 8080:8080
+
+    mender-conductor-ui:
+        environment:
+            - WF_SERVER=http://mender-conductor:8080/api/
+        image: mendersoftware/conductor-ui:1.7.7
+        ports:
+            - 5000:5000
+        networks:
+            - mender
 
     mender-conductor-workers:
         build: ./conductor-workers


### PR DESCRIPTION
This is a research POC for https://tracker.mender.io/browse/MEN-1571.
The short conclusion:
- the research was successful
-  task workers work as expected
- the python client works flawlessly under python3
- all workers can be placed in a single, generic docker container (see Gotchas)

How it works
- `create_organization` workflow fakes our main workflow (without service interactions)
- 2 tasks are defined - `prepare_welcome_email` and `send_email`, and a worker for each
- each worker needs a separate process/main(), but both live in a single container
- task 1 passes input params to 2 via the `outputs` field/mechanism

also, some compose extras and shell helpers are introduced to make testing easier

How to run
- do the usual `./demo up`, wait ~20 secs (hardcoded conductor sleep - see Gotchas)
- go to `localhost: 5000` to inspect workflow/task defs
- before launching the workflow, it's useful to attach to just the worker container: `./demo logs -f mender-conductor-workers ` (dynomite spams stdout completely...)
- launch the workflow via the helper script, e.g. `./conductor/server/workflows/create-organization tenant1 foo@tenant1.com somepass123`
- worker container's logs should indicate that the tasks were started/completed
- see `localhost: 5000` again to view the completed workflow/tasks

Gotchas
1. Process-per-worker 
   * can't run >1 worker in a single process
   * each ConductorWorker enters an infinite polling loop via `start()`
   * btw task distribution happens via http polling (not dynomite/redis) - ConductorWorker uses the dedicated `poll` api
   * for now it's worked around by having the entrypoint start one worker in the background, and another in the foreground - discuss if ok (if the background worker dies - will docker know/restart the container? should we user supervisord?)

2. Conductor startup time
   * conductor takes an indeterminate amount of time to start (10-20s), even though the container is started
   * in this time, workers might fail (max retries)
   * worked around by waiting 20s before starting each worker
   * to discuss: is there a saner way?

3. Various
   * workers *must* return well-formed responses containing *all* fields (see code) - even though they don't have anything to say; otherwise it's a silent failure and stuck workflow

@mendersoftware/rndity @maciejmrowiec 