### PR TITLE
test_security.py: Ignore return code of grep. 

### DIFF
--- a/tests/tests/test_security.py
+++ b/tests/tests/test_security.py
@@ -44,7 +44,7 @@ class TestSecurity(MenderTesting):
         # get all exposed ports from docker
 
         for _ in range(3):
-            exposed_hosts = subprocess.check_output("docker ps | grep %s | grep -o -E '0.0.0.0:[0-9]*'" % ("testprod"), shell=True)
+            exposed_hosts = subprocess.check_output("docker ps | grep %s | grep -o -E '0.0.0.0:[0-9]*' | cat" % ("testprod"), shell=True)
 
             try:
                 for host in exposed_hosts.split():


### PR DESCRIPTION
In the case that grep returns nothing, it also sets a return code
which will fail the test.  Ignore that by piping through cat and
just process the empty return string.

Changelog: Title
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>