### PR TITLE
backend tests: GET management/v2/devices

### DIFF
--- a/backend-tests/tests/api/inventory_v2.py
+++ b/backend-tests/tests/api/inventory_v2.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+import api.client
+
+URL_MGMT = api.client.GATEWAY_URL + '/api/management/v2/inventory'
+URL_INT = 'http://mender-inventory:8080/api/internal/v2/inventory'
+
+URL_MGMT_DEVICES = '/devices'
+URL_MGMT_DEVICE = '/device/{id}'
+
+URL_INT_DEVICE_ATTRIBUTES = '/devices/{id}'

--- a/backend-tests/tests/common.py
+++ b/backend-tests/tests/common.py
@@ -31,6 +31,15 @@ def mongo():
 def clean_mongo(mongo):
     """Fixture setting up a clean (i.e. empty database). Yields
     pymongo.MongoClient connected to the DB."""
+    yield from _clean_mongo(mongo)
+
+@pytest.yield_fixture(scope='class')
+def clean_mongo_cls(mongo):
+    """Fixture setting up a clean (i.e. empty database). Yields
+    pymongo.MongoClient connected to the DB."""
+    yield from _clean_mongo(mongo)
+
+def _clean_mongo(mongo):
     mongo_cleanup(mongo)
     yield mongo
     mongo_cleanup(mongo)

--- a/backend-tests/tests/test_devauth_v2.py
+++ b/backend-tests/tests/test_devauth_v2.py
@@ -28,7 +28,9 @@ import util.crypto
 from common import User, Device, Authset, Tenant, \
         create_user, create_tenant, create_tenant_user, \
         create_random_authset, create_authset, \
-        get_device_by_id_data, change_authset_status
+        get_device_by_id_data, change_authset_status, \
+        wait_conductor_create_devices_inv
+
 
 @pytest.yield_fixture(scope='function')
 def clean_migrated_mongo(clean_mongo):
@@ -362,6 +364,8 @@ def make_devs_with_authsets(user, tenant_token=''):
     for i in range(2):
         dev = make_preauthd_device_with_pending(utoken, num_pending=2, tenant_token=tenant_token)
         devices.append(dev)
+
+    wait_conductor_create_devices_inv(utoken, 5)
 
     return devices
 

--- a/backend-tests/tests/test_inventory.py
+++ b/backend-tests/tests/test_inventory.py
@@ -20,7 +20,7 @@ from common import mongo, clean_mongo
 from infra.cli import CliUseradm, CliDeviceauth, CliTenantadm
 import api.deviceauth as deviceauth_v1
 import api.useradm as useradm
-import api.inventory as inventory
+import api.inventory as inventory_v1
 import api.tenantadm as tenantadm
 import util.crypto
 from common import User, Device, Authset, Tenant, \
@@ -127,12 +127,12 @@ def make_accepted_devices(utoken, devauthd, num_devices=1, tenant_token=''):
 
     return devices
 
-class TestGetDevicesBase:
+class TestGetDevicesV1Base:
     def do_test_get_devices_ok(self, user, tenant_token=''):
         useradmm = ApiClient(useradm.URL_MGMT)
         devauthd = ApiClient(deviceauth_v1.URL_DEVICES)
-        invm = ApiClient(inventory.URL_MGMT)
-        invd = ApiClient(inventory.URL_DEV)
+        invm = ApiClient(inventory_v1.URL_MGMT)
+        invd = ApiClient(inventory_v1.URL_DEV)
 
         # log in user
         r = useradmm.call('POST',
@@ -148,7 +148,7 @@ class TestGetDevicesBase:
         time.sleep(3)
 
         r = invm.with_auth(utoken).call('GET',
-                                        inventory.URL_DEVICES,
+                                        inventory_v1.URL_DEVICES,
                                         qs_params={'per_page':100})
         assert r.status_code == 200
         api_devs = r.json()
@@ -157,8 +157,8 @@ class TestGetDevicesBase:
     def do_test_filter_devices_ok(self, user, tenant_token=''):
         useradmm = ApiClient(useradm.URL_MGMT)
         devauthd = ApiClient(deviceauth_v1.URL_DEVICES)
-        invm = ApiClient(inventory.URL_MGMT)
-        invd = ApiClient(inventory.URL_DEV)
+        invm = ApiClient(inventory_v1.URL_MGMT)
+        invd = ApiClient(inventory_v1.URL_DEV)
 
         # log in user
         r = useradmm.call('POST',
@@ -174,7 +174,7 @@ class TestGetDevicesBase:
         time.sleep(3)
 
         r = invm.with_auth(utoken).call('GET',
-                                        inventory.URL_DEVICES,
+                                        inventory_v1.URL_DEVICES,
                                         qs_params={'per_page':100})
         assert r.status_code == 200
         api_devs = r.json()
@@ -189,7 +189,7 @@ class TestGetDevicesBase:
                     }
             ]
             r = invd.with_auth(d.token).call('PATCH',
-                                        inventory.URL_DEVICE_ATTRIBUTES,
+                                        inventory_v1.URL_DEVICE_ATTRIBUTES,
                                         payload)
             assert r.status_code == 200
 
