### PR TITLE
Release tool pr option 

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -560,20 +560,29 @@ def annotation_version(repo, tag_avail):
     else:
         return "%s version %s Build %s." % (repo.git, match.group(1), match.group(2))
 
+def version_components(version):
+    """Returns a four-tuple containing the version componets major, minor, patch
+    and beta, as ints. Beta does not include the "b"."""
+
+    match = re.match("^([0-9]+)\.([0-9]+)\.([0-9]+)(?:b([0-9]+))?", version)
+    if match is None:
+        raise Exception("Invalid version '%s' passed to version_components." % version)
+
+    if match.group(4) is None:
+        return (int(match.group(1)), int(match.group(2)), int(match.group(3)), None)
+    else:
+        return (int(match.group(1)), int(match.group(2)), int(match.group(3)), int(match.group(4)))
+
 def find_prev_version(tag_list, version):
     """Finds the highest version in tag_list which is less than version.
     tag_list is expected to be sorted with highest version first."""
 
     match = re.match(r"^([0-9]+)\.([0-9]+)\.([0-9]+)", version)
-    version_major = int(match.group(1))
-    version_minor = int(match.group(2))
-    version_patch = int(match.group(3))
+    (version_major, version_minor, version_patch, version_beta) = version_components(version)
 
     for tag in tag_list:
         match = re.match(r"^([0-9]+)\.([0-9]+)\.([0-9]+)", tag)
-        tag_major = int(match.group(1))
-        tag_minor = int(match.group(2))
-        tag_patch = int(match.group(3))
+        (tag_major, tag_minor, tag_patch, tag_beta) = version_components(tag)
 
         if tag_major < version_major:
             return tag
@@ -583,9 +592,29 @@ def find_prev_version(tag_list, version):
             elif tag_minor == version_minor:
                 if tag_patch < version_patch:
                     return tag
+                elif tag_patch == version_patch:
+                    if tag_beta is not None and version_beta is None:
+                        return tag
+                    elif tag_beta is not None and version_beta is not None and tag_beta < version_beta:
+                        return tag
 
     # No lower version found.
     return None
+
+def next_patch_version(prev_version, next_beta=None):
+    """Returns the next patch version is a series, based on the given version.
+    If next_beta is not None, then the version will be a new beta, instead of a
+    new patch release."""
+
+    (major, minor, patch, beta) = version_components(prev_version)
+    if next_beta:
+        new_version = "%d.%d.%db%d" % (major, minor, patch, next_beta)
+    elif beta is not None:
+        new_version = "%d.%d.%d" % (major, minor, patch)
+    else:
+        new_version = "%d.%d.%d" % (major, minor, patch + 1)
+    assert prev_version != new_version, "Previous and new version should not be the same!"
+    return new_version
 
 def generate_new_tags(state, tag_avail, final):
     """Creates new build tags, and returns the new tags in a modified tag_avail. If
@@ -873,10 +902,14 @@ def switch_following_branch(state, tag_avail):
                 local = current[(current.index('/') + 1):]
                 update_state(state, [repo.git, 'following'], local)
 
-def assign_default_following_branch(state, repo):
+def find_default_following_branch(state, repo, version):
     remote = find_upstream_remote(state, repo.git)
-    branch = re.sub(r"\.[^.]+$", ".x", state[repo.git]['version'])
-    update_state(state, [repo.git, 'following'], "%s/%s" % (remote, branch))
+    branch = re.sub(r"\.[^.]+$", ".x", version)
+    return "%s/%s" % (remote, branch)
+
+def assign_default_following_branch(state, repo):
+    update_state(state, [repo.git, 'following'],
+                 find_default_following_branch(state, repo, state[repo.git]['version']))
 
 def merge_release_tag(state, tag_avail, repo):
     """Merge tag into version branch, but only for Git history's sake, the 'ours'
@@ -1078,6 +1111,63 @@ def do_build(args):
 
     trigger_jenkins_build(state, check_tag_availability(state))
 
+def determine_version_to_include_in_release(state, repo):
+    version = state_value(state, [repo.git, 'version'])
+
+    if version is not None:
+        return version
+
+    # Is there already a version in the same series? Look at integration.
+    tag_list = sorted_final_version_list(integration_dir())
+    prev_of_integration = find_prev_version(tag_list, state['version'])
+    (overall_major, overall_minor, overall_patch, overall_beta) = version_components(state['version'])
+    (prev_major, prev_minor, prev_patch, prev_beta) = version_components(prev_of_integration)
+
+    prev_of_repo = None
+    new_repo_version = None
+    follow_branch = None
+    if overall_major == prev_major and overall_minor == prev_minor:
+        # Same series. Us it as basis.
+        prev_of_repo = version_of(integration_dir(), repo.container, in_integration_version=prev_of_integration)
+        new_repo_version = next_patch_version(prev_of_repo, next_beta=overall_beta)
+        follow_branch = find_default_following_branch(state, repo, new_repo_version)
+    else:
+        # No series exists. Base on master.
+        prev_of_repo = sorted_final_version_list(os.path.join(state['repo_dir'], repo.git))[0]
+        (major, minor, patch, beta) = version_components(prev_of_repo)
+        new_repo_version = "%d.%d.0" % (major, minor + 1)
+        if overall_beta:
+            new_repo_version += "b%d" % overall_beta
+        follow_branch = "%s/master" % find_upstream_remote(state, repo.git)
+
+    cmd = ["log", "%s..%s" % (prev_of_repo, follow_branch)]
+
+    print("cd %s && git %s:" % (repo.git, " ".join(cmd)))
+    execute_git(state, repo.git, cmd)
+
+    print()
+    print("Above is the output of 'cd %s && git %s'" % (repo.git, " ".join(cmd)))
+    reply = ask("Based on this, is there a reason for a new release of %s? "
+                % repo.git)
+
+    if reply.lower().startswith("y"):
+        reply = ask("Should the new release of %s be version %s? "
+                    % (repo.git, new_repo_version))
+        if reply.lower().startswith("y"):
+            update_state(state, [repo.git, 'version'], new_repo_version)
+    else:
+        reply = ask("Should the release of %s be left at the previous version %s? "
+                    % (repo.git, prev_of_repo))
+        if reply.lower().startswith("y"):
+            update_state(state, [repo.git, 'version'], prev_of_repo)
+
+    if state_value(state, [repo.git, 'version']) is None:
+        reply = ask("Ok. Please input the new version of %s manually: " % repo.git)
+        update_state(state, [repo.git, 'version'], reply)
+
+    print()
+    print("--------------------------------------------------------------------------------")
+
 def do_release():
     """Handles the interactive menu for doing a release."""
 
