### PR TITLE
MEN-1939: Add request retrying for API calls.

### DIFF
--- a/tests/MenderAPI/__init__.py
+++ b/tests/MenderAPI/__init__.py
@@ -9,6 +9,8 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 # don't complain about non-verified ssl connections
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
+from requests_helpers import requests_retry
+
 from common import *
 from common_docker import *
 

--- a/tests/MenderAPI/auth_v2.py
+++ b/tests/MenderAPI/auth_v2.py
@@ -31,7 +31,7 @@ class DeviceAuthV2():
 
     def get_device(self, device_id):
         url = self.get_auth_v2_base_path() + device_id
-        return requests.get(url, verify=False, headers=self.auth.get_auth_token())
+        return requests_retry().get(url, verify=False, headers=self.auth.get_auth_token())
 
     def get_devices(self, expected_devices=1):
         return self.get_devices_status(expected_devices=expected_devices)
@@ -50,7 +50,7 @@ class DeviceAuthV2():
             sleeptime += 5
             try:
                 logger.info("getting all devices from :%s" % (device_status_path))
-                devices = requests.get(device_status_path, headers=self.auth.get_auth_token(), verify=False)
+                devices = requests_retry().get(device_status_path, headers=self.auth.get_auth_token(), verify=False)
                 assert devices.status_code == requests.status_codes.codes.ok
                 assert len(devices.json()) == expected_devices
                 break
@@ -80,10 +80,10 @@ class DeviceAuthV2():
         headers = {"Content-Type": "application/json"}
         headers.update(self.auth.get_auth_token())
 
-        r = requests.put(self.get_auth_v2_base_path() + "devices/%s/auth/%s/status" % (device_id, auth_set_id),
-                         verify=False,
-                         headers=headers,
-                         data=json.dumps({"status": status}))
+        r = requests_retry().put(self.get_auth_v2_base_path() + "devices/%s/auth/%s/status" % (device_id, auth_set_id),
+                                 verify=False,
+                                 headers=headers,
+                                 data=json.dumps({"status": status}))
         assert r.status_code == requests.status_codes.codes.no_content
 
     def check_expected_status(self, status, expected_value, max_wait=60*60, polling_frequency=1):
@@ -135,7 +135,7 @@ class DeviceAuthV2():
         headers = {"Content-Type": "application/json"}
         headers.update(self.auth.get_auth_token())
 
-        return requests.post(path, data=json.dumps(req), headers=headers, verify=False)
+        return requests_retry().post(path, data=json.dumps(req), headers=headers, verify=False)
 
     def delete_auth_set(self, did, aid):
         path = "https://%s/api/management/v2/devauth/devices/%s/auth/%s" % (get_mender_gateway(), did, aid)
@@ -143,12 +143,12 @@ class DeviceAuthV2():
         headers = {"Content-Type": "application/json"}
         headers.update(self.auth.get_auth_token())
 
-        return requests.delete(path, headers=headers, verify=False)
+        return requests_retry().delete(path, headers=headers, verify=False)
 
     def decommission(self, deviceID, expected_http_code=204):
         decommission_path_url = self.get_auth_v2_base_path() + "devices/" + str(deviceID)
-        r = requests.delete(decommission_path_url,
-                            verify=False,
-                            headers=self.auth.get_auth_token())
+        r = requests_retry().delete(decommission_path_url,
+                                    verify=False,
+                                    headers=self.auth.get_auth_token())
         assert r.status_code == expected_http_code
         logger.info("device [%s] is decommissioned" % (deviceID))

--- a/tests/MenderAPI/authentication.py
+++ b/tests/MenderAPI/authentication.py
@@ -92,7 +92,7 @@ class Authentication:
         self.auth_header = None
 
     def _do_login(self, username, password):
