### PR TITLE
Added integration tests for failover servers mechanism

### DIFF
--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -37,8 +37,8 @@ services:
             # Examples:
             #   1m - 1MB/s
             #   512k - 512kB/s
-            #DOWNLOAD_SPEED: 1m
-            MAX_CONNECTIONS: 100
+            #DOWNLOAD_SPEED: 3m
+            MAX_CONNECTIONS: 30
         volumes:
             - ./certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt
             - ./certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key

--- a/extra/failover-testing/build_api-gateway/Dockerfile
+++ b/extra/failover-testing/build_api-gateway/Dockerfile
@@ -1,0 +1,5 @@
+FROM mendersoftware/api-gateway:master
+RUN sed -i -e 's/mender-\(useradm\|inventory\|deployments\|device-auth\|device-adm\|gui\)/mender-\1-2/g' \
+               /usr/local/openresty/nginx/conf/nginx.conf
+RUN sed -i -e 's/docker\.mender\.io/docker\.mender-failover\.io/g' \
+               /usr/local/openresty/nginx/conf/nginx.conf

--- a/extra/failover-testing/docker-compose.failover-server.yml
+++ b/extra/failover-testing/docker-compose.failover-server.yml
@@ -1,0 +1,221 @@
+version: '2'
+services:
+
+    #
+    # mender-deployments
+    #
+    mender-deployments-2:
+        image: mendersoftware/deployments:master
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+        depends_on:
+            - mender-mongo-2
+        command: server --automigrate
+        volumes:
+            - ./certs/storage-proxy/cert.crt:/etc/ssl/certs/s3.docker.mender.io.crt
+        environment:
+            STORAGE_BACKEND_CERT: /etc/ssl/certs/s3.docker.mender.io.crt
+            DEPLOYMENTS_AWS_AUTH_KEY: minio
+            DEPLOYMENTS_AWS_AUTH_SECRET: minio123
+            DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io:9000
+
+    #
+    # mender-gui
+    #
+    mender-gui-2:
+        image: mendersoftware/gui:master
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+        environment:
+            - INTEGRATION_VERSION
+        environment:
+            # enable demo mode for UI
+            DEMO: "true"
+
+    #
+    # mender-api-gateway
+    #
+    mender-api-gateway-2:
+        # TODO: maybe there's a clenaer way of doing this?
+        build:
+            # paths are relative to parent docker-compose.yml file
+            context: extra/failover-testing/
+            dockerfile: ./build_api-gateway/Dockerfile
+        image: custom-mender-api-gateway
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+        # critical - otherwise nginx may not detect
+        # these servers and exits with 'upstream server not found'
+        depends_on:
+            - mender-device-auth-2
+            - mender-device-adm-2
+            - mender-deployments-2
+            - mender-gui-2
+            - mender-useradm-2
+            - mender-inventory-2
+        networks:
+            mender-failover:
+                aliases:
+                    - docker.mender-failover.io
+        volumes:
+            - ./certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.crt
+            - ./certs/api-gateway/private.key:/var/www/mendersoftware/cert/private.key
+        environment:
+            ALLOWED_HOSTS: ~.
+
+    #
+    # mender-device-auth
+    #
+    mender-device-auth-2:
+        image: mendersoftware/deviceauth:master
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+        depends_on:
+            - mender-mongo-2
+        command: server --automigrate
+        volumes:
+            - ./keys/deviceauth/private.key:/etc/deviceauth/rsa/private.pem
+
+    #
+    # mender-device-adm
+    #
+    mender-device-adm-2:
+        image: mendersoftware/deviceadm:master
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+        depends_on:
+            - mender-mongo-2
+        command: server --automigrate
+
+    #
+    # mender-inventory
+    #
+    mender-inventory-2:
+        image: mendersoftware/inventory:master
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+        depends_on:
+            - mender-mongo-2
+        command: server --automigrate
+
+    #
+    # mender-useradm
+    #
+    mender-useradm-2:
+        image: mendersoftware/useradm:master
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+        depends_on:
+            - mender-mongo-2
+        command: server --automigrate
+        volumes:
+            - ./keys/useradm/private.key:/etc/useradm/rsa/private.pem
+
+    mender-mongo-2:
+        image: mongo:3.4
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            mender-failover:
+                aliases:
+                    - mongo-deployments
+                    - mongo-device-adm
+                    - mongo-device-auth
+                    - mongo-inventory
+                    - mongo-useradm
+
+    mender-conductor-2:
+        image: mendersoftware/mender-conductor:master
+        depends_on:
+            - mender-elasticsearch-2
+            - mender-redis-2
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+        volumes:
+            - ./conductor/server/config:/app/config
+        environment:
+            - CONFIG_PROP=config.properties
+
+    mender-elasticsearch-2:
+        image: mendersoftware/elasticsearch:2.4
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+
+    mender-redis-2:
+        image: redis:3.2.11-alpine
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender-failover
+        volumes:
+            - ./conductor/redis/redis.conf:/etc/redis/redis.conf
+            - ./conductor/redis/entrypoint.sh:/redis/entrypoint.sh
+            - /var/lib/redis
+        entrypoint: /redis/entrypoint.sh
+
+    
+
+    # Add client to failover network as well
+    mender-client:
+        networks:
+            - mender-failover
+
+    # Start a new minio and storage backend service on failover network
+    minio-2:
+        image: mendersoftware/minio:RELEASE.2016-12-13T17-19-42Z
+        networks:
+            mender-failover:
+                aliases:
+                    - minio.s3.docker.mender.io
+        command: server /export
+        environment:
+            MINIO_ACCESS_KEY: minio
+            MINIO_SECRET_KEY: minio123
+
+    storage-proxy-2:
+        image: mendersoftware/openresty:1.11.2.2-alpine
+
+        networks:
+            mender-failover:
+                aliases:
+                    - s3.docker.mender.io
+        depends_on:
+            - minio-2
+        volumes:
+            - ./extra/failover-testing/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
+            - ./certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt
+            - ./certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key
+        environment:
+            MAX_CONNECTIONS: 100
+
+networks:
+    mender-failover:

