### PR TITLE
Fix excessive builds

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -16,7 +16,7 @@ git:
     - deployments-enterprise
     docker_container:
     - mender-deployments
-    release_component: false
+    release_component: true
 
   deviceadm:
     docker_image:
@@ -112,7 +112,7 @@ git:
     - useradm-enterprise
     docker_container:
     - mender-useradm
-    release_component: false
+    release_component: true
 
 docker_image:
   deployments:
@@ -127,7 +127,7 @@ docker_image:
     - deployments-enterprise
     docker_container:
     - mender-deployments
-    release_component: false
+    release_component: true
 
   deviceadm:
     git:
@@ -225,7 +225,7 @@ docker_image:
     - useradm-enterprise
     docker_container:
     - mender-useradm
-    release_component: false
+    release_component: true
 
 docker_container:
   mender-deployments:

--- a/component-maps.yml
+++ b/component-maps.yml
@@ -1,0 +1,314 @@
+# A map that lists all our git repositories, docker images, and docker container
+# names, and how they are associated to one another. When you add something to
+# this list, make sure to add it to all three sections: "git", "docker_image"
+# and "docker_container". Binary tools that don't have Docker components, will
+# only have the "git" part.
+git:
+  deployments:
+    docker_image:
+    - deployments
+    docker_container:
+    - mender-deployments
+    release_component: true
+
+  deployments-enterprise:
+    docker_image:
+    - deployments-enterprise
+    docker_container:
+    - mender-deployments
+    release_component: false
+
+  deviceadm:
+    docker_image:
+    - deviceadm
+    docker_container:
+    - mender-device-adm
+    release_component: false
+
+  deviceauth:
+    docker_image:
+    - deviceauth
+    docker_container:
+    - mender-device-auth
+    release_component: true
+
+  gui:
+    docker_image:
+    - gui
+    docker_container:
+    - mender-gui
+    release_component: true
+
+  integration:
+    docker_image: []
+    docker_container: []
+    release_component: true
+
+  inventory:
+    docker_image:
+    - inventory
+    docker_container:
+    - mender-inventory
+    release_component: true
+
+  mender:
+    docker_image:
+    - mender-client-qemu
+    - mender-client-docker
+    - mender-client-qemu-rofs
+    docker_container:
+    - mender-client
+    release_component: true
+
+  mender-api-gateway-docker:
+    docker_image:
+    - api-gateway
+    docker_container:
+    - mender-api-gateway
+    release_component: true
+
+  mender-artifact:
+    docker_image: []
+    docker_container: []
+    release_component: true
+
+  mender-cli:
+    docker_image: []
+    docker_container: []
+    release_component: true
+
+  mender-conductor:
+    docker_image:
+    - mender-conductor
+    - email-sender
+    docker_container:
+    - mender-conductor
+    - mender-email-sender
+    release_component: true
+
+  mender-conductor-enterprise:
+    docker_image:
+    - mender-conductor-enterprise
+    docker_container:
+    - mender-conductor
+    release_component: true
+
+  tenantadm:
+    docker_image:
+    - tenantadm
+    docker_container:
+    - mender-tenantadm
+    release_component: false
+
+  useradm:
+    docker_image:
+    - useradm
+    docker_container:
+    - mender-useradm
+    release_component: true
+
+  useradm-enterprise:
+    docker_image:
+    - useradm-enterprise
+    docker_container:
+    - mender-useradm
+    release_component: false
+
+docker_image:
+  deployments:
+    git:
+    - deployments
+    docker_container:
+    - mender-deployments
+    release_component: true
+
+  deployments-enterprise:
+    git:
+    - deployments-enterprise
+    docker_container:
+    - mender-deployments
+    release_component: false
+
+  deviceadm:
+    git:
+    - deviceadm
+    docker_container:
+    - mender-device-adm
+    release_component: false
+
+  deviceauth:
+    git:
+    - deviceauth
+    docker_container:
+    - mender-device-auth
+    release_component: true
+
+  gui:
+    git:
+    - gui
+    docker_container:
+    - mender-gui
+    release_component: true
+
+  inventory:
+    git:
+    - inventory
+    docker_container:
+    - mender-inventory
+    release_component: true
+
+  mender-client-docker:
+    git:
+    - mender
+    docker_container:
+    - mender-client
+    release_component: true
+
+  mender-client-qemu:
+    git:
+    - mender
+    docker_container:
+    - mender-client
+    release_component: true
+
+  mender-client-qemu-rofs:
+    git:
+    - mender
+    docker_container:
+    - mender-client
+    release_component: true
+
+  api-gateway:
+    git:
+    - mender-api-gateway-docker
+    docker_container:
+    - mender-api-gateway
+    release_component: true
+
+  mender-conductor:
+    git:
+    - mender-conductor
+    docker_container:
+    - mender-conductor
+    release_component: true
+
+  email-sender:
+    git:
+    - mender-conductor
+    docker_container:
+    - mender-email-sender
+    release_component: true
+
+  mender-conductor-enterprise:
+    git:
+    - mender-conductor-enterprise
+    docker_container:
+    - mender-conductor
+    release_component: true
+
+  tenantadm:
+    git:
+    - tenantadm
+    docker_container:
+    - mender-tenantadm
+    release_component: false
+
+  useradm:
+    git:
+    - useradm
+    docker_container:
+    - mender-useradm
+    release_component: true
+
+  useradm-enterprise:
+    git:
+    - useradm-enterprise
+    docker_container:
+    - mender-useradm
+    release_component: false
+
+docker_container:
+  mender-deployments:
+    git:
+    - deployments
+    - deployments-enterprise
+    docker_image:
+    - deployments
+    - deployments-enterprise
+    release_component: true
+
+  mender-device-auth:
+    git:
+    - deviceauth
+    docker_image:
+    - deviceauth
+    release_component: true
+
+  mender-device-adm:
+    git:
+    - deviceadm
+    docker_image:
+    - deviceadm
+    release_component: false
+
+  mender-gui:
+    git:
+    - gui
+    docker_image:
+    - gui
+    release_component: true
+
+  mender-inventory:
+    git:
+    - inventory
+    docker_image:
+    - inventory
+    release_component: true
+
+  mender-client:
+    git:
+    - mender
+    docker_image:
+    - mender-client-qemu
+    - mender-client-docker
+    - mender-client-qemu-rofs
+    release_component: true
+
+  mender-api-gateway:
+    git:
+    - mender-api-gateway-docker
+    docker_image:
+    - api-gateway
+    release_component: true
+
+  mender-conductor:
+    git:
+    - mender-conductor
+    - mender-conductor-enterprise
+    docker_image:
+    - mender-conductor
+    - mender-conductor-enterprise
+    release_component: true
+
+  mender-email-sender:
+    git:
+    - mender-conductor
+    docker_image:
+    - email-sender
+    release_component: true
+
+  mender-tenantadm:
+    git:
+    - tenantadm
+    docker_image:
+    - tenantadm
+    release_component: false
+
+  mender-useradm:
+    git:
+    - useradm
+    - useradm-enterprise
+    docker_image:
+    - useradm
+    - useradm-enterprise
+    release_component: true

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -53,234 +53,7 @@ DRY_RUN = False
 USE_GITLAB = False
 
 class Component:
-    # A map that lists all our git repositories, docker images, and docker
-    # container names, and how they are associated to one another. When you add
-    # something to this list, make sure to add it to all three sections: "git",
-    # "docker_image" and "docker_container". Binary tools that don't have Docker
-    # components, will only have the "git" part.
-    COMPONENT_MAPS = {
-        "git": {
-            "deployments": {
-                "docker_image": ["deployments"],
-                "docker_container": ["mender-deployments"],
-                "release_component": True,
-            },
-            "deployments-enterprise": {
-                "docker_image": ["deployments-enterprise"],
-                "docker_container": ["mender-deployments"],
-                "release_component": False,
-            },
-            "deviceadm": {
-                "docker_image": ["deviceadm"],
-                "docker_container": ["mender-device-adm"],
-                "release_component": False,
-            },
-            "deviceauth": {
-                "docker_image": ["deviceauth"],
-                "docker_container": ["mender-device-auth"],
-                "release_component": True,
-            },
-            "gui": {
-                "docker_image": ["gui"],
-                "docker_container": ["mender-gui"],
-                "release_component": True,
-            },
-            "integration": {
-                "docker_image": [],
-                "docker_container": [],
-                "release_component": True,
-            },
-            "inventory": {
-                "docker_image": ["inventory"],
-                "docker_container": ["mender-inventory"],
-                "release_component": True,
-            },
-            "mender": {
-                "docker_image": ["mender-client-qemu", "mender-client-docker", "mender-client-qemu-rofs"],
-                "docker_container": ["mender-client"],
-                "release_component": True,
-            },
-            "mender-api-gateway-docker": {
-                "docker_image": ["api-gateway"],
-                "docker_container": ["mender-api-gateway"],
-                "release_component": True,
-            },
-            "mender-artifact": {
-                "docker_image": [],
-                "docker_container": [],
-                "release_component": True,
-            },
-            "mender-cli": {
-                "docker_image": [],
-                "docker_container": [],
-                "release_component": True,
-            },
-            "mender-conductor": {
-                "docker_image": ["mender-conductor", "email-sender"],
-                "docker_container": ["mender-conductor", "mender-email-sender"],
-                "release_component": True,
-            },
-            "mender-conductor-enterprise": {
-                "docker_image": ["mender-conductor-enterprise"],
-                "docker_container": ["mender-conductor"],
-                "release_component": True,
-            },
-            "tenantadm": {
-                "docker_image": ["tenantadm"],
-                "docker_container": ["mender-tenantadm"],
-                "release_component": False,
-            },
-            "useradm": {
-                "docker_image": ["useradm"],
-                "docker_container": ["mender-useradm"],
-                "release_component": True,
-            },
-            "useradm-enterprise": {
-                "docker_image": ["useradm-enterprise"],
-                "docker_container": ["mender-useradm"],
-                "release_component": False,
-            },
-        },
-        "docker_image": {
-            "deployments": {
-                "git": ["deployments"],
-                "docker_container": ["mender-deployments"],
-                "release_component": True,
-            },
-            "deployments-enterprise": {
-                "git": ["deployments-enterprise"],
-                "docker_container": ["mender-deployments"],
-                "release_component": False,
-            },
-            "deviceadm": {
-                "git": ["deviceadm"],
-                "docker_container": ["mender-device-adm"],
-                "release_component": False,
-            },
-            "deviceauth": {
-                "git": ["deviceauth"],
-                "docker_container": ["mender-device-auth"],
-                "release_component": True,
-            },
-            "gui": {
-                "git": ["gui"],
-                "docker_container": ["mender-gui"],
-                "release_component": True,
-            },
-            "inventory": {
-                "git": ["inventory"],
-                "docker_container": ["mender-inventory"],
-                "release_component": True,
-            },
-            "mender-client-docker": {
-                "git": ["mender"],
-                "docker_container": ["mender-client"],
-                "release_component": True,
-            },
-            "mender-client-qemu": {
-                "git": ["mender"],
-                "docker_container": ["mender-client"],
-                "release_component": True,
-            },
-            "mender-client-qemu-rofs": {
-                "git": ["mender"],
-                "docker_container": ["mender-client"],
-                "release_component": True,
-            },
-            "api-gateway": {
-                "git": ["mender-api-gateway-docker"],
-                "docker_container": ["mender-api-gateway"],
-                "release_component": True,
-            },
-            "mender-conductor": {
-                "git": ["mender-conductor"],
-                "docker_container": ["mender-conductor"],
-                "release_component": True,
-            },
-            "email-sender": {
-                "git": ["mender-conductor"],
-                "docker_container": ["mender-email-sender"],
-                "release_component": True,
-            },
-            "mender-conductor-enterprise": {
-                "git": ["mender-conductor-enterprise"],
-                "docker_container": ["mender-conductor"],
-                "release_component": True,
-            },
-            "tenantadm": {
-                "git": ["tenantadm"],
-                "docker_container": ["mender-tenantadm"],
-                "release_component": False,
-            },
-            "useradm": {
-                "git": ["useradm"],
-                "docker_container": ["mender-useradm"],
-                "release_component": True,
-            },
-            "useradm-enterprise": {
-                "git": ["useradm-enterprise"],
-                "docker_container": ["mender-useradm"],
-                "release_component": False,
-            },
-        },
-        "docker_container": {
-            "mender-deployments": {
-                "git": ["deployments", "deployments-enterprise"],
-                "docker_image": ["deployments", "deployments-enterprise"],
-                "release_component": True,
-            },
-            "mender-device-auth": {
-                "git": ["deviceauth"],
-                "docker_image": ["deviceauth"],
-                "release_component": True,
-            },
-            "mender-device-adm": {
-                "git": ["deviceadm"],
-                "docker_image": ["deviceadm"],
-                "release_component": False,
-            },
-            "mender-gui": {
-                "git": ["gui"],
-                "docker_image": ["gui"],
-                "release_component": True,
-            },
-            "mender-inventory": {
-                "git": ["inventory"],
-                "docker_image": ["inventory"],
-                "release_component": True,
-            },
-            "mender-client": {
-                "git": ["mender"],
-                "docker_image": ["mender-client-qemu", "mender-client-docker", "mender-client-qemu-rofs"],
-                "release_component": True,
-            },
-            "mender-api-gateway": {
-                "git": ["mender-api-gateway-docker"],
-                "docker_image": ["api-gateway"],
-                "release_component": True,
-            },
-            "mender-conductor": {
-                "git": ["mender-conductor", "mender-conductor-enterprise"],
-                "docker_image": ["mender-conductor", "mender-conductor-enterprise"],
-                "release_component": True,
-            },
-            "mender-email-sender": {
-                "git": ["mender-conductor"],
-                "docker_image": ["email-sender"],
-                "release_component": True,
-            },
-            "mender-tenantadm": {
-                "git": ["tenantadm"],
-                "docker_image": ["tenantadm"],
-                "release_component": False,
-            },
-            "mender-useradm": {
-                "git": ["useradm", "useradm-enterprise"],
-                "docker_image": ["useradm", "useradm-enterprise"],
-                "release_component": True,
-            },
-        },
-    }
+    COMPONENT_MAPS = None
 
     name = None
     type = None
