### PR TITLE
compose: revert to elastic 2.2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
             - mender
 
     mender-elasticsearch:
-        image: mendersoftware/elasticsearch:2.4
+        image: elasticsearch:2.2.2
         extends:
             file: common.yml
             service: mender-base

--- a/extra/failover-testing/docker-compose.failover-server.yml
+++ b/extra/failover-testing/docker-compose.failover-server.yml
@@ -162,7 +162,7 @@ services:
             - CONFIG_PROP=config.properties
 
     mender-elasticsearch-2:
-        image: mendersoftware/elasticsearch:2.4
+        image: elasticsearch:2.2.2
         extends:
             file: common.yml
             service: mender-base
@@ -182,7 +182,7 @@ services:
             - /var/lib/redis
         entrypoint: /redis/entrypoint.sh
 
-    
+
 
     # Add client to failover network as well
     mender-client:


### PR DESCRIPTION
follows saas revert due to issues with unicode chars.

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

related: https://github.com/mendersoftware/saas/pull/153