@@ -1122,14 +1212,12 @@ def do_release():
 
     update_state(state, ["integration", 'version'], state['version'])
 
-    for repo in sorted(REPOS.values(), key=repo_sort_key):
-        if state_value(state, [repo.git, 'version']) is None:
-            update_state(state, [repo.git, 'version'],
-                         ask("What version of %s should be included? " % repo.git))
-
     input = ask("Do you want to fetch all the latest tags and branches in all repositories (will not change checked-out branch)? ")
     if input.startswith("Y") or input.startswith("y"):
         refresh_repos(state)
+
+    for repo in sorted(REPOS.values(), key=repo_sort_key):
+        determine_version_to_include_in_release(state, repo)
 
     # Fill data about available tags.
     tag_avail = check_tag_availability(state)

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -806,6 +806,27 @@ def trigger_jenkins_build(state, tag_avail):
             # that they can be repeated in subsequent builds.
             update_state(state, ['extra_buildparams', name], params[name])
 
+    pr_count = 0
+    pr_repo = None
+    for repo in GIT_TO_BUILDPARAM_MAP:
+        match = re.match("^pull/([0-9]+)/head$", params.get(GIT_TO_BUILDPARAM_MAP[repo]))
+        if match:
+            pr_count += 1
+            pr_repo = repo
+            pr_number = match.group(1)
+    # If there is exactly one pull request, then offer to trigger a job with
+    # Github status updates.
+    if pr_count == 1:
+        print("You are triggering a job for one pull request.")
+        reply = ask("Do you want to enable Github status updates for it? ")
+        if reply.lower().startswith("y"):
+            params['REPO_TO_TEST'] = pr_repo
+            params['PR_TO_TEST'] = pr_number
+            remote = find_upstream_remote(state, pr_repo)
+            execute_git(state, pr_repo, ["fetch", remote, "pull/%s/head" % pr_number])
+            rev = execute_git(state, pr_repo, ["rev-parse", "FETCH_HEAD"], capture=True)
+            params['GIT_COMMIT'] = rev
+
     # Order is important here, because Jenkins passes in the same parameters
     # multiple times, as pairs that complete each other.
     # Jenkins additionally needs the input as json as well, so create that from
@@ -1109,7 +1130,17 @@ def do_build(args):
               % (repo_dir, RELEASE_TOOL_STATE))
         update_state(state, ["repo_dir"], repo_dir)
 
-    trigger_jenkins_build(state, check_tag_availability(state))
+    tag_avail = check_tag_availability(state)
+
+    if args.pr is not None:
+        match = re.match("^([^/]+)/([0-9]+)$", args.pr)
+        if match is None:
+            raise Exception("%s is not a valid repo/pr pair!" % args.pr)
+        repo = match.group(1)
+        assert repo in GIT_TO_BUILDPARAM_MAP.keys(), "%s needs to be in GIT_TO_BUILDPARAM_MAP"
+        tag_avail[repo]['build_tag'] = "pull/%s/head" % match.group(2)
+
+    trigger_jenkins_build(state, tag_avail)
 
 def determine_version_to_include_in_release(state, repo):
     version = state_value(state, [repo.git, 'version'])
@@ -1478,6 +1509,9 @@ def main():
     parser.add_argument("-b", "--build", dest="build", metavar="VERSION",
                         const=True, nargs="?",
                         help="Build the given version of Mender")
+    parser.add_argument("--pr", dest="pr", metavar="REPO/PR-NUMBER",
+                        help="Can only be used with -b. Specifies one repository and pull request number "
+                        + "that should be triggered with the rest of the repository versions.")
     parser.add_argument("--release", action="store_true",
                         help="Start the release process (interactive)")
     parser.add_argument("-s", "--simulate-push", action="store_true",


### PR DESCRIPTION
```
commit a00184ce3ea5af9f879a5a4b512254d00a7f70d6
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Feb 1 13:29:28 2018

    release_tool: Add --pr option and Github status update support.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 98c5930a87a97e0655378df1cca4de42abb899f7
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Feb 1 09:30:57 2018

    MEN-1405: release_tool: Auto-provide next version needed for a release.
    
    It can't be fully automatic, but offers the user a log, and he can
    decide whether a new release of the service is necessary.
    
    Changelog: none
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```