### PR TITLE
Fix/e2e test ci setup

### DIFF
--- a/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -44,8 +44,6 @@ services:
     ##
 
   mender-gui:
-    build:
-      dockerfile: ${GUI_REPOSITORY}/Dockerfile
-      context: ${GUI_REPOSITORY}
+    image: mendersoftware/gui:pr
     environment:
       - GATEWAY_IP=docker.mender.io


### PR DESCRIPTION
This is a preparatory PR to allow https://github.com/mendersoftware/gui/pull/526 to reuse the prior created gui image and cut down ci time