### PR TITLE
tests/test_preauth: use real keys

### DIFF
--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -138,7 +138,17 @@ UwIDAQAB
         dev = devs[0]
 
         # try to preauthorize the same id data, new key
-        r = adm.preauth(dev['device_identity'], 'preauth-key')
+        preauth_key = '''-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzogVU7RGDilbsoUt/DdH
+VJvcepl0A5+xzGQ50cq1VE/Dyyy8Zp0jzRXCnnu9nu395mAFSZGotZVr+sWEpO3c
+yC3VmXdBZmXmQdZqbdD/GuixJOYfqta2ytbIUPRXFN7/I7sgzxnXWBYXYmObYvdP
+okP0mQanY+WKxp7Q16pt1RoqoAd0kmV39g13rFl35muSHbSBoAW3GBF3gO+mF5Ty
+1ddp/XcgLOsmvNNjY+2HOD5F/RX0fs07mWnbD7x+xz7KEKjF+H7ZpkqCwmwCXaf0
+iyYyh1852rti3Afw4mDxuVSD7sd9ggvYMc0QHIpQNkD4YWOhNiE1AB0zH57VbUYG
+UwIDAQAB
+-----END PUBLIC KEY-----
+'''
+        r = adm.preauth(dev['device_identity'], preauth_key)
         assert r.status_code == 409
 
 


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-1900

needed by https://github.com/mendersoftware/deviceadm/pull/136