### PR TITLE
tests: enterprise fixture names

### DIFF
--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -202,7 +202,7 @@ def running_custom_production_setup(request):
 
 
 @pytest.fixture(scope="function")
-def multitenancy_setup_without_client(request):
+def enterprise_no_client(request):
     if not conftest.run_tenant_tests:
         pytest.skip("Tenant tests disabled")
 
@@ -228,7 +228,7 @@ def multitenancy_setup_without_client(request):
 
 
 @pytest.fixture(scope="function")
-def standard_setup_one_client_bootstrapped_with_s3_and_mt(request):
+def enterprise_client_s3(request):
     if not conftest.run_tenant_tests:
         pytest.skip("Tenant tests disabled")
 
@@ -256,7 +256,7 @@ def standard_setup_one_client_bootstrapped_with_s3_and_mt(request):
     request.addfinalizer(fin)
 
 @pytest.fixture(scope="function")
-def multitenancy_setup_without_client_with_smtp(request):
+def enterprise_no_client_smtp(request):
     if not conftest.run_tenant_tests:
         pytest.skip("Tenant tests disabled")
 

--- a/tests/tests/test_00_multi_tenancy.py
+++ b/tests/tests/test_00_multi_tenancy.py
@@ -50,7 +50,7 @@ class TestMultiTenancy(MenderTesting):
                     skip_reboot_verification=True,
                     hosts=get_mender_client_by_container_name(mender_client_container))
 
-    @pytest.mark.usefixtures("multitenancy_setup_without_client")
+    @pytest.mark.usefixtures("enterprise_no_client")
     def test_token_validity(self):
         """ verify that only devices with valid tokens can bootstrap
             successfully to a multitenancy setup """
@@ -98,7 +98,7 @@ class TestMultiTenancy(MenderTesting):
         set_correct_tenant_token(token)
         auth_v2.get_devices(expected_devices=1)
 
-    @pytest.mark.usefixtures("multitenancy_setup_without_client")
+    @pytest.mark.usefixtures("enterprise_no_client")
     def test_artifacts_exclusive_to_user(self):
         users = [
             {"email": "foo1@foo1.com", "password": "hunter2hunter2", "username": "foo1"},
@@ -124,7 +124,7 @@ class TestMultiTenancy(MenderTesting):
             assert len(artifacts_for_user)
             assert artifacts_for_user[0]["name"] == user["email"]
 
-    @pytest.mark.usefixtures("multitenancy_setup_without_client")
+    @pytest.mark.usefixtures("enterprise_no_client")
     def test_clients_exclusive_to_user(self):
         users = [
             {
@@ -181,7 +181,7 @@ class TestMultiTenancy(MenderTesting):
             else:
                 assert False, "decommissioned device still available in inventory"
 
-    @pytest.mark.usefixtures("multitenancy_setup_without_client")
+    @pytest.mark.usefixtures("enterprise_no_client")
     def test_multi_tenancy_deployment(self):
         """ Simply make sure we are able to run the multi tenancy setup and
            bootstrap 2 different devices to different tenants """
@@ -219,7 +219,7 @@ class TestMultiTenancy(MenderTesting):
                                 fail=user["fail"])
 
 
-    @pytest.mark.usefixtures("multitenancy_setup_without_client")
+    @pytest.mark.usefixtures("enterprise_no_client")
     def test_multi_tenancy_deployment_aborting(self):
         """ Simply make sure we are able to run the multi tenancy setup and
            bootstrap 2 different devices to different tenants """
@@ -250,7 +250,7 @@ class TestMultiTenancy(MenderTesting):
                     hosts=get_mender_client_by_container_name(user["container"]))
 
     @MenderTesting.aws_s3
-    @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped_with_s3_and_mt")
+    @pytest.mark.usefixtures("enterprise_client_s3")
     def test_multi_tenancy_deployment_s3(self):
 
         def verify_object_id_and_tagging():

--- a/tests/tests/test_create_organization.py
+++ b/tests/tests/test_create_organization.py
@@ -29,7 +29,7 @@ import asyncore
 from MenderAPI import *
 
 class TestCreateOrganization(MenderTesting):
-    @pytest.mark.usefixtures("multitenancy_setup_without_client_with_smtp")
+    @pytest.mark.usefixtures("enterprise_no_client_smtp")
     def test_success(self):
 
         logging.info("Starting TestCreateOrganization")
@@ -64,7 +64,7 @@ class TestCreateOrganization(MenderTesting):
                                   auth=HTTPBasicAuth("some.user@example.com", "asdfqwer1234"))
         assert r.status_code == 200
 
-    @pytest.mark.usefixtures("multitenancy_setup_without_client_with_smtp")
+    @pytest.mark.usefixtures("enterprise_no_client_smtp")
     def test_duplicate_organization_name(self):
         payload = {"request_id": "123456", "organization": "tenant-foo", "email":"some.user@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
         rsp = requests_retry().post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
@@ -73,7 +73,7 @@ class TestCreateOrganization(MenderTesting):
         rsp = requests_retry().post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)
         assert rsp.status_code == 202
 
-    @pytest.mark.usefixtures("multitenancy_setup_without_client_with_smtp")
+    @pytest.mark.usefixtures("enterprise_no_client_smtp")
     def test_duplicate_email(self):
         payload = {"request_id": "123456", "organization": "tenant-foo", "email":"some.user@example.com", "password": "asdfqwer1234", "g-recaptcha-response": "foobar"}
         rsp = requests_retry().post("https://%s/api/management/v1/tenantadm/tenants" % get_mender_gateway(), data=payload, verify=False)

--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -169,17 +169,17 @@ class TestPreauth(TestPreauthBase):
 
 class TestPreauthMultiTenant(TestPreauthBase):
     @pytest.mark.skip(reason="there is a problem with this test: MEN-1797")
-    @pytest.mark.usefixtures("multitenancy_setup_without_client")
+    @pytest.mark.usefixtures("enterprise_no_client")
     def test_ok_preauth_and_bootstrap(self):
         self.__create_tenant_and_container()
         self.do_test_ok_preauth_and_bootstrap()
 
-    @pytest.mark.usefixtures("multitenancy_setup_without_client")
+    @pytest.mark.usefixtures("enterprise_no_client")
     def test_ok_preauth_and_remove(self):
         self.__create_tenant_and_container()
         self.do_test_ok_preauth_and_remove()
 
-    @pytest.mark.usefixtures("multitenancy_setup_without_client")
+    @pytest.mark.usefixtures("enterprise_no_client")
     def test_fail_preauth_existing(self):
         self.__create_tenant_and_container()
         self.do_test_fail_preauth_existing()


### PR DESCRIPTION
no too much refactoring - enterprise layers are already used
in several fixtures pertaining to MT.

renamed them as 'enterprise', shortened fixture names and that's about it.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>

https://tracker.mender.io/browse/MEN-2657