@@ -198,20 +198,20 @@ class TestGetDevicesBase:
         qs_params['per_page'] = 100
         qs_params['mac'] = 'de:ad:be:ef:06:7'
         r = invm.with_auth(utoken).call('GET',
-                                        inventory.URL_DEVICES,
+                                        inventory_v1.URL_DEVICES,
                                         qs_params=qs_params)
         assert r.status_code == 200
         api_devs = r.json()
         assert len(api_devs) == 1
 
-class TestGetDevices(TestGetDevicesBase):
+class TestGetDevicesV1(TestGetDevicesV1Base):
     def test_get_devices_ok(self, user):
         self.do_test_get_devices_ok(user)
 
     def test_filter_devices_ok(self, user):
         self.do_test_filter_devices_ok(user)
 
-class TestGetDevicesMultitenant(TestGetDevicesBase):
+class TestGetDevicesV1Multitenant(TestGetDevicesV1Base):
     def test_get_devices_ok(self, tenants_users):
         for t in tenants_users:
             self.do_test_get_devices_ok(t.users[0], tenant_token=t.tenant_token)
@@ -220,12 +220,12 @@ class TestGetDevicesMultitenant(TestGetDevicesBase):
         for t in tenants_users:
             self.do_test_filter_devices_ok(t.users[0], tenant_token=t.tenant_token)
 
-class TestDevicePatchAttributes:
+class TestDevicePatchAttributesV1:
     def test_ok(self, user):
         useradmm = ApiClient(useradm.URL_MGMT)
         devauthd = ApiClient(deviceauth_v1.URL_DEVICES)
-        invm = ApiClient(inventory.URL_MGMT)
-        invd = ApiClient(inventory.URL_DEV)
+        invm = ApiClient(inventory_v1.URL_MGMT)
+        invd = ApiClient(inventory_v1.URL_DEV)
 
         # log in user
         r = useradmm.call('POST',
@@ -258,13 +258,13 @@ class TestDevicePatchAttributes:
                     }
             ]
             r = invd.with_auth(d.token).call('PATCH',
-                                        inventory.URL_DEVICE_ATTRIBUTES,
+                                        inventory_v1.URL_DEVICE_ATTRIBUTES,
                                         payload)
             assert r.status_code == 200
 
         for d in devs:
             r = invm.with_auth(utoken).call('GET',
-                                            inventory.URL_DEVICE,
+                                            inventory_v1.URL_DEVICE,
                                             path_params={'id': d.id})
             assert r.status_code == 200
 
@@ -284,8 +284,8 @@ class TestDevicePatchAttributes:
     def test_fail_no_attr_value(self, user):
         useradmm = ApiClient(useradm.URL_MGMT)
         devauthd = ApiClient(deviceauth_v1.URL_DEVICES)
-        invm = ApiClient(inventory.URL_MGMT)
-        invd = ApiClient(inventory.URL_DEV)
+        invm = ApiClient(inventory_v1.URL_MGMT)
+        invd = ApiClient(inventory_v1.URL_DEV)
 
         # log in user
         r = useradmm.call('POST',
@@ -307,6 +307,6 @@ class TestDevicePatchAttributes:
                     }
             ]
             r = invd.with_auth(d.token).call('PATCH',
-                                        inventory.URL_DEVICE_ATTRIBUTES,
+                                        inventory_v1.URL_DEVICE_ATTRIBUTES,
                                         payload)
             assert r.status_code == 400

--- a/backend-tests/tests/test_inventory.py
+++ b/backend-tests/tests/test_inventory.py
@@ -75,8 +75,9 @@ def rand_id_data():
 
     return {'mac': mac, 'sn': sn}
 