@@ -305,8 +78,19 @@ class Component:
             raise Exception("Tried to get yml name from non-yml component")
         return self.name
 
+    def set_custom_component_maps(self, maps):
+        # Set local maps for this object only.
+        self.COMPONENT_MAPS = maps
+
+    @staticmethod
+    def _initialize_component_maps():
+        if Component.COMPONENT_MAPS is None:
+            with open(os.path.join(integration_dir(), "component-maps.yml")) as fd:
+                Component.COMPONENT_MAPS = yaml.safe_load(fd)
+
     @staticmethod
     def get_component_of_type(type, name):
+        Component._initialize_component_maps()
         if Component.COMPONENT_MAPS[type].get(name) is None:
             raise KeyError("Component '%s' of type %s not found" % (name, type))
         return Component(name, type)
@@ -322,6 +106,7 @@ class Component:
 
     @staticmethod
     def get_components_of_type(type, only_release=None, only_non_release=False):
+        Component._initialize_component_maps()
         if only_release is None:
             if only_non_release:
                 only_release = False
@@ -343,12 +128,14 @@ class Component:
     def associated_components_of_type(self, type):
         """Returns all components of type `type` that are associated with self."""
 
+        Component._initialize_component_maps()
+
         if type == self.type:
             return [Component(self.name, self.type)]
 
         try:
             comps = []
