### PR TITLE
Amend quoting fix for test/run.sh script

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -182,7 +182,16 @@ if ! pip2 list|grep -e pytest-html >/dev/null 2>&1; then
 fi
 
 if [[ -n $SPECIFIC_INTEGRATION_TEST ]]; then
-    SPECIFIC_INTEGRATION_TEST_ARG="-k $SPECIFIC_INTEGRATION_TEST"
+    SPECIFIC_INTEGRATION_TEST_FLAG="-k"
 fi
 
-python2 -m pytest $XDIST_ARGS $MAX_FAIL_ARG -s --verbose --junitxml=results.xml $HTML_REPORT $pass_args "$SPECIFIC_INTEGRATION_TEST_ARG" $DEFAULT_TESTS
+python2 -m pytest \
+    $XDIST_ARGS \
+    $MAX_FAIL_ARG \
+    -s \
+    --verbose \
+    --junitxml=results.xml \
+    $HTML_REPORT \
+    $pass_args \
+    $SPECIFIC_INTEGRATION_TEST_FLAG "$SPECIFIC_INTEGRATION_TEST" \
+    $DEFAULT_TESTS


### PR DESCRIPTION
The previous fix wasn't working properly on GitLab nor for Jenkins.

Actually, I think that integration tests for this specific selection case (not Enterprise) it has never worked in Jenkins. The wicked situation here is that any build launched with a PR in integration repo will always resolve to run "all" tests, hence this specific case can only be tested once the code hits master.

Commit follows:

```
commit 1ebbcd48c9f0830b2b5d744c85f58b29d6f3f356
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Fri Aug 30 09:36:29 2019 +0200

Amend quoting fix for test/run.sh script

So that it can correctly evaluate any combination of tests expressions
passed through SPECIFIC_INTEGRATION_TEST. This will work both when the
caller uses single quotes in the variable or escaped double quotes.

This commit amends incomplete fix from commit 743622a

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```