### PR TITLE
backend-tests: fix key comparison

### DIFF
--- a/backend-tests/tests/test_account_suspension.py
+++ b/backend-tests/tests/test_account_suspension.py
@@ -23,6 +23,7 @@ import api.deviceadm as deviceadm
 import api.tenantadm as tenantadm
 import api.deployments as deployments
 from infra.cli import CliTenantadm, CliUseradm
+from util.crypto import compare_keys
 
 class Tenant:
     def __init__(self, name):
@@ -120,7 +121,7 @@ def tenants_users_devices(tenants_users, mongo):
             assert r.status_code == 200
 
             api_devs = r.json()
-            api_dev = [x for x in api_devs if x['key'] == d.pubkey][0]
+            api_dev = [x for x in api_devs if compare_keys(x['key'], d.pubkey)][0]
             d.authset_id = api_dev['id']
 
             t.devices.append(d)

--- a/backend-tests/tests/util/crypto.py
+++ b/backend-tests/tests/util/crypto.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+# Copyright 2018 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+from Crypto.PublicKey import RSA
+
+def compare_keys(a,b):
+    ai = RSA.importKey(a)
+    bi = RSA.importKey(b)
+
+    return ai.exportKey().decode() == bi.exportKey().decode()


### PR DESCRIPTION
deviceauth will do key and iddata normalization, so raw string comparisons won't work.

fix this by comparing key contents via serializing and deserializing again.