### PR TITLE
mark MT tests as -Enterprise for test suite selection

### DIFF
--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -203,8 +203,8 @@ def running_custom_production_setup(request):
 
 @pytest.fixture(scope="function")
 def enterprise_no_client(request):
-    if not conftest.run_tenant_tests:
-        pytest.skip("Tenant tests disabled")
+    if conftest.is_integration_branch:
+        pytest.skip("Enterprise tests disabled on integration branches")
 
     stop_docker_compose()
     reset_mender_api()
@@ -229,8 +229,8 @@ def enterprise_no_client(request):
 
 @pytest.fixture(scope="function")
 def enterprise_client_s3(request):
-    if not conftest.run_tenant_tests:
-        pytest.skip("Tenant tests disabled")
+    if conftest.is_integration_branch:
+        pytest.skip("Enterprise tests disabled on integration branches")
 
     stop_docker_compose()
     reset_mender_api()
@@ -257,8 +257,8 @@ def enterprise_client_s3(request):
 
 @pytest.fixture(scope="function")
 def enterprise_no_client_smtp(request):
-    if not conftest.run_tenant_tests:
-        pytest.skip("Tenant tests disabled")
+    if conftest.is_integration_branch:
+        pytest.skip("Enterprise tests disabled on integration branches")
 
     stop_docker_compose()
     reset_mender_api()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ docker_lock = filelock.FileLock("docker_lock")
 production_setup_lock = filelock.FileLock(".exposed_ports_lock")
 
 inline_logs = False
-run_tenant_tests = True
+is_integration_branch = False
 machine_name = None
 
 try:
@@ -112,9 +112,10 @@ def pytest_configure(config):
 
     version = subprocess.check_output(["../extra/release_tool.py", "--version-of", "integration"])
     if re.search("(^|/)[0-9]+\.[0-9]+\.[x0-9]+", version):
-        # Don't run tenant tests for release branches.
-        global run_tenant_tests
-        run_tenant_tests = False
+        # Don't run enterprise tests for release branches.
+        # Has to do with tenantadm's release cycle (master only), but we're forced to skip the whole enterprise set.
+        global is_integration_branch
+        is_integration_branch = True
 
     MenderTesting.set_test_conditions(config)
 

--- a/tests/tests/test_00_multi_tenancy.py
+++ b/tests/tests/test_00_multi_tenancy.py
@@ -25,7 +25,7 @@ from common_update import update_image_successful, update_image_failed, \
 from mendertesting import MenderTesting
 from tests import artifact_lock
 
-class TestMultiTenancy(MenderTesting):
+class TestMultiTenancyEnterprise(MenderTesting):
     def mender_log_contains_aborted_string(self, mender_client_container="mender-client"):
         expected_string = "deployment aborted at the backend"
 

--- a/tests/tests/test_create_organization.py
+++ b/tests/tests/test_create_organization.py
@@ -28,7 +28,7 @@ from threading import Thread
 import asyncore
 from MenderAPI import *
 
-class TestCreateOrganization(MenderTesting):
+class TestCreateOrganizationEnterprise(MenderTesting):
     @pytest.mark.usefixtures("enterprise_no_client_smtp")
     def test_success(self):
 

--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -167,7 +167,7 @@ class TestPreauth(TestPreauthBase):
         self.do_test_fail_preauth_existing()
 
 
-class TestPreauthMultiTenant(TestPreauthBase):
+class TestPreauthEnterprise(TestPreauthBase):
     @pytest.mark.skip(reason="there is a problem with this test: MEN-1797")
     @pytest.mark.usefixtures("enterprise_no_client")
     def test_ok_preauth_and_bootstrap(self):


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-2658

we're unifying test selection mechanism - in both integration and backend-integration, tests will be tagged as Enterprise, and we'll select based on this suffix via pytest -k.

all tests using the enterprise setup are therefore tagged as such.
some code review reminded me that we already have a test selection mechanism - the $SPECIFIC_INTEGRATION_TEST env var accepted by run.sh. so basically it seems we're all set for test selection.

minor remarks:
- the name of the var could be changed to $SPECIFIC_INTEGRATION_TEST***S***, but I don't want to touch it - it would ripple through jenkins config, possibly mender-qa, god knows what else. it's 'good enough'
- I refactored slightly the stuff around 'run_multitenant_tests' flag as it was confusing - see commit message

@kacf your review is important here
 