### PR TITLE
MEN-2438: Conditionally skip test that needs `/data/mender/mender.conf`.

### DIFF
--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -246,6 +246,11 @@ class TestFaultTolerance(MenderTesting):
                     hosts=get_mender_clients())
             return
 
+        with settings(warn_only=True):
+            output = run("test -e /data/mender/mender.conf")
+            if output.return_code != 0:
+                pytest.skip("Needs split mender.conf configuration to run this test")
+
         tmpdir = tempfile.mkdtemp()
         try:
             orig_image = conftest.get_valid_image()


### PR DESCRIPTION
It doesn't exist in thud and earlier.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 014a6c946488cb2a88789ac4b6fec0febe9831b0)