### PR TITLE
compose: make deviceauth depend on conductor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
             - mender
         depends_on:
             - mender-mongo
+            - mender-conductor
 
     #
     # mender-inventory


### PR DESCRIPTION
some tests manage to issue e.g. a PUT /status before conductor is
ready to go with its provision_device workflow. make deviceauth wait
until conductor is fully up.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>