### PR TITLE
tests: Clean up usage of docker-compose instance/project names.

### DIFF
--- a/tests/production_test_env.py
+++ b/tests/production_test_env.py
@@ -22,13 +22,16 @@ parser.add_argument('--kill', dest='kill', action='store_true',
 parser.add_argument('--test-deployment', dest='deploy', action='store_true',
                     help='start testing upgrade test procedure (used for upgrade testing)')
 
-conftest.docker_compose_instance = "testprod"
+parser.add_argument('--docker-compose-instance', required=True,
+                    help='The docker-compose instance to use (project name)')
 
 if len(sys.argv) == 1:
     parser.print_help()
     sys.exit(1)
 
 args = parser.parse_args()
+
+conftest.docker_compose_instance = args.docker_compose_instance
 
 def fill_production_template():
 
@@ -68,7 +71,7 @@ if args.start:
 
     # start docker-compose
     ret = subprocess.call(["docker-compose",
-                           "-p", "testprod",
+                           "-p", conftest.docker_compose_instance,
                            "-f", "docker-compose.yml",
                            "-f", "docker-compose.storage.minio.yml",
                            "-f", "./production-testing-env.yml",
@@ -101,4 +104,4 @@ if args.deploy:
     print("devices=%d" % len(devices))
 
 if args.kill:
-    subprocess.call(["docker-compose", "-p", "testprod", "down", "-v", "--remove-orphans"])
+    subprocess.call(["docker-compose", "-p", conftest.docker_compose_instance, "down", "-v", "--remove-orphans"])

--- a/tests/tests/test_update.py
+++ b/tests/tests/test_update.py
@@ -54,7 +54,8 @@ def setup_upgrade_source(upgrade_from):
                           cwd="upgrade-from/tests")
     assert ret == 0, "failed running 'run.sh --get-requirements' on upgrade source"
 
-    ret = subprocess.call(["python", "production_test_env.py", "--start"],
+    ret = subprocess.call(["python", "production_test_env.py", "--start",
+                           "--docker-compose-instance", conftest.docker_compose_instance],
                           cwd="upgrade-from/tests")
     assert ret == 0, "failed running 'production_test_env.py start' on upgrade source"
 
@@ -63,7 +64,8 @@ def perform_upgrade():
     ret = subprocess.call(["cp", "-r", "tests/upgrade-from/keys-generated", "."], cwd="..")
     assert ret == 0, "faled to copy keys from original environment"
 
-    subprocess.check_call(["./production_test_env.py", "--start"])
+    subprocess.check_call(["./production_test_env.py", "--start",
+                           "--docker-compose-instance", conftest.docker_compose_instance])
 
     # give time for all microservices to come online
     time.sleep(60 * 5)
@@ -81,7 +83,9 @@ def setup_fake_clients(device_count, fail_count):
 
 def provision_upgrade_server():
     # deploy update to 10 devices
-    ret = subprocess.Popen(["python", "production_test_env.py", "--test-deployment"], cwd="upgrade-from/tests", stdout=subprocess.PIPE)
+    ret = subprocess.Popen(["python", "production_test_env.py", "--test-deployment",
+                            "--docker-compose-instance", conftest.docker_compose_instance],
+                           cwd="upgrade-from/tests", stdout=subprocess.PIPE)
     time.sleep(120)
 
     # extract deployment_id and artifact_id from piped output
@@ -100,7 +104,6 @@ class BackendUpdating():
     provisioned_artifact_id = None
 
     def __init__(self, upgrade_from):
-        conftest.docker_compose_instance = "testprod"
         setup_docker_volumes()
         setup_upgrade_source(upgrade_from)
         self.fake_client_process = setup_fake_clients(10, 3)


### PR DESCRIPTION
Use truly random names everywhere, even for production setups. Should
reduce the chance of namespaces clashing.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>