### PR TITLE
Upgrade Conductor to 1.8.1

### DIFF
--- a/conductor/server/entrypoint/conductor-load
+++ b/conductor/server/entrypoint/conductor-load
@@ -1,6 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
-import httplib
+import http.client
 import json
 import argparse
 import logging
@@ -23,7 +23,7 @@ def request(addr, method, url, body=None, headers=None):
     if not headers:
         headers = {}
 
-    with closing(httplib.HTTPConnection(addr)) as conn:
+    with closing(http.client.HTTPConnection(addr)) as conn:
         conn.request(method, url, body=body, headers=headers)
         resp = conn.getresponse()
         return (resp.status, resp.read())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
                     - mongo-useradm
 
     mender-conductor:
-        image: mendersoftware/conductor:1.7.7
+        image: mendersoftware/conductor:1.8.1
         depends_on:
             - mender-elasticsearch
             - mender-dynomite

--- a/extra/conductor-ui.yml
+++ b/extra/conductor-ui.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     mender-conductor-ui:
-        image: mendersoftware/conductor-ui:1.7.7
+        image: mendersoftware/conductor-ui:1.8.1
         environment:
             - WF_SERVER=http://mender-conductor:8080/api/
         depends_on:


### PR DESCRIPTION
Main changes:
* Correct logging setup to stdout in docker image
* ElasticCache / Redis support
* Image size reduction comming from change of base images of docker to apline linux.
* Minor bug fixes and improvements.
* JSON_TRANSFORM system tasks.

Full change list: https://github.com/Netflix/conductor/compare/v1.7.6...v1.8.1

Changelog: Title

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>