### PR TITLE
test deviceauth's cli propagate-inventory

### DIFF
--- a/backend-tests/tests/infra/cli.py
+++ b/backend-tests/tests/infra/cli.py
@@ -70,3 +70,15 @@ class CliDeviceauth:
             cmd.extend(['--tenant', tenant_id])
 
         docker.exec(self.cid, cmd)
+
+    def propagate_inventory(self, tenant_id='', dry_run=False):
+        cmd = ['usr/bin/deviceauth',
+               'propagate-inventory']
+
+        if tenant_id is not None:
+            cmd.extend(['--tenant_id', tenant_id])
+
+        if dry_run:
+            cmd.extend(['--dry-run'])
+
+        docker.exec(self.cid, cmd)

--- a/backend-tests/tests/test_devauth_v2.py
+++ b/backend-tests/tests/test_devauth_v2.py
@@ -23,7 +23,8 @@ import api.deviceauth_v2 as deviceauth_v2
 import api.useradm as useradm
 import api.tenantadm as tenantadm
 import api.deployments as deployments
-import api.inventory as inventory
+import api.inventory as inventory_v1
+import api.inventory_v2 as inventory
 import util.crypto
 from common import User, Device, Authset, Tenant, \
         create_user, create_tenant, create_tenant_user, \
@@ -1154,10 +1155,10 @@ class TestAuthsetMgmtBase:
         return 'rejected'
 
     def verify_dev_provisioned(self, dev, utoken):
-        invm = ApiClient(inventory.URL_MGMT)
+        invm = ApiClient(inventory_v1.URL_MGMT)
 
         r = invm.with_auth(utoken).call('GET',
-                                        inventory.URL_DEVICE,
+                                        inventory_v1.URL_DEVICE,
                                         path_params={'id': dev.id})
         assert r.status_code == 200
 
@@ -1207,6 +1208,7 @@ class TestAuthsetMgmtMultitenant(TestAuthsetMgmtBase):
     def test_delete_status_failed(self, tenants_devs_authsets):
         for t in tenants_devs_authsets:
             self.do_test_delete_status_failed(t.devices, t.users[0])
+
 
 def filter_and_page_devs(devs, page=None, per_page=None, status=None):
         if status is not None:


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-2482

needs https://github.com/mendersoftware/deviceauth/pull/287 if you want to test it yourself.

note that the fixes above are done on master. this pr must go to device_filtering though because it uses v2 APIs.