-        r = requests.post("https://%s/api/management/%s/useradm/auth/login" % (get_mender_gateway(), api_version), verify=False, auth=HTTPBasicAuth(username, password))
+        r = requests_retry().post("https://%s/api/management/%s/useradm/auth/login" % (get_mender_gateway(), api_version), verify=False, auth=HTTPBasicAuth(username, password))
         assert r.status_code == 200 or r.status_code == 401
 
         if r.status_code == 200:

--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -34,14 +34,14 @@ class Deployments(object):
     def upload_image(self, filename, description="abc"):
         image_path_url = self.get_deployments_base_path() + "artifacts"
 
-        r = requests.post(image_path_url,
-                          verify=False,
-                          headers=self.auth.get_auth_token(),
-                          files=(
-                              ("description", (None, description)),
-                              ("size", (None, str(os.path.getsize(filename)))),
-                              ("artifact", (filename, open(filename), "application/octet-stream"))
-                          ))
+        r = requests_retry().post(image_path_url,
+                                  verify=False,
+                                  headers=self.auth.get_auth_token(),
+                                  files=(
+                                      ("description", (None, description)),
+                                      ("size", (None, str(os.path.getsize(filename)))),
+                                      ("artifact", (filename, open(filename), "application/octet-stream"))
+                                  ))
 
         logger.info("Received image upload status code: " + str(r.status_code) + " with payload: " + str(r.text))
         assert r.status_code == requests.status_codes.codes.created
@@ -57,8 +57,8 @@ class Deployments(object):
         headers = {'Content-Type': 'application/json'}
         headers.update(self.auth.get_auth_token())
 
-        r = requests.post(deployments_path_url, headers=headers,
-                          data=json.dumps(trigger_data), verify=False)
+        r = requests_retry().post(deployments_path_url, headers=headers,
+                                  data=json.dumps(trigger_data), verify=False)
 
         logger.debug("triggering deployment with: " + json.dumps(trigger_data))
         logging.info("deployment returned: " + r.text)
@@ -71,7 +71,7 @@ class Deployments(object):
 
     def get_logs(self, device, deployment_id, expected_status=200):
         deployments_logs_url = self.get_deployments_base_path() + "deployments/%s/devices/%s/log" % (deployment_id, device)
-        r = requests.get(deployments_logs_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().get(deployments_logs_url, headers=self.auth.get_auth_token(), verify=False)
         assert r.status_code == expected_status
 
         logger.info("Logs contain " + str(r.text))
@@ -83,14 +83,14 @@ class Deployments(object):
         if status:
             deployments_status_url += "?status=%s" % (status)
 
-        r = requests.get(deployments_status_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().get(deployments_status_url, headers=self.auth.get_auth_token(), verify=False)
 
         assert r.status_code == requests.status_codes.codes.ok
         return json.loads(r.text)
 
     def get_statistics(self, deployment_id):
         deployments_statistics_url = self.get_deployments_base_path() + "deployments/%s/statistics" % (deployment_id)
-        r = requests.get(deployments_statistics_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().get(deployments_statistics_url, headers=self.auth.get_auth_token(), verify=False)
         assert r.status_code == requests.status_codes.codes.ok
 
         try:
@@ -152,41 +152,41 @@ class Deployments(object):
 
     def get_deployment_overview(self, deployment_id):
         deployments_overview_url = self.get_deployments_base_path() + "deployments/%s/devices" % (deployment_id)
-        r = requests.get(deployments_overview_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().get(deployments_overview_url, headers=self.auth.get_auth_token(), verify=False)
         assert r.status_code == requests.status_codes.codes.ok
         return r.json()
 
     def get_deployment(self, deployment_id):
         deployments_url = self.get_deployments_base_path() + "deployments/%s" % (deployment_id)
-        r = requests.get(deployments_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().get(deployments_url, headers=self.auth.get_auth_token(), verify=False)
         assert r.status_code == requests.status_codes.codes.ok
         return r.json()
 
     def get_artifact_details(self, artifact_id):
         artifact_url = self.get_deployments_base_path() + "artifacts/%s" % (artifact_id)
-        r = requests.get(artifact_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().get(artifact_url, headers=self.auth.get_auth_token(), verify=False)
         assert r.status_code == requests.status_codes.codes.ok
         return r.json()
 
     def delete_artifact(self, artifact_id):
         artifact_url = self.get_deployments_base_path() + "artifacts/%s" % (artifact_id)
-        r = requests.delete(artifact_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().delete(artifact_url, headers=self.auth.get_auth_token(), verify=False)
         assert r.status_code == requests.status_codes.codes.no_content
 
     def get_artifacts(self, auth_create_new_user=True):
         artifact_url = self.get_deployments_base_path() + "artifacts"
-        r = requests.get(artifact_url, headers=self.auth.get_auth_token(auth_create_new_user), verify=False)
+        r = requests_retry().get(artifact_url, headers=self.auth.get_auth_token(auth_create_new_user), verify=False)
         assert r.status_code == requests.status_codes.codes.ok
         return r.json()
 
     def abort(self, deployment_id):
         deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (deployment_id)
-        r = requests.put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "aborted"})
+        r = requests_retry().put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "aborted"})
         time.sleep(5)
         assert r.status_code == requests.status_codes.codes.no_content
 
     def abort_finished_deployment(self, deployment_id):
         deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (deployment_id)
-        r = requests.put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "aborted"})
+        r = requests_retry().put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "aborted"})
         time.sleep(5)
         assert r.status_code == requests.status_codes.codes.unprocessable_entity

