### PR TITLE
tests/test_preauth: use real public key

### DIFF
--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -92,7 +92,16 @@ class TestPreauthBase(MenderTesting):
         """
         # preauthorize
         preauth_iddata = "{\"mac\":\"preauth-mac\"}"
-        preauth_key = "preauth-key"
+        preauth_key = '''-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzogVU7RGDilbsoUt/DdH
+VJvcepl0A5+xzGQ50cq1VE/Dyyy8Zp0jzRXCnnu9nu395mAFSZGotZVr+sWEpO3c
+yC3VmXdBZmXmQdZqbdD/GuixJOYfqta2ytbIUPRXFN7/I7sgzxnXWBYXYmObYvdP
+okP0mQanY+WKxp7Q16pt1RoqoAd0kmV39g13rFl35muSHbSBoAW3GBF3gO+mF5Ty
+1ddp/XcgLOsmvNNjY+2HOD5F/RX0fs07mWnbD7x+xz7KEKjF+H7ZpkqCwmwCXaf0
+iyYyh1852rti3Afw4mDxuVSD7sd9ggvYMc0QHIpQNkD4YWOhNiE1AB0zH57VbUYG
+UwIDAQAB
+-----END PUBLIC KEY-----
+'''
 
         r = adm.preauth(preauth_iddata, preauth_key)
         assert r.status_code == 201


### PR DESCRIPTION
neither deviceadm nor deviceauth will accept an invalid
key from here on.

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>