### PR TITLE
Remove the timeout for this test, it seems it is not enough

### DIFF
--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -113,7 +113,6 @@ class TestBasicIntegration(MenderTesting):
 
 
 
-    @pytest.mark.timeout(1000)
     @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
     def test_forced_update_check_from_client(self):
         """Upload a device with a broken image, followed by a valid image"""


### PR DESCRIPTION
The code will trigger the timeout in deployments.check_expected_status
if necessary.

In Jenkins we install the pip dependencies manually, while in GitLab we
use the tests/requirements.txt specification. Thus, this problem is only
visible in GitLab runs.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>