--- a/extra/failover-testing/nginx.conf
+++ b/extra/failover-testing/nginx.conf
@@ -1,0 +1,112 @@
+worker_processes  auto;
+
+error_log  /dev/stdout warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+env DOWNLOAD_SPEED;
+env MAX_CONNECTIONS;
+
+http {
+
+    init_by_lua_block {
+        ngx.log(ngx.WARN, "download speed limit: " .. (os.getenv("DOWNLOAD_SPEED") or "not set"))
+        ngx.log(ngx.WARN, "max connections: " .. (os.getenv("MAX_CONNECTIONS") or "not set"))
+    }
+
+    upstream minio_backend {
+        server minio-2:9000 max_fails=0;
+    }
+
+    lua_shared_dict my_limit_conn_store 100m;
+
+    server {
+
+        proxy_max_temp_file_size 0;
+
+        listen 9000 ssl;
+
+        ssl_certificate /var/www/storage-proxy/cert/cert.crt;
+        ssl_certificate_key /var/www/storage-proxy/cert/private.key;
+
+        ssl_protocols TLSv1.1 TLSv1.2;
+        ssl_ciphers HIGH:!aNULL:!MD5:!SHA;
+        ssl_prefer_server_ciphers on;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_tickets off;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+
+        add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+        add_header X-Frame-Options DENY;
+        add_header X-Content-Type-Options nosniff;
+
+        location / {
+            access_by_lua_block {
+                -- rate and connection limiting is applied only to GET requests
+                if ngx.req.get_method() == "GET" then
+
+                   local max_connections = tonumber(os.getenv("MAX_CONNECTIONS"))
+                   if max_connections ~= nil then
+                      local limit_conn = require "resty.limit.conn"
+
+                      local lim, err = limit_conn.new("my_limit_conn_store", max_connections, 0, 1)
+                      if not lim then
+                         ngx.log(ngx.ERR,
+                                 "failed to instantiate a resty.limit.conn object: ", err)
+                         return ngx.exit(500)
+                      end
+
+                      local key = ngx.var.binary_remote_addr
+                      local delay, err = lim:incoming(key, true)
+                      if not delay and err ~= "rejected" then
+                         ngx.log(ngx.ERR, "failed to limit req: ", err)
+                         return ngx.exit(500)
+                      elseif not delay or delay > 0 then
+                         ngx.log(ngx.WARN, "connection rejected")
+                         return ngx.exit(503)
+                      end
+
+                      if lim:is_committed() then
+                         local ctx = ngx.ctx
+                         ctx.limit_conn = lim
+                         ctx.limit_conn_key = key
+                         ctx.limit_conn_delay = delay
+                      end
+                   end
+
+                   local download_speed = os.getenv("DOWNLOAD_SPEED")
+                   if download_speed ~= nil then
+                      ngx.var.limit_rate = download_speed
+                   end
+                end
+            }
+
+            log_by_lua_block {
+                local ctx = ngx.ctx
+                local lim = ctx.limit_conn
+                if lim then
+                    local latency = tonumber(ngx.var.request_time)
+                    local key = ctx.limit_conn_key
+                    assert(key)
+                    local conn, err = lim:leaving(key, latency)
+                    if not conn then
+                        ngx.log(ngx.ERR,
+                                "failed to record the connection leaving ",
+                                "request: ", err)
+                        return
+                    end
+                end
+            }
+            client_max_body_size 0;
+            proxy_request_buffering off;
+            proxy_http_version 1.1;
+
+            proxy_set_header Host $http_host;
+            proxy_pass http://minio_backend;
+        }
+    }
+}

--- a/tests/common.py
+++ b/tests/common.py
@@ -34,6 +34,7 @@ ST_CustomSetup = 7
 ST_MultiTenancyNoClient = 8
 ST_OneClientsBootstrapped_AWS_S3_MT = 9
 ST_MultiTenancyNoClientWithSmtp = 10
+ST_Failover = 11
 
 HAVE_TOKEN_TIMEOUT = 60 * 5
 MENDER_STORE = '/data/mender/mender-store'

--- a/tests/common_docker.py
+++ b/tests/common_docker.py
@@ -103,7 +103,7 @@ def stop_docker_compose():
 
 def start_docker_compose(clients=1):
     docker_compose_cmd("up -d")
-    
+
     if clients > 1:
         docker_compose_cmd("scale mender-client=%d" % clients)
 
@@ -130,7 +130,8 @@ def docker_get_ip_of(service):
 
     output = subprocess.check_output(cmd + \
                                      "| xargs -r " \
-                                     "docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'",
+                                     "docker inspect --format='{{.NetworkSettings.Networks.%s_mender.IPAddress}}'" % \
+                                     conftest.docker_compose_instance,
                                      shell=True)
 
     # Return as list.
@@ -160,8 +161,8 @@ def get_mender_client_by_container_name(image_name):
     output = subprocess.check_output(cmd, shell=True)
     return output.strip() + ":8822"
 
-def get_mender_gateway():
-    gateway = docker_get_ip_of("mender-api-gateway")
+def get_mender_gateway(service="mender-api-gateway"):
+    gateway = docker_get_ip_of(service)
 
     if len(gateway) != 1:
         raise SystemExit("expected one instance of api-gateway running, but found: %d instance(s)" % len(gateway))

--- a/tests/tests/common_update.py
+++ b/tests/tests/common_update.py
@@ -32,6 +32,7 @@ def common_update_procedure(install_image,
                             signed=False,
                             devices=None,
                             scripts=[],
+                            pre_upload_callback=lambda: None,
                             pre_deployment_callback=lambda: None,
                             deployment_triggered_callback=lambda: None):
 
@@ -49,6 +50,7 @@ def common_update_procedure(install_image,
             created_artifact = image.make_artifact(install_image, device_type, artifact_id, artifact_file, signed=signed, scripts=scripts)
 
             if created_artifact:
+                pre_upload_callback()
                 deploy.upload_image(created_artifact)
                 if devices is None:
                     devices = list(set([device["device_id"] for device in adm.get_devices_status("accepted")]))
@@ -72,6 +74,7 @@ def update_image_successful(install_image,
                             signed=False,
                             skip_reboot_verification=False,
                             expected_mender_clients=1,
+                            pre_upload_callback=lambda: None,
                             pre_deployment_callback=lambda: None,
                             deployment_triggered_callback=lambda: None):
     """


### PR DESCRIPTION
Added failover servers integration tests, which utilizes two different servers
and a single client. For this test case to work, a new docker-compose file with
duplication of all server microservices with minor modifications had to be made.

changelog: title

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>