### PR TITLE
release-tool: include email-sender in REPOS

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -81,6 +81,7 @@ REPOS = {
     "gui": RepoName("mender-gui", "gui", "gui", True),
     "inventory": RepoName("mender-inventory", "inventory", "inventory", True),
     "useradm": RepoName("mender-useradm", "useradm", "useradm", True),
+    "email-sender": RepoName("mender-email-sender", "email-sender", "mender-conductor/email-sender", True),
 
     # These ones doesn't have a Docker name, but just use same as Git for
     # indexing purposes.


### PR DESCRIPTION
needed in https://tracker.mender.io/browse/QA-27.

email-sender has its own image, an we'd like to be able to --set-version via the release tool when running backend integration tests.