### PR TITLE
Move mender-artifacts declaration to minio yml file.

### DIFF
--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -22,3 +22,9 @@ services:
             - minio
         volumes:
             - ./storage-proxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
+volumes:
+    # mender artifacts storage
+    mender-artifacts:
+      external:
+          # use external volume created manually
+          name: mender-artifacts

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -157,11 +157,6 @@ services:
         entrypoint: /redis/entrypoint.sh
 
 volumes:
-    # mender artifacts storage
-    mender-artifacts:
-      external:
-          # use external volume created manually
-          name: mender-artifacts
     # deployments service database
     mender-deployments-db:
       external:


### PR DESCRIPTION
This way if the start script is modified to use the S3 yml file the local
volume is no longer needed

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>