### PR TITLE
tests: Print exception info as soon as the failure happens.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,7 @@ def pytest_runtest_setup(item):
 
 def pytest_exception_interact(node, call, report):
     if report.failed:
+        logging.error("Test %s failed with exception:\n%s" % (str(node), call.excinfo.getrepr()))
         for log in log_files:
             logger.info("printing content of : %s" % log)
             logger.info("Running with PID: %d, PPID: %d" % (os.getpid(), os.getppid()))


### PR DESCRIPTION
This makes it easier to see exactly what has failed, and means you
don't have to wait until the end of a run to see what happened.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>