-            for name in Component.COMPONENT_MAPS[self.type][self.name][type]:
+            for name in self.COMPONENT_MAPS[self.type][self.name][type]:
                 comps.append(Component(name, type))
             return comps
         except KeyError:
@@ -369,6 +156,10 @@ class Component:
         for comp in comps:
             comp.type = "yml"
         return comps
+
+    def is_release_component(self):
+        Component._initialize_component_maps()
+        return self.COMPONENT_MAPS[self.type][self.name]['release_component']
 
 
 # A map from git repo name to build parameter name in Jenkins.
@@ -2021,6 +1812,37 @@ def do_set_version_to(args):
     repo = Component.get_component_of_any_type(args.set_version_of)
     set_docker_compose_version_to(integration_dir(), repo, args.version)
 
+def is_marked_as_releaseable_in_integration_version(integration_version, repo_git, repo_git_version):
+    try:
+        component_maps = execute_git(None, integration_dir(),
+                                     ["show", "%s:component-maps.yml" % integration_version],
+                                     capture=True, capture_stderr=True)
+    except subprocess.CalledProcessError:
+        # No component-maps.yml found.
+        if integration_version == "master":
+            # For master branch, we should require that the maps are found, so
+            # that we update the paths in case we move it somewhere.
+            raise Exception("Could not find component-maps.yml at expected location in master branch. Please fix!")
+        elif repo_git_version == "master":
+            # If we're looking for the master version of component, and the
+            # component-maps.yml isn't found, we assume that the component is
+            # not releaseable. The reasoning behind this is that no releaseable
+            # component should ever use "master" in any other branch than
+            # integration/master, where we know that component-maps.yml
+            # exists. This gets rid of many false positives from tenantadm,
+            # which is marked as master in a whole range of old integration
+            # versions.
+            return False
+        else:
+            # Else we assume it is releaseable.
+            return True
+
+    # When we have the component-maps.yml data from the given integration
+    # version, do a lookup.
+    comp = Component.get_component_of_type("git", repo_git)
+    comp.set_custom_component_maps(yaml.safe_load(component_maps))
+    return comp.is_release_component()
+
 def do_integration_versions_including(args):
     if not args.version:
         print("--integration-versions-including requires --version argument")