-def make_pending_device(utoken, tenant_token=''):
-    id_data = rand_id_data()
+def make_pending_device(utoken, tenant_token='', id_data=None):
+    if id_data is None:
+        id_data = rand_id_data()
 
     priv, pub = util.crypto.rsa_get_keypair()
     new_set = create_authset(id_data, pub, priv, utoken, tenant_token=tenant_token)
@@ -89,8 +90,8 @@ def make_pending_device(utoken, tenant_token=''):
 
     return dev
 
-def make_accepted_device(utoken, devauthd, tenant_token=''):
-    dev = make_pending_device(utoken, tenant_token=tenant_token)
+def make_accepted_device(utoken, devauthd, tenant_token='', id_data=None):
+    dev = make_pending_device(utoken, tenant_token=tenant_token, id_data=id_data)
     aset_id = dev.authsets[0].id
     change_authset_status(dev.id, aset_id, 'accepted', utoken)
 

--- a/backend-tests/tests/test_inventory.py
+++ b/backend-tests/tests/test_inventory.py
@@ -485,13 +485,10 @@ def get_v2_devices_mt(tenants_users_cls):
     return tenants_users
 
 class TestGetDevicesBase:
-    def do_test_ok_all(self, user, tenant_id='', tenant_token=''):
+    def do_test_ok_all(self, user, devs, tenant_id='', tenant_token=''):
         """ All devices """
-        useradmm = ApiClient(useradm.URL_MGMT)
-        devauthd = ApiClient(deviceauth_v1.URL_DEVICES)
         invm = ApiClient(inventory.URL_MGMT)
-        invd = ApiClient(inventory_v1.URL_DEV)
-        invi = ApiClient(inventory.URL_INT)
+        useradmm = ApiClient(useradm.URL_MGMT)
 
         # log in user
         r = useradmm.call('POST',
@@ -499,8 +496,6 @@ class TestGetDevicesBase:
                           auth=(user.name, user.pwd))
         assert r.status_code == 200
         utoken = r.text
-        devs = make_devs_get_v2(utoken, devauthd, invd, invi, tenant_id=tenant_id, tenant_token=tenant_token)
-
         r = invm.with_auth(utoken).call('GET',
                                         inventory.URL_MGMT_DEVICES,
                                         qs_params={'per_page':100})
@@ -511,13 +506,10 @@ class TestGetDevicesBase:
         api_devs = r.json()
         assert len(api_devs) == len(devs)
 
-    def do_test_ok_paging(self, user, tenant_id='', tenant_token=''):
+    def do_test_ok_paging(self, user, devs, tenant_id='', tenant_token=''):
         """ A couple paging scenarios """
-        useradmm = ApiClient(useradm.URL_MGMT)
-        devauthd = ApiClient(deviceauth_v1.URL_DEVICES)
         invm = ApiClient(inventory.URL_MGMT)
-        invd = ApiClient(inventory_v1.URL_DEV)
-        invi = ApiClient(inventory.URL_INT)
+        useradmm = ApiClient(useradm.URL_MGMT)
 
         # log in user
         r = useradmm.call('POST',
@@ -525,13 +517,11 @@ class TestGetDevicesBase:
                           auth=(user.name, user.pwd))
         assert r.status_code == 200
         utoken = r.text
-        devs = make_devs_get_v2(utoken, devauthd, invd, invi, tenant_id=tenant_id, tenant_token=tenant_token)
 
