### PR TITLE
demo: suppress warning on newer docker-compose versions

### DIFF
--- a/demo
+++ b/demo
@@ -45,12 +45,20 @@ done
 docker images | grep -q 'mendersoftware/deployments'
 
 if [[ "$?" -eq 1 ]]; then
+    compose_args=""
     docker_compose_output=$(docker-compose pull -h)
-    echo "$docker_compose_output" | grep -q -- '--parallel'
 
-    if [[ "$?" -eq 0 ]]; then
-        docker-compose pull --parallel
+    # If --no-parallel option exists, it means that docker-compose is
+    # running a version where --parallel is default and will warn about
+    # deprecated option if used.
+    #
+    # This behavior was changed in version docker-compose 1.21.0
+    echo "$docker_compose_output" | grep -q -- '--no-parallel'
+    if [[ "$?" -eq 1 ]]; then
+        compose_args = "--parallel"
     fi
+
+    docker-compose pull ${compose_args}
 fi
 
 if [[ "$1" == "up" ]]; then


### PR DESCRIPTION
docker-compose version 1.21.0 and greater has deprecated
the --parallel option printing the following if used:

    WARNING: --parallel option is deprecated and will be
    removed in future versions.

This is because "--parallel" is the default mode as of
version 1.21.0.

Suppress warning by only using the --parallel option
if --no-parallel option does not exist because this
was added together with deprecation of --parallel.

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>