### PR TITLE
 Increase bandwith limit to 3 MB/s per device for demo setup. 

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -44,8 +44,8 @@ services:
             # Examples:
             #   1m - 1MB/s
             #   512k - 512kB/s
-            DOWNLOAD_SPEED: 1m
-            MAX_CONNECTIONS: 100
+            DOWNLOAD_SPEED: 3m
+            MAX_CONNECTIONS: 30
         volumes:
             - ./certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt
             - ./certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key


### PR DESCRIPTION
Rare to see demo setup with more than 30 devices.

Changelog: Increase bandwidth limit to 3 MB/s per device for demo setup.

Signed-off-by: Eystein Måløy Stenberg <eystein@mender.io>