### PR TITLE
set HSTS max-age via env/demo config files

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -26,6 +26,7 @@ services:
             - ./certs/api-gateway/private.key:/var/www/mendersoftware/cert/private.key
         environment:
             ALLOWED_HOSTS: localhost docker.mender.io
+            HSTS_MAX_AGE: 0
 
     storage-proxy:
         ports:

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -47,6 +47,7 @@ services:
         volumes:
             - ./certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt
             - ./certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key
+            - ./storage-proxy/nginx.conf.demo:/usr/local/openresty/nginx/conf/nginx.conf
 
     mender-deployments:
         command: server --automigrate

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -24,5 +24,3 @@ services:
                     - s3.docker.mender.io
         depends_on:
             - minio
-        volumes:
-            - ./storage-proxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -42,6 +42,7 @@ services:
         volumes:
             - ./certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt
             - ./certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key
+            - ./storage-proxy/nginx.conf.demo:/usr/local/openresty/nginx/conf/nginx.conf
 
     mender-deployments:
         command: server --automigrate

--- a/storage-proxy/nginx.conf.demo
+++ b/storage-proxy/nginx.conf.demo
@@ -1,0 +1,112 @@
+worker_processes  auto;
+
+error_log  /dev/stdout warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+env DOWNLOAD_SPEED;
+env MAX_CONNECTIONS;
+
+http {
+
+    init_by_lua_block {
+        ngx.log(ngx.WARN, "download speed limit: " .. (os.getenv("DOWNLOAD_SPEED") or "not set"))
+        ngx.log(ngx.WARN, "max connections: " .. (os.getenv("MAX_CONNECTIONS") or "not set"))
+    }
+
+    upstream minio_backend {
+        server minio:9000 max_fails=0;
+    }
+
+    lua_shared_dict my_limit_conn_store 100m;
+
+    server {
+
+        proxy_max_temp_file_size 0;
+
+        listen 9000 ssl;
+
+        ssl_certificate /var/www/storage-proxy/cert/cert.crt;
+        ssl_certificate_key /var/www/storage-proxy/cert/private.key;
+
+        ssl_protocols TLSv1.1 TLSv1.2;
+        ssl_ciphers HIGH:!aNULL:!MD5:!SHA;
+        ssl_prefer_server_ciphers on;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_tickets off;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+
+        add_header Strict-Transport-Security "max-age=0; includeSubdomains; preload";
+        add_header X-Frame-Options DENY;
+        add_header X-Content-Type-Options nosniff;
+
+        location / {
+            access_by_lua_block {
+                -- rate and connection limiting is applied only to GET requests
+                if ngx.req.get_method() == "GET" then
+
+                   local max_connections = tonumber(os.getenv("MAX_CONNECTIONS"))
+                   if max_connections ~= nil then
+                      local limit_conn = require "resty.limit.conn"
+
+                      local lim, err = limit_conn.new("my_limit_conn_store", max_connections, 0, 1)
+                      if not lim then
+                         ngx.log(ngx.ERR,
+                                 "failed to instantiate a resty.limit.conn object: ", err)
+                         return ngx.exit(500)
+                      end
+
+                      local key = ngx.var.binary_remote_addr
+                      local delay, err = lim:incoming(key, true)
+                      if not delay and err ~= "rejected" then
+                         ngx.log(ngx.ERR, "failed to limit req: ", err)
+                         return ngx.exit(500)
+                      elseif not delay or delay > 0 then
+                         ngx.log(ngx.WARN, "connection rejected")
+                         return ngx.exit(503)
+                      end
+
+                      if lim:is_committed() then
+                         local ctx = ngx.ctx
+                         ctx.limit_conn = lim
+                         ctx.limit_conn_key = key
+                         ctx.limit_conn_delay = delay
+                      end
+                   end
+
+                   local download_speed = os.getenv("DOWNLOAD_SPEED")
+                   if download_speed ~= nil then
+                      ngx.var.limit_rate = download_speed
+                   end
+                end
+            }
+
+            log_by_lua_block {
+                local ctx = ngx.ctx
+                local lim = ctx.limit_conn
+                if lim then
+                    local latency = tonumber(ngx.var.request_time)
+                    local key = ctx.limit_conn_key
+                    assert(key)
+                    local conn, err = lim:leaving(key, latency)
+                    if not conn then
+                        ngx.log(ngx.ERR,
+                                "failed to record the connection leaving ",
+                                "request: ", err)
+                        return
+                    end
+                end
+            }
+            client_max_body_size 0;
+            proxy_request_buffering off;
+            proxy_http_version 1.1;
+
+            proxy_set_header Host $http_host;
+            proxy_pass http://minio_backend;
+        }
+    }
+}

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -86,6 +86,7 @@ services:
         volumes:
             - ./template/keys-generated/certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt:ro
             - ./template/keys-generated/certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key:ro
+            - ./storage-proxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
 
     mender-deployments:
         command: server --automigrate


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-2440

gateway has a new setting now - so set it in demo: https://github.com/mendersoftware/mender-api-gateway-docker/pull/103.

proxy also needs max-age=0, but it doesn't have the substitution logic that the gateway has - so simply have 2 config files, one for demo, one for prod.
