### PR TITLE
[Don't merge] Delay device startup by 15s after starting last backend service.

### DIFF
--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -11,3 +11,11 @@ services:
         stdin_open: true
         tty: true
         privileged: true
+        depends_on:
+            # api-gateway is the last backend service to start
+            - mender-api-gateway
+        # delay device startup to give backend services extra time to start
+        entrypoint:
+            - /bin/sh
+            - -c
+            - sleep 15 && ./entrypoint.sh


### PR DESCRIPTION
Testing tweaks to integration testing. Delay starting resource consuming device in the setup and give backend some extra time to start.

Changelog: none

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>