--- a/tests/MenderAPI/inventory.py
+++ b/tests/MenderAPI/inventory.py
@@ -35,31 +35,31 @@ class Inventory():
         params = {}
         if has_group is not None:
             params = ({"has_group": has_group})
-        ret = requests.get(self.get_inv_base_path() + "devices", params=params, headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().get(self.get_inv_base_path() + "devices", params=params, headers=self.auth.get_auth_token(), verify=False)
         assert ret.status_code == requests.status_codes.codes.ok
         return ret.json()
 
     def get_device(self, device_id):
         headers = self.auth.get_auth_token()
         devurl = "%s%s/%s" % (self.get_inv_base_path(), "device", device_id)
-        ret = requests.get(devurl, headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().get(devurl, headers=self.auth.get_auth_token(), verify=False)
         return ret
 
 
     def get_groups(self):
-        ret = requests.get(self.get_inv_base_path() + "groups", headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().get(self.get_inv_base_path() + "groups", headers=self.auth.get_auth_token(), verify=False)
         assert ret.status_code == requests.status_codes.codes.ok
         return ret.json()
 
     def get_devices_in_group(self, group):
         req = "groups/%s/devices" % group
-        ret = requests.get(self.get_inv_base_path() + req, headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().get(self.get_inv_base_path() + req, headers=self.auth.get_auth_token(), verify=False)
         assert ret.status_code == requests.status_codes.codes.ok
         return ret.json()
 
     def get_device_group(self, device):
         req = "devices/%s/group" % device
-        ret = requests.get(self.get_inv_base_path() + req, headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().get(self.get_inv_base_path() + req, headers=self.auth.get_auth_token(), verify=False)
         assert ret.status_code == requests.status_codes.codes.ok
         return ret.json()
 
@@ -68,10 +68,10 @@ class Inventory():
         headers.update(self.auth.get_auth_token())
         body = '{"group":"%s"}' % group
         req = "devices/%s/group" % device
-        ret = requests.put(self.get_inv_base_path() + req, data=body, headers=headers, verify=False)
+        ret = requests_retry().put(self.get_inv_base_path() + req, data=body, headers=headers, verify=False)
         assert ret.status_code == requests.status_codes.codes.no_content
 
     def delete_device_from_group(self, device, group):
         req = "devices/%s/group/%s" % (device, group)
-        ret = requests.delete(self.get_inv_base_path() + req, headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().delete(self.get_inv_base_path() + req, headers=self.auth.get_auth_token(), verify=False)
         assert ret.status_code == requests.status_codes.codes.no_content

--- a/tests/MenderAPI/requests_helpers.py
+++ b/tests/MenderAPI/requests_helpers.py
@@ -1,0 +1,13 @@
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+# Will retry on 500 Server error
+def requests_retry(status_forcelist=[500, 502]):
+    s = requests.Session()
+    retries = Retry(total=5,
+                    backoff_factor=1,
+                    status_forcelist=status_forcelist,
+                    method_whitelist=['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'])
+    s.mount('https://', HTTPAdapter(max_retries=retries))
+    return s

--- a/tests/tests/conductor.py
+++ b/tests/tests/conductor.py
@@ -13,6 +13,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 import requests
+from MenderAPI import requests_retry
 
 
 class Conductor:
@@ -41,7 +42,7 @@ class Conductor:
             'q': query,
         }
 
-        rsp = requests.get(self.addr+self.API_WF_SEARCH, qs)
+        rsp = requests_retry().get(self.addr+self.API_WF_SEARCH, params=qs)
         rsp.raise_for_status()
         return rsp.json()
 

--- a/tests/tests/test_create_organization.py
+++ b/tests/tests/test_create_organization.py
@@ -42,7 +42,7 @@ class TestCreateOrganization(MenderTesting):
         logging.info("TestCreateOrganization: making request")
 
         payload = {"request_id": "123456", "organization": "tenant-foo", "email":"some.user@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
-        rsp = requests.post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
+        rsp = requests_retry().post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
 
         assert rsp.status_code == 202
 
@@ -59,29 +59,29 @@ class TestCreateOrganization(MenderTesting):
         smtp_mock.assert_called()
         logging.info("TestCreateOrganization: Assert ok.")
 
-        r = requests.post("https://%s/api/management/%s/useradm/auth/login" % (get_mender_gateway(), api_version),
-                verify=False,
-                auth=HTTPBasicAuth("some.user@example.com", "asdfqwer1234"))
+        r = requests_retry().post("https://%s/api/management/%s/useradm/auth/login" % (get_mender_gateway(), api_version),
+                                  verify=False,
+                                  auth=HTTPBasicAuth("some.user@example.com", "asdfqwer1234"))
         assert r.status_code == 200
 
     @pytest.mark.usefixtures("multitenancy_setup_without_client_with_smtp")
     def test_duplicate_organization_name(self):
         payload = {"request_id": "123456", "organization": "tenant-foo", "email":"some.user@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
-        rsp = requests.post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
+        rsp = requests_retry().post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
         assert rsp.status_code == 202
         payload = {"request_id": "123457", "organization": "tenant-foo", "email":"some.user2@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
-        rsp = requests.post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
+        rsp = requests_retry().post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
         assert rsp.status_code == 202
 
     @pytest.mark.usefixtures("multitenancy_setup_without_client_with_smtp")
     def test_duplicate_email(self):
         payload = {"request_id": "123456", "organization": "tenant-foo", "email":"some.user@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
-        rsp = requests.post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
+        rsp = requests_retry().post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
         logging.debug("first request to tenant adm returned: ", rsp.text)
         assert rsp.status_code == 202
 
         payload = {"request_id": "123457", "organization": "tenant-foo2", "email":"some.user@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
-        rsp = requests.post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
+        rsp = requests_retry().post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
         logging.debug("second request to tenant adm returned: ", rsp.text)
         assert rsp.status_code == 409
 


### PR DESCRIPTION
This is motivated by the extremely unpredictable issue where MongoDB
will either return I/O timeout or connection refused, both of which
seem to be caused by high load. It is a frequently occurring issue in
our parallel tests, but when testing manually the issue always seems
to go away on subsequent attempts.

Hence this fix to add a retry mechanism when doing API requests and
the server returns 500 Server Error (and only then).

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>