### PR TITLE
tests: un-skip TestCreateOrganization::test_success

### DIFF
--- a/tests/tests/test_create_organization.py
+++ b/tests/tests/test_create_organization.py
@@ -29,7 +29,6 @@ import asyncore
 from MenderAPI import *
 
 class TestCreateOrganization(MenderTesting):
-    @pytest.mark.skip(reason="QA-45, QA-46")
     @pytest.mark.usefixtures("multitenancy_setup_without_client_with_smtp")
     def test_success(self):
 


### PR DESCRIPTION
after ES update this test passes locally.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>