### PR TITLE
Fix license generation remote non origin

### DIFF
--- a/extra/README-release_tool.md
+++ b/extra/README-release_tool.md
@@ -77,13 +77,13 @@ In this tutorial we go through the typical work flow when doing a release.
 #### Preparing for a release
 
 1. The first thing you need to do is to verify that the script has knowledge of
-   all the repositories it needs to for a given release. Check the `REPOS`
+   all the repositories it needs to for a given release. Check `COMPONENT_MAPS`
    variable inside the script, and add or remove repositories as needed. Make
    sure you read the comments above it, since some changes may require
    additional sections to be changed.
 
 2. Before you can use the release mode of the tool, one prerequisite is
-   required: All repositories mentioned in the `REPOS` variable inside the
+   required: All repositories mentioned in `COMPONENT_MAPS` variable inside the
    script source must be available inside a single directory (having them as
    symlinks pointing somewhere else is ok). The script will ask about the
    location of this directory before starting.

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -1298,7 +1298,8 @@ def do_license_generation(state, tag_avail):
     for repo in Component.get_components_of_type("git", only_release=True):
         tmpdirs.append(setup_temp_git_checkout(state, repo.git(), tag_or_followed_branch(repo.git())))
     for repo in Component.get_components_of_type("git", only_non_release=True):
-        tmpdirs.append(setup_temp_git_checkout(state, repo.git(), "origin/master"))
+        remote = find_upstream_remote(state, repo.git())
+        tmpdirs.append(setup_temp_git_checkout(state, repo.git(), remote + "/master"))
 
     try:
         with open("generated-license-text.txt", "w") as fd:


### PR DESCRIPTION
```
commit dcb67d985796d2b8f2df43fa79ecc0512bfc8048
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Tue Jun 18 14:52:38 2019 +0200

    Fix minor typo on the release tool documentation
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit ef96faa3d6f622577430c6773ae4108889cbd996
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Tue Jun 18 14:51:14 2019 +0200

    Allow diferent remote names different than origin on licence generation
    
    By using the already existing code rather than a hardcoded origin
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```