@@ -2058,6 +1880,10 @@ def do_integration_versions_including(args):
             # If key doesn't exist it's because the version is from before
             # that component existed. So definitely not a match.
             continue
+
+        if not is_marked_as_releaseable_in_integration_version(candidate, repo.git(), args.version):
+            continue
+
         if version == args.version:
             matches.append(candidate)
 

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -315,7 +315,7 @@ def get_docker_compose_data_from_json_list(json_list):
     """
     data = {}
     for json_str in json_list:
-        json_elem = yaml.load(json_str)
+        json_elem = yaml.safe_load(json_str)
         for container, cont_info in json_elem['services'].items():
             image = cont_info.get('image')
             if image is None or "mendersoftware/" not in image:
@@ -1103,7 +1103,7 @@ def trigger_build(state, tag_avail):
             subprocess.call("%s %s" % (editor, RELEASE_TOOL_STATE), shell=True)
             with open(RELEASE_TOOL_STATE) as fd:
                 state.clear()
-                state.update(yaml.load(fd))
+                state.update(yaml.safe_load(fd))
             # Trigger update of parameters from disk.
             params = None
             continue
@@ -1546,7 +1546,7 @@ def do_build(args):
         print("Fetching cached parameters from %s. Delete to reset."
               % RELEASE_TOOL_STATE)
         with open(RELEASE_TOOL_STATE) as fd:
-            state = yaml.load(fd)
+            state = yaml.safe_load(fd)
     else:
         state = {}
 
@@ -1692,7 +1692,7 @@ def do_release():
         print("Loading existing release state data...")
         print("Note that you can always edit or delete %s manually" % RELEASE_TOOL_STATE)
         fd = open(RELEASE_TOOL_STATE)
-        state = yaml.load(fd)
+        state = yaml.safe_load(fd)
         fd.close()
 
     if state_value(state, ['repo_dir']) is None:


### PR DESCRIPTION
```
commit 242f774c0049f80b32fb7c8a97549d3ffbf34bf4
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Sep 6 11:04:24 2019

    Mark deployments-enterprise and useradm-enterprise as release components
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit ad34995da63e3e53be79fbbb6ec27b47201a3cc7
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Sep 6 11:01:20 2019

    release_tool: Get rid of yaml warnings.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 0a9512b0a2f421f312d8791392288464c5a9a0e9
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Sep 6 10:54:38 2019

    release_tool: Improve `-f` to take `release_component` into account.
    
    We only want `-f` to give results for components that have been part
    part of a release. Those that haven't can have any arbitrary version
    listed in the docker-compose files, and are not really *part* of a
    release.
    
    For this we have to do quite some restructuring: We need to move the
    COMPONENT_MAPS out of the tool and into its own data file, so that we
    can query it from other branches. Welcome component-maps.yml! We use
    this to query for whether the component was releaseable in the version
    that is being requested, with some special logic to handle cases where
    the file is not present (old branches).
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```