### PR TITLE
Change the trigger build string to reflect the actual behavior.

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -1299,7 +1299,7 @@ def trigger_build(state, tag_avail):
         for param in sorted(params.keys()):
             print(fmt_str % (param, params[param]))
 
-        reply = ask("Will trigger a build with these values, ok? (yes) ")
+        reply = ask("Will trigger a build with these values, ok? (no) ")
         if reply.startswith("Y") or reply.startswith("y"):
             break
 


### PR DESCRIPTION
The default behavior for triggering the build is to not start it
but the message presented to the user is indicating that it will be
started by default.

Changelog: none


Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>