### PR TITLE
release_tool: Move email-sender into optional repositories.

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -81,7 +81,6 @@ REPOS = {
     "gui": RepoName("mender-gui", "gui", "gui", True),
     "inventory": RepoName("mender-inventory", "inventory", "inventory", True),
     "useradm": RepoName("mender-useradm", "useradm", "useradm", True),
-    "email-sender": RepoName("mender-email-sender", "email-sender", "mender-conductor/email-sender", True),
 
     # These ones doesn't have a Docker name, but just use same as Git for
     # indexing purposes.
@@ -93,6 +92,7 @@ REPOS = {
 # These are optional repositories that aren't included when iterating over
 # repositories, but that are available for querying.
 OPTIONAL_REPOS = {
+    "email-sender": RepoName("mender-email-sender", "email-sender", "mender-conductor/email-sender", True),
     "mender-tenantadm": RepoName("mender-tenantadm", "tenantadm", "tenantadm", True),
 }
 


### PR DESCRIPTION
It doesn't have a Git repo, so when release_tool is called with
--verify-integration-references, it tries to verify its commit SHA,
but fails. In optional repos we can still query the component, but we
avoid the Git checking issue.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>