### PR TITLE
Increase timeout for running commands after reconnecting.

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -83,7 +83,7 @@ def ssh_prep_args_impl(tool):
     return (cmd, host, port)
 
 
-def run_after_connect(cmd, wait = 120):
+def run_after_connect(cmd, wait = 300):
     output = ""
     start_time = time.time()
     # Use shorter timeout to get a faster cycle.

--- a/tests/common_docker.py
+++ b/tests/common_docker.py
@@ -90,10 +90,12 @@ def start_docker_compose(clients=1):
         docker_compose_cmd("scale mender-client=%d" % clients)
 
     if inline_logs:
-        docker_compose_cmd("logs -f &")
+        docker_compose_cmd("logs -f &",
+                           env={'COMPOSE_HTTP_TIMEOUT': '100000'})
     else:
         tfile = tempfile.mktemp("mender_testing")
-        docker_compose_cmd("logs -f --no-color > %s 2>&1 &" % tfile)
+        docker_compose_cmd("logs -f --no-color > %s 2>&1 &" % tfile,
+                           env={'COMPOSE_HTTP_TIMEOUT': '100000'})
         logger.info("docker-compose log file stored here: %s" % tfile)
         log_files.append(tfile)
 

--- a/tests/common_docker.py
+++ b/tests/common_docker.py
@@ -70,15 +70,14 @@ def docker_compose_cmd(arg_list, use_common_files=True, env=None):
 
 
 def stop_docker_compose():
-    # take down all COMPOSE_FILES and the s3 specific files
-    docker_compose_cmd(" -f ../docker-compose.storage.s3.yml -f ../extra/travis-testing/s3.yml -f ../docker-compose.tenant.yml down -v")
-
-    # docker-compose issue: https://github.com/docker/compose/issues/4046
-    # under some unknown circumstances, docker-compose log fails to quit, and hangs pytest
-    for p in psutil.process_iter():
-        if "docker-compose -p %s" % (conftest.docker_compose_instance) in p.cmdline() and "logs" in p.cmdline():
-            logger.info("killing lingering 'docker-compose log' process (pid: %s)" % p.cmdline())
-            p.kill()
+    with conftest.docker_lock:
+        # Take down all docker instances in this namespace.
+        cmd = "docker ps -aq -f name=%s | xargs -r docker rm -fv" % conftest.docker_compose_instance
+        logger.info("running %s" % cmd)
+        subprocess.check_call(cmd, shell=True)
+        cmd = "docker network list -q -f name=%s | xargs -r docker network rm" % conftest.docker_compose_instance
+        logger.info("running %s" % cmd)
+        subprocess.check_call(cmd, shell=True)
 
     common.set_setup_type(None)
 

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -155,17 +155,13 @@ def standard_setup_with_short_lived_token():
 def running_custom_production_setup(request):
     conftest.production_setup_lock.acquire()
 
+    stop_docker_compose()
     reset_mender_api()
-
-    # since we are starting a manual instance of the backend,
-    # let the script know the instance is called "testprod"
-    # so that is cleaned up correctly on test failure/error
 
     def fin():
         conftest.production_setup_lock.release()
         stop_docker_compose()
 
-    conftest.docker_compose_instance = "testprod"
     request.addfinalizer(fin)
 
     set_setup_type(ST_CustomSetup)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,7 @@ def pytest_exception_interact(node, call, report):
             logger.info("printing content of : %s" % log)
             with open(log) as f:
                 for line in f.readlines():
-                    print line,
+                    logger.info("%s: %s" % (log, line))
 
 
 @pytest.mark.hookwrapper


### PR DESCRIPTION
On slow droplets we are seeing this timeout exceeded.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>