### PR TITLE
Give 'release_tool.py --version-of' ability to query integration.

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -227,6 +227,14 @@ def get_docker_compose_data_for_rev(git_dir, rev):
     return get_docker_compose_data_from_json_list(yamls)
 
 def version_of(integration_dir, repo_container, in_integration_version=None):
+    if repo_container == "mender-integration":
+        if in_integration_version is not None:
+            # Just return the supplied version string.
+            return in_integration_version
+        else:
+            return execute_git(None, integration_dir, ["describe", "--all", "--always"],
+                               capture=True)
+
     if in_integration_version is not None:
         # Check if there is a range, and if so, return range.
         range_type = ""


### PR DESCRIPTION
In most cases this will just return the supplied value, which may seem
useless, but it often comes up when the repository is part of a list
in a script.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>