### PR TITLE
release-tool: select-test-suite command

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -2198,6 +2198,13 @@ def select_test_suite(git_checkout):
     else:
         return "all"
 
+def do_select_test_suite():
+    """Process --select-test-suite argument."""
+
+    # assume git repos are checked out a level above integration
+    git_checkout = os.path.abspath(os.path.join(integration_dir(), '..'))
+    print(select_test_suite(git_checkout))
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-g", "--version-of", dest="version_of", metavar="SERVICE",
@@ -2233,6 +2240,8 @@ def main():
                         help="Start the release process (interactive)")
     parser.add_argument("--simulate-push", action="store_true",
                         help="Simulate (don't do) pushes")
+    parser.add_argument("--select-test-suite", action="store_true",
+                        help="Based on checked out git revisions, decide which integration suite must run ('open', 'enterprise', 'all').")
     parser.add_argument("-n", "--dry-run", action="store_true",
                         help="Don't take any action at all")
     parser.add_argument("--verify-integration-references", action="store_true",
@@ -2279,6 +2288,8 @@ def main():
         do_release()
     elif args.verify_integration_references:
         do_verify_integration_references(args, optional_too=args.all)
+    elif args.select_test_suite:
+        do_select_test_suite()
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-2660

the command will be used right before running integration tests to determine which test suite to run - open, enterprise, or both.

it reaches out into git repositories to check which components are not in recent master version. this is taken to mean that we're e.g. on a PR, or on a custom revision in general (i.e. this component 'changed').

more specifically, we're checking backend services versions, because they can potentially restrict the test suite to 'just open' or 'just enterprise' tests. 

the rules for test selection are slightly tricky:
- if we're building strictly open services - we must run all tests. open services occur in both open and enterprise setups
- if we're building strictly enteprise services - of course those appear only in the enterprise setup
- if we're building open services, but they have their enteprise counterparts (deployments, useradm,...), we can safely run just 'open' tests. 

there are some corner cases too:
- we might not be building any services at all. maybe we're building mender-cli, or the gateway - make no assumptions and just run everything then

one practical remark:
I could have used the existing component maps to indicate - which components are 'services', which are open, open-with-enterprise, or enterprise.
instead I opted for separate lists (sets) specifying those services verbatim. I didn't want to pollute the existing structs, this way it's clear these entities have different purposes. the component maps are still used strictly for mapping git to docker images/containers. 

