### PR TITLE
tests: never reuse standard_setup_one_client setups

### DIFF
--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -33,9 +33,6 @@ def wait_for_containers(expected_containers, defined_in):
 
 @pytest.fixture(scope="function")
 def standard_setup_one_client(request):
-    if getattr(request, 'param', False) and request.param != "force_new" and setup_type() == ST_OneClient:
-        return
-
     restart_docker_compose()
     reset_mender_api()
 


### PR DESCRIPTION
Changelog: none
Signed-off-by: Gregorio Di Stefano <greg.distefano+github@gmail.com>