### PR TITLE
tests: Add missing setup_type for multitenancy with smtp. 

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -32,6 +32,7 @@ ST_ShortLivedAuthToken = 6
 ST_CustomSetup = 7
 ST_MultiTenancyNoClient = 8
 ST_OneClientsBootstrapped_AWS_S3_MT = 9
+ST_MultiTenancyNoClientWithSmtp = 10
 
 
 def setup_type():

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -226,6 +226,9 @@ def standard_setup_one_client_bootstrapped_with_s3_and_mt(request):
 
 @pytest.fixture(scope="function")
 def multitenancy_setup_without_client_with_smtp(request):
+    if setup_type() == ST_MultiTenancyNoClientWithSmtp:
+        return
+
     stop_docker_compose()
     reset_mender_api()
 
@@ -250,7 +253,7 @@ def multitenancy_setup_without_client_with_smtp(request):
         stop_docker_compose()
 
     request.addfinalizer(fin)
-    set_setup_type(ST_MultiTenancyNoClient)
+    set_setup_type(ST_MultiTenancyNoClientWithSmtp)
 
 
 def get_host_ip():


### PR DESCRIPTION
Without its own setup_type a test may get the wrong kind of setup
before it starts.

Also add the optimization that skips initialization if the environment
is already set up.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>