### PR TITLE
Fixes for demo wget to work on Alpine Linux using latest download

### DIFF
--- a/demo
+++ b/demo
@@ -52,7 +52,7 @@ done
 # Check if the demo-Artifact has been downloaded,
 # or if there exists a newer one in storage.
 DEMO_ARTIFACT_NAME="mender-demo-artifact.mender"
-wget -q --timestamping https://dgsbl4vditpls.cloudfront.net/${DEMO_ARTIFACT_NAME}
+wget -q -O mender-demo-artifact.mender https://dgsbl4vditpls.cloudfront.net/${DEMO_ARTIFACT_NAME}
 
 retval=$?
 if [ $retval -ne 0 ]; then


### PR DESCRIPTION
```
Cherry-pick and squash of:
  Removed timestamping in wget, as busybox does not support it
  Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
  (cherry picked from commit 5dfb1fd1531a12f0c28cf56f2b50a2ceb597e155)

  Explicitly name the file from wget
  Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
  (cherry picked from commit 9c68012a67ce264ca47afdb7c149df0953085018)

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
Backported-by: Lluis Campos <lluis.campos@northern.tech>
```