### PR TITLE
conductor/workflows: fix 404s on decommissioning

### DIFF
--- a/conductor/server/workflows/decommission_device.json
+++ b/conductor/server/workflows/decommission_device.json
@@ -31,7 +31,7 @@
                         "taskReferenceName": "delete_device_deployments",
                         "inputParameters": {
                             "http_request": {
-                                "uri": "http://mender-deployments:8080/api/0.0.1/deployments/devices/${workflow.input.device_id}",
+                                "uri": "http://mender-deployments:8080/api/management/v1/deployments/deployments/devices/${workflow.input.device_id}",
                                 "method": "DELETE",
                                 "headers": {
                                     "X-MEN-RequestID": "${workflow.input.request_id}",

--- a/tests/MenderAPI/device_authentication.py
+++ b/tests/MenderAPI/device_authentication.py
@@ -36,3 +36,7 @@ class DeviceAuthentication(object):
                             headers=self.auth.get_auth_token())
         assert r.status_code == expected_http_code
         logger.info("device [%s] is decommissioned" % (deviceID))
+
+    def get_device(self, device_id):
+        url = self.get_deviceauth_base_path() + device_id
+        return requests.get(url, verify=False, headers=self.auth.get_auth_token())

--- a/tests/MenderAPI/inventory.py
+++ b/tests/MenderAPI/inventory.py
@@ -39,6 +39,13 @@ class Inventory():
         assert ret.status_code == requests.status_codes.codes.ok
         return ret.json()
 
+    def get_device(self, device_id):
+        headers = self.auth.get_auth_token()
+        devurl = "%s%s/%s" % (self.get_inv_base_path(), "device", device_id)
+        ret = requests.get(devurl, headers=self.auth.get_auth_token(), verify=False)
+        return ret
+
+
     def get_groups(self):
         ret = requests.get(self.get_inv_base_path() + "groups", headers=self.auth.get_auth_token(), verify=False)
         assert ret.status_code == requests.status_codes.codes.ok

--- a/tests/common_docker.py
+++ b/tests/common_docker.py
@@ -144,6 +144,14 @@ def get_mender_gateway():
 
     return gateway[0]
 
+def get_mender_conductor():
+    conductor = docker_get_ip_of("mender-conductor")
+
+    if len(conductor) != 1:
+        raise SystemExit("expected one instance of mender-conductor running, but found: %d instance(s)" % len(conductor))
+
+    return conductor[0]
+
 def ssh_is_opened():
     execute(ssh_is_opened_impl, hosts=get_mender_clients())
 

--- a/tests/tests/conductor.py
+++ b/tests/tests/conductor.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+# Copyright 2017 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import requests
+
+
+class Conductor:
+    API_WF_SEARCH = '/api/workflow/search'
+
+    def __init__(self, host):
+        self.addr = 'http://%s:8080' % (host,)
+
+    def get_decommission_device_wfs(self, device_id, state='COMPLETED'):
+        """
+            Get (completed) decommission_device workflows for device.
+        """
+        qs = {
+            'q': 'workflowType IN (%s) AND status IN (%s) AND input.device_id IN (%s)' % \
+                    ('decommission_device', state, device_id)
+        }
+
+        return self.__get_workflows(qs)
+
+
+    def __get_workflows(self, query):
+        """
+            Get workflows according to a search query.
+        """
+        qs = {
+            'q': query,
+        }
+
+        rsp = requests.get(self.addr+self.API_WF_SEARCH, qs)
+        rsp.raise_for_status()
+        return rsp.json()
+

--- a/tests/tests/test_decommission.py
+++ b/tests/tests/test_decommission.py
@@ -30,6 +30,10 @@ class TestDeviceDecommissioning(MenderTesting):
         if common.setup_type() == common.ST_OneClient:
             stop_docker_compose()
 
+    def check_gone_from_inventory(self, device_id):
+        r = inv.get_device(device_id)
+        assert r.status_code == 404, "device [%s] not removed from inventory" % (device_id,)
+
     @MenderTesting.fast
     @pytest.mark.usefixtures("standard_setup_one_client")
     def test_device_decommissioning(self):
@@ -73,6 +77,9 @@ class TestDeviceDecommissioning(MenderTesting):
                 time.sleep(.5)
         else:
             assert False, "decommission_device workflow didn't complete for [%s]" % (device_id,)
+
+        # check device gone from inventory
+        self.check_gone_from_inventory(device_id)
 
         # now check that the device no longer exists in admission
         newAdmissions = adm.get_devices()[0]

--- a/tests/tests/test_decommission.py
+++ b/tests/tests/test_decommission.py
@@ -38,6 +38,13 @@ class TestDeviceDecommissioning(MenderTesting):
         r = deviceauth.get_device(device_id)
         assert r.status_code == 404, "device [%s] not removed from deviceauth" % (device_id,)
 
+    def check_gone_from_deviceadm(self, adm_id, device_id):
+        admissions = adm.get_devices()[0]
+        if device_id != admissions["device_id"] and adm_id != admissions["id"]:
+            logger.info("device [%s] successfully removed from admission: [%s]" % (device_id, str(admissions)))
+        else:
+            assert False, "device [%s] not removed from admission: [%s]" % (device_id, str(admissions))
+
     @MenderTesting.fast
     @pytest.mark.usefixtures("standard_setup_one_client")
     def test_device_decommissioning(self):
@@ -89,11 +96,7 @@ class TestDeviceDecommissioning(MenderTesting):
         self.check_gone_from_deviceauth(device_id)
 
         # now check that the device no longer exists in admission
-        newAdmissions = adm.get_devices()[0]
-        if device_id != newAdmissions["device_id"] and adm_id != newAdmissions["id"]:
-            logger.info("device [%s] successfully removed from admission: [%s]" % (device_id, str(newAdmissions)))
-        else:
-            assert False, "device [%s] not removed from admission: [%s]" % (device_id, str(newAdmissions))
+        self.check_gone_from_deviceadm(adm_id, device_id)
 
         # disabled for time being due to new deployment process
 

--- a/tests/tests/test_decommission.py
+++ b/tests/tests/test_decommission.py
@@ -34,6 +34,10 @@ class TestDeviceDecommissioning(MenderTesting):
         r = inv.get_device(device_id)
         assert r.status_code == 404, "device [%s] not removed from inventory" % (device_id,)
 
+    def check_gone_from_deviceauth(self, device_id):
+        r = deviceauth.get_device(device_id)
+        assert r.status_code == 404, "device [%s] not removed from deviceauth" % (device_id,)
+
     @MenderTesting.fast
     @pytest.mark.usefixtures("standard_setup_one_client")
     def test_device_decommissioning(self):
@@ -80,6 +84,9 @@ class TestDeviceDecommissioning(MenderTesting):
 
         # check device gone from inventory
         self.check_gone_from_inventory(device_id)
+
+        # check device gone from deviceauth
+        self.check_gone_from_deviceauth(device_id)
 
         # now check that the device no longer exists in admission
         newAdmissions = adm.get_devices()[0]

--- a/tests/tests/test_decommission.py
+++ b/tests/tests/test_decommission.py
@@ -97,30 +97,3 @@ class TestDeviceDecommissioning(MenderTesting):
 
         # now check that the device no longer exists in admission
         self.check_gone_from_deviceadm(adm_id, device_id)
-
-        # disabled for time being due to new deployment process
-
-
-        # make sure a deployment to the decommissioned device fails
-        # try:
-        #    time.sleep(120)  # sometimes deployment microservice hasn't removed the device yet
-        #    logger.info("attempting to deploy to decommissioned device: %s" % (device_id))
-        #    deployment_id, _ = common_update_procedure(install_image=conftest.get_valid_image(),
-        #                                               devices=[device_id],
-        #                                               verify_status=False)
-        #except AssertionError:
-        #    logging.info("Failed to deploy upgrade to rejected device, as expected.")
-        #else:
-        #    assert False, "No error while trying to deploy to rejected device"
-
-        # authtoken has been removed
-        #run("strings /data/mender/mender-store | grep -q 'authtoken' || false")
-
-        """
-            at this point, the device will re-appear, since it's actually still
-            online, and not actually decomissioned
-        """
-        #adm.check_expected_status("pending", len(get_mender_clients()))
-
-        # make sure inventory is empty as well
-        # assert len(inv.get_devices()) == 0

--- a/tests/tests/test_decommission.py
+++ b/tests/tests/test_decommission.py
@@ -22,6 +22,7 @@ from helpers import Helpers
 from common_update import common_update_procedure
 from MenderAPI import inv, adm, deviceauth
 from mendertesting import MenderTesting
+from conductor import Conductor
 
 
 class TestDeviceDecommissioning(MenderTesting):
@@ -54,22 +55,31 @@ class TestDeviceDecommissioning(MenderTesting):
         else:
             assert False, "never got inventory"
 
+        # get all completed decommission_device WFs for reference
+        c = Conductor(get_mender_conductor())
+        initial_wfs = c.get_decommission_device_wfs(device_id)
+
         # decommission actual device
         deviceauth.decommission(device_id)
 
-        # now check that the device no longer exists in admissions
+        # check that the workflow completed successfully
         timeout = time.time() + (60 * 5)
         while time.time() < timeout:
-                newAdmissions = adm.get_devices()[0]
-                if device_id != newAdmissions["device_id"] \
-                   and adm_id != newAdmissions["id"]:
-                    logger.info("device [%s] not found in inventory [%s]" % (device_id, str(newAdmissions)))
-                    break
-                else:
-                    logger.info("device [%s] found in inventory..." % (device_id))
+            wfs = c.get_decommission_device_wfs(device_id)
+            if wfs['totalHits'] == initial_wfs['totalHits'] + 1:
+                break
+            else:
+                logger.info("waiting for decommission_device workflow...")
                 time.sleep(.5)
         else:
-            assert False, "decommissioned device still available in admissions"
+            assert False, "decommission_device workflow didn't complete for [%s]" % (device_id,)
+
+        # now check that the device no longer exists in admission
+        newAdmissions = adm.get_devices()[0]
+        if device_id != newAdmissions["device_id"] and adm_id != newAdmissions["id"]:
+            logger.info("device [%s] successfully removed from admission: [%s]" % (device_id, str(newAdmissions)))
+        else:
+            assert False, "device [%s] not removed from admission: [%s]" % (device_id, str(newAdmissions))
 
         # disabled for time being due to new deployment process
 


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-1619

@mendersoftware/rndity @maciejmrowiec 

Includes an extra integration test to verify that the workflow completed successfully.

EDIT: hold on a sec, I'll try to add verifications for `deviceauth` and `inventory` too (for `deployments` it's not feasible)

EDIT2: additional checks are done, ready for review