### PR TITLE
Reenable default tenant token test after API change.

### DIFF
--- a/backend-tests/tests/test_devauth_v2.py
+++ b/backend-tests/tests/test_devauth_v2.py
@@ -1309,7 +1309,6 @@ class TestDefaultTenantTokenEnterprise(object):
         assert len(api_devs) == 0
 
 
-    @pytest.mark.xfail(strict=True, reason="The deviceauth scope changed to allow invalid tokens")
     def test_invalid_tenant_token_added_to_default_account(self, clean_mongo):
         """Verify that an invalid tenant token does show up in the default tenant account"""
 


### PR DESCRIPTION
Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>