### PR TITLE
tests: Make it possible to override XDIST_ARGS entirely.

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -117,7 +117,7 @@ else
     fi
 fi
 
-XDIST_ARGS="-n auto"
+XDIST_ARGS="${XDIST_ARGS:--n ${XDIST_PARALLEL_ARG:-auto}}"
 MAX_FAIL_ARG="--maxfail=1"
 HTML_REPORT="--html=report.html --self-contained-html"
 UPGRADE_TEST_ARG=""
@@ -129,11 +129,6 @@ if ! pip2 list |grep -e pytest-xdist >/dev/null 2>&1; then
 else
     # run all tests when running in parallel
     MAX_FAIL_ARG=""
-
-    # allow you to run something else besides -n auto
-    if [[ -n $XDIST_PARALLEL_ARG ]]; then
-        XDIST_ARGS="-n $XDIST_PARALLEL_ARG"
-    fi
 fi
 
 if ! pip2 list|grep -e pytest-html >/dev/null 2>&1; then


### PR DESCRIPTION
Useful to disable the plugin altogether.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>