### PR TITLE
Relax the max iterations criteria to 50 after failures in Jenkins

### DIFF
--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -952,7 +952,7 @@ class TestStateScripts(MenderTesting):
         work_dir = "test_state_scripts.%s" % client
         deployment_id = None
         try:
-            script_content = '#!/bin/sh\n\necho "echo `date --rfc-3339=seconds | sed -e e/\n//` $(basename $0)" >> /data/test_state_scripts.log\n'
+            script_content = '#!/bin/sh\n\necho "`date --rfc-3339=seconds | sed -e e/\n//` $(basename $0)" >> /data/test_state_scripts.log\n'
             script_failure_content = script_content + "exit 1\n"
 
             old_active = Helpers.get_active_partition()
@@ -1112,11 +1112,11 @@ class TestStateScripts(MenderTesting):
                 + "rm -rf /data/mender/scripts && "
                 + "systemctl start mender")
 
-    def verify_script_log_correct(self, test_set, log):
+    def verify_script_log_correct(self, test_set, log_orig):
         expected_order = test_set['ScriptOrder']
 
         # First remove timestamps from the log
-        log = [l.split(" ")[-1] for l in log]
+        log = [l.split(" ")[-1] for l in log_orig]
 
         # Iterate down the list of expected scripts, and make sure that the log
         # follows the same list.
@@ -1162,8 +1162,8 @@ class TestStateScripts(MenderTesting):
                 assert num_iterations < 50
 
         except:
-            print("Exception in verify_script_log_correct: log of scripts = '%s'"
-                  % "\n".join(log))
-            print("scripts we expected = '%s'"
+            logger.error("Exception in verify_script_log_correct: log of scripts = '%s'"
+                  % "\n".join(log_orig))
+            logger.error("scripts we expected = '%s'"
                   % "\n".join(expected_order))
             raise

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -1155,11 +1155,11 @@ class TestStateScripts(MenderTesting):
             # Test cases with an expectation of success/failure shall do only 1 iteration
             # Test cases with None expectation will loop through the error sequence in a loop, but still
             # we want to make sure that it is reasonable (i.e. looping with the correct time intervals).
-            # For these cases we set a max. of 20 iterations to accomodate for slow running of the framework
+            # For these cases we set a max. of 50 iterations to accomodate for slow running of the framework
             if test_set['ExpectedStatus'] is not None:
                 assert num_iterations == 1
             else:
-                assert num_iterations < 20
+                assert num_iterations < 50
 
         except:
             print("Exception in verify_script_log_correct: log of scripts = '%s'"


### PR DESCRIPTION
These failures are due to resource capacity and not actual test
failures. Anyhow, if the "infinite" loop bug shows again, the num of
iterations will be in the order of thousands.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>