### PR TITLE
Remove need for wget in demo script, and resolve annoying bug.

### DIFF
--- a/demo
+++ b/demo
@@ -27,8 +27,7 @@ DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME:-$(tr -d ".-" <<<${PWD
 
 CLIENT=
 CLIENT_ARGS="-f docker-compose.client.yml -f docker-compose.client.demo.yml"
-# The demo environment has some external dependencies upon: wget, curl, jq
-hash wget 2>/dev/null || { echo >&2 "The demo script requires the 'wget' tool to be available. Aborting."; exit 1; }
+# The demo environment has some external dependencies upon: curl, jq
 hash curl 2>/dev/null || { echo >&2 "The demo script requires the 'curl' tool to be available. Aborting."; exit 1; }
 hash jq 2>/dev/null || { echo >&2 "The demo script requires the 'jq' tool to be available. Aborting."; exit 1; }
 
@@ -58,7 +57,7 @@ done
 # Check if the demo-Artifact has been downloaded,
 # or if there exists a newer one in storage.
 DEMO_ARTIFACT_NAME="mender-demo-artifact.mender"
-wget -q -O mender-demo-artifact.mender https://dgsbl4vditpls.cloudfront.net/${DEMO_ARTIFACT_NAME}
+curl -sz mender-demo-artifact.mender -o mender-demo-artifact.mender https://dgsbl4vditpls.cloudfront.net/${DEMO_ARTIFACT_NAME}
 
 retval=$?
 if [ $retval -ne 0 ]; then


### PR DESCRIPTION
This has been bugging me for a long time. Wget's behavior is extremely
annoying when it comes to handling overwriting of files. Its default
behavior is to not overwrite but to create a new file with a '.1'
suffix which is virtually never what you want (great default behavior,
aye?). The workaround for this is to add `no_clobber = on` in your
`~/.wgetrc` file, which then instead refuses to overwrite. Still not
really what I want (I want to overwrite), but ok, at least I will get
a message about it.

But it gets worse: `no_clobber` is impossible to turn off from the
command line, and you cannot use any options like forcing to
overwrite, checking timestamp or anything, to override it. Therefore
it is impossible for the demo script to take this into account, and
anyone like me with a sane default in their configuration, will be met
with this fatal message every time the demo script is run, except for
the very first time:

```
Failed to download the demo Artifact
```

And yes, *every time*. Doesn't matter if you run `demo up`, `demo
down`, `demo pull`, whatever. One could argue that it should not
download the artifact at all unless you're calling `up`, but that
would not solve the problem if you repeat `demo up`, which the virtual
onboarding demo indeed requires. Deleting the artifact on every
invokation would work, but is incredibly inefficient.

The solution is to switch to curl that actually has good behavior,
which also gets rid of the wget requirement. With the given options,
the download will be attempted on every invokation, but will just
(silently) return '304 Not modified' if it's already downloaded and
hasn't been updated upstream.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>