### PR TITLE
compose/tenant: add CONDUCTOR env var to conductor-workers

### DIFF
--- a/docker-compose.tenant.yml
+++ b/docker-compose.tenant.yml
@@ -30,3 +30,5 @@ services:
             - mender
         depends_on:
             - mender-conductor
+        environment:
+            CONDUCTOR: "http://mender-conductor:8080"


### PR DESCRIPTION
this prevents them from dying over and over again. conductor repos
will be reorganized soon, so this is just a quick fix.

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

Issues: https://tracker.mender.io/browse/MEN-1648


@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano 