### PR TITLE
tests: log in after create org test

### DIFF
--- a/tests/tests/test_create_organization.py
+++ b/tests/tests/test_create_organization.py
@@ -59,6 +59,11 @@ class TestCreateOrganization(MenderTesting):
         smtp_mock.assert_called()
         logging.info("TestCreateOrganization: Assert ok.")
 
+        r = requests.post("https://%s/api/management/%s/useradm/auth/login" % (get_mender_gateway(), api_version),
+                verify=False,
+                auth=HTTPBasicAuth("some.user@example.com", "asdfqwer1234"))
+        assert r.status_code == 200
+
     @pytest.mark.usefixtures("multitenancy_setup_without_client_with_smtp")
     def test_duplicate_organization_name(self):
         payload = {"request_id": "123456", "organization": "tenant-foo", "email":"some.user@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
@@ -74,7 +79,7 @@ class TestCreateOrganization(MenderTesting):
         rsp = requests.post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
         logging.debug("first request to tenant adm returned: ", rsp.text)
         assert rsp.status_code == 202
-        
+
         payload = {"request_id": "123457", "organization": "tenant-foo2", "email":"some.user@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
         rsp = requests.post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
         logging.debug("second request to tenant adm returned: ", rsp.text)


### PR DESCRIPTION
stronger test for create org, in support of user password hashing.

https://tracker.mender.io/browse/MEN-2015

full integration build for this feature: https://mender-jenkins.mender.io/job/mender-builder/label=googlecloud%20&&%20mender_servers/1400/