### PR TITLE
MEN-2682: Allow demo script to run with existing demo user

### DIFF
--- a/demo
+++ b/demo
@@ -181,6 +181,7 @@ done
 
 
 echo "Creating a new user..."
+UPLOAD_ARTIFACT="true"
 RETRIES=0
 while :
 do
@@ -191,12 +192,23 @@ do
              --password=${PASSWORD}
     retval=$?
     case $retval in
-        0) echo "New user created."; break ;;
-        5) # Since the password is not cached in between invocations, there is no way to upload an Artifact.
-            echo "The user already exists"
-            echo "Since the demo script does not cache passwords, therefore"
-            echo "run 'demo down' if you want to delete the user, and create a new demo user"
-            exit 0 ;;
+        0)
+            echo "New user created."
+            echo "****************************************"
+            echo
+            echo "Username: mender-demo@example.com"
+            echo  "Login password: ${PASSWORD}"
+            echo
+            echo "****************************************"
+            echo "Please keep the password available, it will not be cached by the login script."
+            break ;;
+        5) # If the user exists, skip uploading the Artifact
+            UPLOAD_ARTIFACT=""
+            echo "The user already exists. Skipping"
+            echo "If you don't remember the password, you can run '$(basename $0) down' to delete"
+            echo "the old user and rerun '$(basename $0) up' to create a new one."
+            echo "Please note that all data will be deleted from the old demo server."
+            break ;;
         *) echo "docker exec error: " $retval; exit $retval ;;
     esac
     if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
@@ -207,83 +219,78 @@ do
     sleep 5
 done
 
-echo "Getting JWT Token..."
-RETRIES=0
-until [[ "$JWT" != "" ]]; do
-    JWT=$(curl --silent -k -X POST -u ${USER}:${PASSWORD}\
-        --fail\
-        --connect-timeout 5\
-        $MENDER_SERVER_URI/api/management/v1/useradm/auth/login)
+if [[ $UPLOAD_ARTIFACT == "true" ]]; then
+
+    echo "Getting JWT Token..."
+    RETRIES=0
+    until [[ "$JWT" != "" ]]; do
+        JWT=$(curl --silent -k -X POST -u ${USER}:${PASSWORD}\
+            --fail\
+            --connect-timeout 5\
+            $MENDER_SERVER_URI/api/management/v1/useradm/auth/login)
+        retval=$?
+        if [[ $retval -ne 0 ]]; then
+            echo "Failed to get the 'JWT' token from the useradm service."
+            echo "This is needed in order to upload the demo Artifact."
+            echo "curl exit code: " $retval
+            echo "Retrying in 5..."
+        fi
+        if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
+            echo "Retried $RETRIES times without success. Giving up."
+            exit 1
+        fi
+        RETRIES=$((RETRIES+1))
+        sleep 5
+    done
+    echo "JWT token: " $JWT
+
+    echo "Uploading the Artifact to the server..."
+    cout=
+    RETRIES=0
+    while :
+    do
+        cout=$(curl --silent -k -X POST \
+                    --fail\
+                    --show-error\
+                    --connect-timeout 5\
+                    --header "Authorization: Bearer ${JWT}"\
+                    --form "size=${ARTIFACT_SIZE_BYTES}"\
+                    --form "artifact=@${DEMO_ARTIFACT_NAME}"\
+                    $MENDER_SERVER_URI/api/management/v1/deployments/artifacts)
+        retval=$?
+        if [[ $retval -ne 0 ]]; then
+            echo "Failed to upload the Artifact to the demo server. curl error code: " $retval
+            echo "Sleeping for 5 seconds before making another attempt..."
+        else
+            break
+        fi
+        if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
+            echo "Retried $RETRIES times without success. Giving up."
+            exit 1
+        fi
+        RETRIES=$((RETRIES+1))
+        sleep 5
+    done
+
+    errout=$(jq '.error' <<< $cout)
+
     retval=$?
     if [[ $retval -ne 0 ]]; then
-        echo "Failed to get the 'JWT' token from the useradm service."
-        echo "This is needed in order to upload the demo Artifact."
-        echo "curl exit code: " $retval
-        echo "Retrying in 5..."
+        echo "Failed to parse the json response from the Mender server"
+        echo "Response: "
+        echo $cout
+        exit $retval
     fi
-    if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
-        echo "Retried $RETRIES times without success. Giving up."
-        exit 1
-    fi
-    RETRIES=$((RETRIES+1))
-    sleep 5
-done
 
-echo "JWT token: " $JWT
+    case "$errout" in
+    " Artifact not unique"*) echo "Artifact already exists on the server" ;;
+        "") echo "Artifact uploaded to the demo server" ;;
+        *) echo "Uploading the demo Artifact failed with error: " $errout
+        exit 1 ;;
+    esac
 
-echo "Uploading the Artifact to the server..."
-cout=
-RETRIES=0
-while :
-do
-    cout=$(curl --silent -k -X POST \
-                --fail\
-                --show-error\
-                --connect-timeout 5\
-                --header "Authorization: Bearer ${JWT}"\
-                --form "size=${ARTIFACT_SIZE_BYTES}"\
-                --form "artifact=@${DEMO_ARTIFACT_NAME}"\
-                $MENDER_SERVER_URI/api/management/v1/deployments/artifacts)
-    retval=$?
-    if [[ $retval -ne 0 ]]; then
-        echo "Failed to upload the Artifact to the demo server. curl error code: " $retval
-        echo "Sleeping for 5 seconds before making another attempt..."
-    else
-        break
-    fi
-    if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
-        echo "Retried $RETRIES times without success. Giving up."
-        exit 1
-    fi
-    RETRIES=$((RETRIES+1))
-    sleep 5
-done
-
-errout=$(jq '.error' <<< $cout)
-
-retval=$?
-
-if [[ $retval -ne 0 ]]; then
-    echo "Failed to parse the json response from the Mender server"
-    echo "Response: "
-    echo $cout
-    exit $retval
 fi
 
-case "$errout" in
-   " Artifact not unique"*) echo "Artifact already exists on the server" ;;
-    "") echo "Artifact uploaded to the demo server" ;;
-    *) echo "Uploading the demo Artifact failed with error: " $errout
-       exit 1 ;;
-esac
-
-echo "****************************************"
-echo
-echo "Username: mender-demo@example.com"
-echo  "Login password: ${PASSWORD}"
-echo
-echo "****************************************"
-echo "Please keep the password available, it will not be cached by the login script."
 echo "Backend ready and running in the background. Press Enter to show the logs."
 echo "Press Ctrl-C to stop the backend and quit."
 read -se

--- a/demo
+++ b/demo
@@ -6,9 +6,7 @@ usage() {
     cat <<EOF
 $(basename $0) [options] docker-options
 
---client
-	Enable emulated client. To enable more than one client, you can use:
-	  $(basename $0) --client scale mender-client=2
+--client    Enable emulated client
 
 All other arguments passed to this command are passed directly to
 docker-compose, if you want to run the demo, run:


### PR DESCRIPTION
Modify the design so that instead of failing on existing user, it just
skips uploading the Artifact (it assumes it was successfully uploaded
when the user was created).

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>