### PR TITLE
MEN-2408: Resolve docker credentials problems in integration

### DIFF
--- a/reset
+++ b/reset
@@ -8,11 +8,11 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-sudo docker-compose ps | grep -q Up
+docker-compose ps | grep -q Up
 
 if [ $? -eq 0 ]; then
   echo "Please stop the server before resetting."
   exit 1
 fi
 
-sudo ./demo rm -v
+./demo rm -v

--- a/reset-user
+++ b/reset-user
@@ -8,7 +8,7 @@ while true; do
     echo
     case $yn in
         [y]* )
-            exec sudo docker-compose \
+            exec docker-compose \
                 exec \
                 mender-mongo-useradm \
                 mongo useradm --eval "db.users.remove({})"

--- a/stop
+++ b/stop
@@ -4,4 +4,4 @@ set -e -o pipefail
 
 ./verify-docker-versions
 
-sudo ./demo stop
+./demo stop

--- a/up
+++ b/up
@@ -41,14 +41,14 @@ setuphosts() {
 
     if [ -s "$tmpfile" ] ; then
        log "adding the following entries to /etc/hosts:"
-       sudo tee -a /etc/hosts < "$tmpfile"
+       cat "$tmpfile"
+       sudo tee -a /etc/hosts < "$tmpfile" > /dev/null
     fi
     rm -f "$tmpfile"
 }
 
 rundocker() {
-    # sudo -E ./demo scale mender-client=3  # NB! Typically run this just once, will add 3 clients each time
-    sudo -E ./demo up
+    ./demo up
 }
 
 showhelp() {

--- a/update
+++ b/update
@@ -2,11 +2,11 @@
 # Updates to latest upstream docker compose and images.
 # Mostly for demo purposes, be careful in production!
 
-sudo ./demo ps | grep -q Up
+./demo ps | grep -q Up
 
 if [ $? -eq 0 ]; then
   echo "Please stop the server before updating."
   exit 1
 fi
 
-sudo ./demo pull
+./demo pull

--- a/verify-docker-versions
+++ b/verify-docker-versions
@@ -24,10 +24,21 @@ compare_versions() {
   return 0
 }
 
+# test that user has rights to use docker
+
+DOCKER_ENGINE_INFO_STDERR=$(docker info 2>&1 >/dev/null)
+DOCKER_ENGINE_INFO_RETVAL=$?
+if [[ $DOCKER_ENGINE_INFO_RETVAL -ne 0 ]]; then
+  >&2 echo "Local user has insufficient permissions to connect to the docker daemon."
+  >&2 echo "Please add user to 'docker' group to be able to access it or check the documentation for your host OS."
+  >&2 echo "Be aware that if you were just added to the group, you need to log out and in again."
+  >&2 echo $DOCKER_ENGINE_INFO_STDERR
+  exit 1
+fi
 
 # test Docker Engine version
 
-DOCKER_ENGINE_VERSION_STRING=$(sudo docker info 2>/dev/null | grep "Server Version")
+DOCKER_ENGINE_VERSION_STRING=$(docker info 2>/dev/null | grep "Server Version")
 
 DOCKER_ENGINE_VERSION_NEW_SCHEME_REGEX="Server Version: ([0-9]{2,})|([2-9]+)\.[0-9]+\.[0-9]+"
 


### PR DESCRIPTION
The user shall have rights to access the docker daemon, as required in
the official Mender docs, to be able to run this scripts.

Removed all the sudo calls from the Docker-related scripts and added a
check for it in verify-docker-versions script.

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>