### PR TITLE
Removed unused class variables from MenderAPI classes

### DIFF
--- a/tests/MenderAPI/auth_v2.py
+++ b/tests/MenderAPI/auth_v2.py
@@ -17,7 +17,6 @@
 from MenderAPI import *
 
 class DeviceAuthV2():
-    auth = None
 
     def __init__(self, auth):
         self.reset()

--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -18,8 +18,6 @@ from MenderAPI import *
 class Deployments(object):
     # track the last statistic for a deployment id
     last_statistic = {}
-    auth = None
-    auth_v2 = None
 
     def __init__(self, auth, auth_v2):
         self.reset()


### PR DESCRIPTION
auth_v2 and deployments have a declared a few unused class variables,
removing for clarity.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>