### PR TITLE
QA-37: Fix inability to query repos that have been removed.

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -66,20 +66,20 @@ class RepoName:
         self.git = git
         self.has_container = has_container
 
-# All our repos, and also a map from docker-compose image name to all
+# All our repos, including repos that were part of our release before, and
+# aren't anymore. It's also a map from docker-compose image name to all
 # names. The key is container name, and thereafter the order is the order of the
 # RepoName constructor, just above.
 #
-# This is the main list of repos that will be used throughout the script. If you
-# add anything here, make sure to also update REPO_ALIASES (if there are
-# alternate names) and GIT_TO_BUILDPARAM_MAP (which tells the tool how to
-# trigger Jenkins jobs.
-REPOS = {
+# If you add anything here, make sure to also update GIT_TO_BUILDPARAM_MAP
+# (which tells the tool how to trigger Jenkins jobs.
+REPO_MAP = {
     "api-gateway": RepoName("mender-api-gateway", "api-gateway", "mender-api-gateway-docker", True),
     "mender-client-qemu": RepoName("mender-client", "mender-client-qemu", "mender", True),
     "mender-conductor": RepoName("mender-conductor", "mender-conductor", "mender-conductor", True),
     "mender-conductor-enterprise": RepoName("mender-conductor", "mender-conductor-enterprise", "mender-conductor-enterprise", True),
     "deployments": RepoName("mender-deployments", "deployments", "deployments", True),
+    "deviceadm": RepoName("mender-device-adm", "deviceadm", "deviceadm", True),
     "deviceauth": RepoName("mender-device-auth", "deviceauth", "deviceauth", True),
     "gui": RepoName("mender-gui", "gui", "gui", True),
     "inventory": RepoName("mender-inventory", "inventory", "inventory", True),
@@ -91,6 +91,11 @@ REPOS = {
     "mender-cli": RepoName("mender-cli", "mender-cli", "mender-cli", False),
     "integration": RepoName("integration", "integration", "integration", False),
 }
+
+# This is the main list of repos that will be used throughout the script. This
+# will be filled by entries from REPO_MAP, depending on which ones are actually
+# available in the version we're querying.
+REPOS = None
 
 # These are optional repositories that aren't included when iterating over
 # repositories, but that are available for querying.
@@ -263,6 +268,22 @@ def get_docker_compose_data_for_rev(git_dir, rev):
         yamls.append(output)
 
     return get_docker_compose_data_from_json_list(yamls)
+
+def update_repo_list(in_version=None):
+    """Updates the REPOS map by starting with REPO_MAP, checking which repositories
+    are actually used in the given version, and then adding those to REPOS."""
+
+    git_dir = integration_dir()
+    if in_version:
+        data = get_docker_compose_data_for_rev(git_dir, in_version)
+    else:
+        data = get_docker_compose_data(git_dir)
+
+    global REPOS
+    REPOS = {}
+    for repo_docker in REPO_MAP.keys():
+        if repo_docker == "integration" or data.get(repo_docker) is not None:
+            REPOS[repo_docker] = REPO_MAP[repo_docker]
 
 def version_of(integration_dir, repo_docker, in_integration_version=None):
     if repo_docker == "integration":
@@ -1760,6 +1781,11 @@ def main():
     if args.dry_run:
         global DRY_RUN
         DRY_RUN = True
+
+    if args.in_integration_version:
+        update_repo_list(args.in_integration_version)
+    else:
+        update_repo_list()
 
     if args.version_of is not None:
         do_version_of(args)


### PR DESCRIPTION
We need to be able to query repos that have been in the product
earlier, but which have been removed, both when using the `--list`
argument and the `--version-of` argument. To achieve this we turn the
existing static list into a candidate map instead, and fill it based
on which versions are available either in the current working
directory or, if given the `--in-integration-version` argument, that
version.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>