### PR TITLE
Add Enterprise production template and restructure a little.

### DIFF
--- a/production/config/enterprise.yml.template
+++ b/production/config/enterprise.yml.template
@@ -1,0 +1,16 @@
+# This is a template file for running Mender Enterprise. It builds on the
+# prod.yml template file, so everything described there applies to this template
+# as well.
+#
+# Notes:
+# - integration/docker-compose.enterprise.yml file is assumed to be included
+
+version: '2'
+services:
+
+    mender-device-auth:
+        environment:
+            # Set this to a tenant token that should be used for clients that
+            # don't supply a tenant token. If empty, clients without a tenant
+            # token will be rejected.
+            DEVICEAUTH_DEFAULT_TENANT_TOKEN: ''

--- a/production/config/prod.yml.template
+++ b/production/config/prod.yml.template
@@ -10,8 +10,6 @@
 # - certificates and key are mounted into containers using volumes
 # - minio artifacts are stored in a named volume `mender-artifacts`; volume
 #   needs to be created manually using `docker volume create mender-artifacts`
-# - paths need to be adjusted, ie, replace /template/ with production directory
-#   (see list of compose bugs)
 
 # related compose bugs:
 # - https://github.com/docker/compose/issues/3874
@@ -24,7 +22,7 @@ services:
     mender-useradm:
         command: server --automigrate
         volumes:
-            - ./template/keys-generated/keys/useradm/private.key:/etc/useradm/rsa/private.pem:ro
+            - ./production/keys-generated/keys/useradm/private.key:/etc/useradm/rsa/private.pem:ro
         logging:
             options:
                 max-file: "10"
@@ -33,7 +31,7 @@ services:
     mender-device-auth:
         command: server --automigrate
         volumes:
-            - ./template/keys-generated/keys/deviceauth/private.key:/etc/deviceauth/rsa/private.pem:ro
+            - ./production/keys-generated/keys/deviceauth/private.key:/etc/deviceauth/rsa/private.pem:ro
         logging:
             options:
                 max-file: "10"
@@ -53,8 +51,8 @@ services:
         networks:
             - mender
         volumes:
-            - ./template/keys-generated/certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.crt:ro
-            - ./template/keys-generated/certs/api-gateway/private.key:/var/www/mendersoftware/cert/private.key:ro
+            - ./production/keys-generated/certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.crt:ro
+            - ./production/keys-generated/certs/api-gateway/private.key:/var/www/mendersoftware/cert/private.key:ro
         logging:
             options:
                 max-file: "10"
@@ -84,14 +82,14 @@ services:
             DOWNLOAD_SPEED: 1m
             MAX_CONNECTIONS: 100
         volumes:
-            - ./template/keys-generated/certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt:ro
-            - ./template/keys-generated/certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key:ro
+            - ./production/keys-generated/certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt:ro
+            - ./production/keys-generated/certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key:ro
             - ./storage-proxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
 
     mender-deployments:
         command: server --automigrate
         volumes:
-            - ./template/keys-generated/certs/storage-proxy/cert.crt:/etc/ssl/certs/storage-proxy.crt:ro
+            - ./production/keys-generated/certs/storage-proxy/cert.crt:/etc/ssl/certs/storage-proxy.crt:ro
         environment:
             STORAGE_BACKEND_CERT: /etc/ssl/certs/storage-proxy.crt
             # access key, the same value as MINIO_ACCESS_KEY

--- a/production/run
+++ b/production/run
@@ -8,9 +8,18 @@ export MENDER_ARTIFACT_VERSION=$(../extra/release_tool.py -g mender-artifact)
 export MENDER_VERSION=$(../extra/release_tool.py -g mender)
 export MENDER_DEB_PACKAGE_VERSION=$MENDER_VERSION
 
+ENTERPRISE_DOCKER_COMPOSE=
+ENTERPRISE_PROD=
+if [ -f ./config/enterprise.yml ]; then
+    ENTERPRISE_DOCKER_COMPOSE="-f ../docker-compose.enterprise.yml"
+    ENTERPRISE_PROD="-f ./config/enterprise.yml"
+fi
+
 exec docker-compose \
      -p menderproduction \
      -f ../docker-compose.yml \
      -f ../docker-compose.storage.minio.yml \
-     -f ./prod.yml \
+     $ENTERPRISE_DOCKER_COMPOSE \
+     -f ./config/prod.yml \
+     $ENTERPRISE_PROD \
      "$@"

--- a/tests/production_test_env.py
+++ b/tests/production_test_env.py
@@ -37,8 +37,8 @@ conftest.docker_compose_instance = args.docker_compose_instance
 def fill_production_template():
 
     # copy production environment yml file
-    subprocess.check_output(["cp", "template/prod.yml", "production-testing-env.yml"], cwd="../")
-    subprocess.check_output("sed -i 's/template\///g' ../production-testing-env.yml", shell=True)
+    subprocess.check_output(["cp", "production/config/prod.yml.template", "production-testing-env.yml"], cwd="../")
+    subprocess.check_output("sed -i 's,/production/,/,g' ../production-testing-env.yml", shell=True)
     subprocess.check_output("sed -i 's/ALLOWED_HOSTS: my-gateway-dns-name/ALLOWED_HOSTS: ~./' ../production-testing-env.yml", shell=True)
     subprocess.check_output("sed -i '0,/set-my-alias-here.com/s/set-my-alias-here.com/localhost/' ../production-testing-env.yml", shell=True)
     subprocess.check_output("sed -i 's|DEPLOYMENTS_AWS_URI:.*|DEPLOYMENTS_AWS_URI: https://localhost:9000|' ../production-testing-env.yml", shell=True)


### PR DESCRIPTION
The restructuring is mainly to address a weakness in the original
template, which was that since the user was expected to copy all the
files in the template directory, it's not possible for us to provide
updates to the `run` script.

Addressed this by instead providing an OOTB production directory, with
tracked `run` script and templates named with `.template` suffix. This
should be completely compatible with existing installations except
that the user need to delete the `run` script from his repository.
This also means that we can cut the step in the production
guide to replace path names, because the files are already in the
correct directory.

Changelog: Introduced `enterprise.yml` template in production
directory to install an Enterprise backend server.

Changelog: The old `template` directory has been replaced with a
dedicated `production` directory, and templates are now provided as
single files with the `.template` suffix instead. These should be
copied to their non-`.template` location before being used. The `run`
script should no longer be copied, and if it already exists in the
`production` directory before merging this change, it should be
removed before attempting to merge or rebase.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>