### PR TITLE
client: Use KVM automatically if available. Remove "./demo --kvm" option.

### DIFF
--- a/demo
+++ b/demo
@@ -2,10 +2,8 @@
 
 usage() {
     cat <<EOF
-$(basename $0) [--kvm] docker-options
+$(basename $0) [options] docker-options
 
---kvm
-	Enable KVM hardware acceleration of client VM.
 --no-client
 	Disable emulated client.
 
@@ -26,11 +24,7 @@ while [ -n "$1" ]; do
             continue
         fi
     elif [ "$1" = "--kvm" ]; then
-        if [ -z "$CLIENT" ]; then
-            echo "$1 cannot be used when there is no client!"
-            exit 1
-        fi
-        CLIENT="$CLIENT -f docker-compose.client-privileged.yml"
+        echo "--kvm argument is deprecated. KVM will be enabled automatically if available"
     else
         if [ "$#" -eq 0 ]; then
             usage

--- a/docker-compose.client-privileged.yml
+++ b/docker-compose.client-privileged.yml
@@ -1,8 +1,0 @@
-version: '2'
-services:
-
-    #
-    # mender-client
-    #
-    mender-client:
-        privileged: true

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -10,3 +10,4 @@ services:
             - mender
         stdin_open: true
         tty: true
+        privileged: true

--- a/tests/common_docker.py
+++ b/tests/common_docker.py
@@ -26,7 +26,6 @@ import os
 COMPOSE_FILES = [
     "../docker-compose.yml",
     "../docker-compose.client.yml",
-    "../docker-compose.client-privileged.yml",
     "../docker-compose.storage.minio.yml",
     "../docker-compose.testing.yml",
 ]

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -73,7 +73,6 @@ def standard_setup_one_client_bootstrapped_with_s3():
 
     docker_compose_cmd("-f ../docker-compose.yml \
                         -f ../docker-compose.client.yml \
-                        -f ../docker-compose.client-privileged.yml \
                         -f ../docker-compose.testing.yml \
                         -f ../docker-compose.storage.minio.yml \
                         -f ../docker-compose.storage.s3.yml up -d",
@@ -121,7 +120,6 @@ def standard_setup_with_short_lived_token():
 
     docker_compose_cmd("-f ../docker-compose.yml \
                         -f ../docker-compose.client.yml \
-                        -f ../docker-compose.client-privileged.yml \
                         -f ../docker-compose.storage.minio.yml  \
                         -f ../docker-compose.testing.yml \
                         -f ../extra/expired-token-testing/docker-compose.short-token.yml up -d",
@@ -145,7 +143,6 @@ def setup_failover():
 
     docker_compose_cmd("-f ../docker-compose.yml \
                         -f ../docker-compose.client.yml \
-                        -f ../docker-compose.client-privileged.yml \
                         -f ../docker-compose.storage.minio.yml  \
                         -f ../docker-compose.testing.yml \
                         -f ../extra/failover-testing/docker-compose.failover-server.yml up -d",


### PR DESCRIPTION
For this we need to always run the client in a privileged container.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>