### PR TITLE
tests/run: fix unquoted param expansion

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -185,4 +185,4 @@ if [[ -n $SPECIFIC_INTEGRATION_TEST ]]; then
     SPECIFIC_INTEGRATION_TEST_ARG="-k $SPECIFIC_INTEGRATION_TEST"
 fi
 
-python2 -m pytest $XDIST_ARGS $MAX_FAIL_ARG -s --verbose --junitxml=results.xml $HTML_REPORT $pass_args $SPECIFIC_INTEGRATION_TEST_ARG $DEFAULT_TESTS
+python2 -m pytest $XDIST_ARGS $MAX_FAIL_ARG -s --verbose --junitxml=results.xml $HTML_REPORT $pass_args "$SPECIFIC_INTEGRATION_TEST_ARG" $DEFAULT_TESTS


### PR DESCRIPTION
...for SPECIFIC_INTEGRATION_TEST_ARG.

otherwise, the arg will be split on whitespaces, which
is critical to avoid here.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>