### PR TITLE
Make sure not to install fabric 2.0.

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.12.0
 pytest>=3.0
-Fabric>=1.13.0
+Fabric>=1.13.0, <2
 filelock>=2.0
 psutil
 selenium


### PR DESCRIPTION
Fabric 2.0 test dependency is not compatible with our test framework.

Changelog: none

Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>