-        # default paging (20)
         cases = [
-                { 
+                {
                     'name': 'default, pg 1',
-                    'page': None, 
+                    'page': None,
                     'per_page': None,
 
                     'expected_devs': filter_page_sort_devs(devs, page=1, per_page=20),
@@ -539,7 +529,7 @@ class TestGetDevicesBase:
                 },
                 {
                     'name': 'default, pg 2',
-                    'page': 2, 
+                    'page': 2,
                     'per_page': None,
 
                     'expected_devs': [],
@@ -547,7 +537,7 @@ class TestGetDevicesBase:
                 },
                 {
                     'name': 'custom, per pg 5',
-                    'page': None, 
+                    'page': None,
                     'per_page': 5,
 
                     'expected_devs': filter_page_sort_devs(devs, page=1, per_page=5),
@@ -555,7 +545,7 @@ class TestGetDevicesBase:
                 },
                 {
                     'name': 'custom, pg 2, per pg 5',
-                    'page': 2, 
+                    'page': 2,
                     'per_page': 5,
 
                     'expected_devs': filter_page_sort_devs(devs, page=2, per_page=5),
@@ -563,7 +553,7 @@ class TestGetDevicesBase:
                 },
                 {
                     'name': 'custom, past bounds',
-                    'page': 5, 
+                    'page': 5,
                     'per_page': 5,
 
                     'expected_devs': [],
@@ -593,13 +583,10 @@ class TestGetDevicesBase:
 
             compare_devs(case['expected_devs'], api_devs)
 
-    def do_test_ok_filter(self, user, tenant_id='', tenant_token=''):
+    def do_test_ok_filter(self, user, devs, tenant_id='', tenant_token=''):
         """ Just filtering scenarios """
-        useradmm = ApiClient(useradm.URL_MGMT)
-        devauthd = ApiClient(deviceauth_v1.URL_DEVICES)
         invm = ApiClient(inventory.URL_MGMT)
-        invd = ApiClient(inventory_v1.URL_DEV)
-        invi = ApiClient(inventory.URL_INT)
+        useradmm = ApiClient(useradm.URL_MGMT)
 
         # log in user
         r = useradmm.call('POST',
@@ -607,7 +594,6 @@ class TestGetDevicesBase:
                           auth=(user.name, user.pwd))
         assert r.status_code == 200
         utoken = r.text
-        devs = make_devs_get_v2(utoken, devauthd, invd, invi, tenant_id=tenant_id, tenant_token=tenant_token)
 
         cases = [
             {
@@ -673,14 +659,11 @@ class TestGetDevicesBase:
             compare_devs(case['expected_devs'], api_devs)
 
             assert int(r.headers['X-Total-Count']) == case['expected_total'], 'case {}'.format(case['name'])
- 
-    def do_test_ok_sort(self, user, tenant_id='', tenant_token=''):
+
+    def do_test_ok_sort(self, user, devs, tenant_id='', tenant_token=''):
         """ Just sorting scenarios """
-        useradmm = ApiClient(useradm.URL_MGMT)
-        devauthd = ApiClient(deviceauth_v1.URL_DEVICES)
         invm = ApiClient(inventory.URL_MGMT)
-        invd = ApiClient(inventory_v1.URL_DEV)
-        invi = ApiClient(inventory.URL_INT)
+        useradmm = ApiClient(useradm.URL_MGMT)
 
         # log in user
         r = useradmm.call('POST',
@@ -688,7 +671,6 @@ class TestGetDevicesBase:
                           auth=(user.name, user.pwd))
         assert r.status_code == 200
         utoken = r.text
-        devs = make_devs_get_v2(utoken, devauthd, invd, invi, tenant_id=tenant_id, tenant_token=tenant_token)
 
         cases = [
             {
@@ -725,15 +707,9 @@ class TestGetDevicesBase:
 
             assert int(r.headers['X-Total-Count']) == case['expected_total'], 'case {}'.format(case['name'])
 
-    def do_test_ok_filter_sort_page(self, user, tenant_id='', tenant_token=''):
-        """
-            Full blown 'mixed' case, extend into test pairs as an improvement (on bug report?).
-        """
-        useradmm = ApiClient(useradm.URL_MGMT)
-        devauthd = ApiClient(deviceauth_v1.URL_DEVICES)
+    def do_test_ok_filter_sort_page(self, user, devs, tenant_id='', tenant_token=''):
         invm = ApiClient(inventory.URL_MGMT)
-        invd = ApiClient(inventory_v1.URL_DEV)
-        invi = ApiClient(inventory.URL_INT)
+        useradmm = ApiClient(useradm.URL_MGMT)
 
         # log in user
         r = useradmm.call('POST',
@@ -741,8 +717,6 @@ class TestGetDevicesBase:
                           auth=(user.name, user.pwd))
         assert r.status_code == 200
         utoken = r.text
-
-        devs = make_devs_get_v2(utoken, devauthd, invd, invi, tenant_id=tenant_id, tenant_token=tenant_token)
 
         r = invm.with_auth(utoken).call('GET',
                                         inventory.URL_MGMT_DEVICES,
@@ -757,55 +731,55 @@ class TestGetDevicesBase:
 
         api_devs = r.json()
 
-        expected_devs = filter_page_sort_devs(devs, 
-                page=2, 
-                per_page=2, 
+        expected_devs = filter_page_sort_devs(devs,
+                page=2,
+                per_page=2,
                 filters=[
-                    {'scope': 'identity', 'name': 'batch', 'val': 'batch1'}, 
+                    {'scope': 'identity', 'name': 'batch', 'val': 'batch1'},
                     {'scope': 'identity', 'name': 'common', 'val': 'common'}],
                 sort={'scope': 'identity', 'name': 'sn', 'asc': True})
 
         compare_devs(expected_devs, api_devs)
 
-        assert int(r.headers['X-Total-Count']) == 5 
+        assert int(r.headers['X-Total-Count']) == 5
 
 class TestGetDevices(TestGetDevicesBase):
-    def test_ok_all(self, user):
-        self.do_test_ok_all(user)
+    def test_ok_all(self, user_cls, get_v2_devices):
+        self.do_test_ok_all(user_cls, get_v2_devices)
 
-    def test_ok_paging(self, user):
-        self.do_test_ok_paging(user)
+    def test_ok_paging(self, user_cls, get_v2_devices):
+        self.do_test_ok_paging(user_cls, get_v2_devices)
 
-    def test_ok_filter(self, user):
-        self.do_test_ok_filter(user)
-    
-    def test_ok_sort(self, user):
-        self.do_test_ok_sort(user)
+    def test_ok_filter(self, user_cls, get_v2_devices):
+        self.do_test_ok_filter(user_cls, get_v2_devices)
 
-    def test_ok_filter_sort_page(self, user):
-        self.do_test_ok_filter_sort_page(user)
+    def test_ok_sort(self, user_cls, get_v2_devices):
+        self.do_test_ok_sort(user_cls, get_v2_devices)
+
+    def test_ok_filter_sort_page(self, user_cls, get_v2_devices):
+        self.do_test_ok_filter_sort_page(user_cls, get_v2_devices)
 
 
 class TestGetDevicesMultitenant(TestGetDevicesBase):
-    def test_ok_all(self, tenants_users):
-        for t in tenants_users:
-            self.do_test_ok_all(t.users[0], tenant_token=t.tenant_token, tenant_id=t.id)
+    def test_ok_all(self, tenants_users_cls, get_v2_devices_mt):
+        for t in tenants_users_cls:
+            self.do_test_ok_all(t.users[0], t.devices, tenant_token=t.tenant_token, tenant_id=t.id)
 
-    def test_ok_paging(self, tenants_users):
-        for t in tenants_users:
-            self.do_test_ok_paging(t.users[0], tenant_token=t.tenant_token, tenant_id=t.id)
+    def test_ok_paging(self, tenants_users_cls, get_v2_devices_mt):
+        for t in tenants_users_cls:
+            self.do_test_ok_paging(t.users[0], t.devices, tenant_token=t.tenant_token, tenant_id=t.id)
 
-    def test_ok_filter(self, tenants_users):
-        for t in tenants_users:
-            self.do_test_ok_filter(t.users[0], tenant_token=t.tenant_token, tenant_id=t.id)
-    
-    def test_ok_sort(self, tenants_users):
-        for t in tenants_users:
-            self.do_test_ok_sort(t.users[0], tenant_token=t.tenant_token, tenant_id=t.id)
+    def test_ok_filter(self, tenants_users_cls, get_v2_devices_mt):
+        for t in tenants_users_cls:
+            self.do_test_ok_filter(t.users[0], t.devices, tenant_token=t.tenant_token, tenant_id=t.id)
 
-    def test_ok_filter_sort_page(self, tenants_users):
-        for t in tenants_users:
-            self.do_test_ok_filter_sort_page(t.users[0], tenant_token=t.tenant_token, tenant_id=t.id)
+    def test_ok_sort(self, tenants_users_cls, get_v2_devices_mt):
+        for t in tenants_users_cls:
+            self.do_test_ok_sort(t.users[0], t.devices, tenant_token=t.tenant_token, tenant_id=t.id)
+
+    def test_ok_filter_sort_page(self, tenants_users_cls, get_v2_devices_mt):
+        for t in tenants_users_cls:
+            self.do_test_ok_filter_sort_page(t.users[0], t.devices,tenant_token=t.tenant_token, tenant_id=t.id)
 
 def filter_page_sort_devs(devs, page=None, per_page=None, filters=None, sort=None):
         """


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-2529

note it's on a new `device_filtering` branch, mirroring inventory's `device_filtering` - where the GET is actually implemented.

a lot of this was hunting time-sensitive bugs around conductor (see comments in code).
also - some optimization, I started with data setup per test func, which caused massive overhead (couple mins total). had to be reworked to saner per-class setup.

tested manually with https://github.com/mendersoftware/inventory/pull/137 and https://github.com/mendersoftware/mender-api-gateway-docker/pull/104
