### PR TITLE
extend conductor configuration with logging configuartion file

### DIFF
--- a/conductor/server/config/log4j.properties
+++ b/conductor/server/config/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -78,6 +78,7 @@ services:
             - ./conductor/server/config:/app/config
         environment:
             - CONFIG_PROP=config.properties
+            - LOG_CONFIG=/app/config/log4j.properties
             - CONDUCTOR_JAVA_OPTS=-Xms128m -Xmx128m
         ports:
             - "8080:8080"

--- a/template/prod.yml
+++ b/template/prod.yml
@@ -124,6 +124,7 @@ services:
             - ./conductor/server/config:/app/config
         environment:
             - CONFIG_PROP=config.properties
+            - LOG_CONFIG=/app/config/log4j.properties
 
     mender-mongo:
         volumes:


### PR DESCRIPTION
Conductor should use INFO as a default log level, but with default configuartion, it's logging DEBUGs.

Issues: https://github.com/Netflix/conductor/issues/1127, https://tracker.mender.io/browse/MEN-2644
