### PR TITLE
tests/integration: update create organization test

### DIFF
--- a/tests/tests/test_create_organization.py
+++ b/tests/tests/test_create_organization.py
@@ -60,13 +60,13 @@ class TestCreateOrganization(MenderTesting):
         logging.info("TestCreateOrganization: Assert ok.")
 
     @pytest.mark.usefixtures("multitenancy_setup_without_client_with_smtp")
-    def test_duplicate_tenant(self):
+    def test_duplicate_organization_name(self):
         payload = {"request_id": "123456", "organization": "tenant-foo", "email":"some.user@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
         rsp = requests.post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
         assert rsp.status_code == 202
         payload = {"request_id": "123457", "organization": "tenant-foo", "email":"some.user2@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
         rsp = requests.post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
-        assert rsp.status_code == 409
+        assert rsp.status_code == 202
 
     @pytest.mark.usefixtures("multitenancy_setup_without_client_with_smtp")
     def test_duplicate_email(self):


### PR DESCRIPTION
Test was checking if it is not possible to create two organizations with
the same organization name.
Right now it is possible to do that, so we should check that this
operation will succeeded.