### PR TITLE
Backend integration test: tenantadm `create-org` CLI command

### DIFF
--- a/backend-tests/tests/test_tenantadm.py
+++ b/backend-tests/tests/test_tenantadm.py
@@ -1,0 +1,131 @@
+import logging
+import pytest
+import subprocess
+import time
+
+import api
+import pymongo
+import infra
+
+from common import mongo, mongo_cleanup
+from common import User, Device, Tenant, create_user, create_tenant, \
+        create_tenant_user, create_org
+
+logger = logging.getLogger(__name__)
+
+@pytest.yield_fixture(scope="function")
+def clean_mongo_tenant_migration(mongo):
+    mongo_cleanup(mongo)
+    tenant_cli = infra.cli.CliTenantadm()
+    tenant_cli.migrate()
+    yield mongo
+    mongo_cleanup(mongo)
+
+
+class TestCreateOrganizationCLIEnterprise:
+    api_mgmt_useradm = api.client.ApiClient(api.useradm.URL_MGMT)
+    logger = logger.getChild("TestCreateOrganizationCLIEnterprise")
+
+    def test_success(self, clean_mongo_tenant_migration):
+        """
+        Create a single organization and verify that the created user
+        is able to log in.
+        """
+        self.logger.info("Starting `test_success`")
+
+        out = create_org("fooCorp", "user@example.com", "pwd")
+        self.logger.debug("tenant id: %s" % out)
+
+        # Retry login for 3 min
+        for i in range(60 * 3):
+            time.sleep(1)
+            rsp = self.api_mgmt_useradm.call("POST", api.useradm.URL_LOGIN,
+                                             auth=("user@example.com", "pwd"))
+            if rsp.status_code == 200:
+                break
+        assert rsp.status_code == 200
+
+        self.logger.info("`test_success` finished successfully.")
+
+
+    def test_duplicate_username(self, clean_mongo_tenant_migration):
+        """
+        Duplicate username (e-mail) should not be allowed, as this
+        leads to conflicting login credentials.
+        """
+        err = None
+
+        self.logger.debug("Starting `test_duplicate_username`")
+
+        self.logger.debug("First tenant creation call")
+        out = create_org("fooCorp", "user@example.com", "321password")
+        self.logger.debug("stdout: %s" % out)
+
+        # Retry login for 3 min
+        for i in range(60 * 3):
+            time.sleep(1)
+            rsp = self.api_mgmt_useradm.call("POST", api.useradm.URL_LOGIN,
+                                             auth=("user@example.com", "321password"))
+            if rsp.status_code == 200:
+                self.logger.debug("Successfully logged into account")
+                break
+        assert rsp.status_code == 200
+
+        try:
+            self.logger.debug("Second tenant creation call")
+            out = create_org("barCorp", "user@example.com", "321password")
+            self.logger.debug("stdout: %s" % out)
+        except subprocess.CalledProcessError as e:
+            err = e
+
+        if err == None:
+            pytest.fail("Duplicate user email is not allowed!")
+
+        # Retry login for 3 min
+        for i in range(60 * 3):
+            time.sleep(1)
+            rsp = self.api_mgmt_useradm.call("POST", api.useradm.URL_LOGIN,
+                                             auth=("user@example.com", "321password"))
+            if rsp.status_code == 200:
+                break
+        assert rsp.status_code == 200
+
+        self.logger.info("`test_duplicate_username` finished successfully.")
+
+    def test_duplicate_organization(self, clean_mongo_tenant_migration):
+        """
+        It should be allowed to create duplicate organizations as long
+        as the user e-mails (login credentials) differ.
+        """
+        self.logger.debug("Starting `test_duplicate_username`")
+
+        out = create_org("fooCorp",
+                         "foo@corp.org",
+                         "321password")
+
+        # Retry login for 3 min
+        for i in range(60 * 3):
+            time.sleep(1)
+            rsp = self.api_mgmt_useradm.call("POST", api.useradm.URL_LOGIN,
+                                             auth=("foo@corp.org",
+                                                   "321password"))
+            if rsp.status_code == 200:
+                self.logger.debug("Successfully logged into account")
+                break
+        assert rsp.status_code == 200
+
+        out = create_org("fooCorp",
+                         "foo@acme.com",
+                         "password123")
+
+        # Retry login for 3 min
+        for i in range(60 * 3):
+            time.sleep(1)
+            rsp = self.api_mgmt_useradm.call("POST", api.useradm.URL_LOGIN,
+                                             auth=("foo@acme.com",
+                                                   "password123"))
+            if rsp.status_code == 200:
+                break
+        assert rsp.status_code == 200
+
+        self.logger.info("`test_duplicate_username` finished successfully.")

--- a/tests/tests/test_os_ent_migration.py
+++ b/tests/tests/test_os_ent_migration.py
@@ -34,7 +34,7 @@ import testutils.api.useradm as useradm
 
 @pytest.fixture(scope="class")
 def initial_os_setup():
-    """ Start the minimum OS setup, create some uses and devices. 
+    """ Start the minimum OS setup, create some uses and devices.
         Return {"os_devs": [...], "os_users": [...]}
     """
 
@@ -87,7 +87,7 @@ def migrated_enterprise_setup(initial_enterprise_setup):
     return dict(ent_data.items() + initial_enterprise_setup.items())
 
 def initialize_os_setup():
-    """ Seed the OS setup with all operational data - users and devices. 
+    """ Seed the OS setup with all operational data - users and devices.
         Return {"os_devs": [...], "os_users": [...]}
     """
     uadmm = ApiClient('https://{}/api/management/v1/useradm'.format(get_mender_gateway()))
@@ -112,9 +112,9 @@ def initialize_os_setup():
     # get tokens for all
     for d in devs:
         body, sighdr = deviceauth_v1.auth_req(
-                            d.id_data,
-                            d.authsets[0].pubkey,           
-                            d.authsets[0].privkey)
+            d.id_data,
+            d.authsets[0].pubkey,
+            d.authsets[0].privkey)
 
         r = dauthd.call('POST',
                         deviceauth_v1.URL_AUTH_REQS,
@@ -128,7 +128,7 @@ def initialize_os_setup():
 
 def migrate_ent_setup():
     """ Migrate the ENT setup - create a tenant and user via create-org,
-        substitute default token env in the ent. testing layer. 
+        substitute default token env in the ent. testing layer.
     """
     ensure_conductor_ready(60, 'create_organization')
 
@@ -165,10 +165,10 @@ class TestEntMigration:
             r = uadmm.call('POST', useradm.URL_LOGIN, auth=(u.name, u.pwd))
             assert r.status_code == 401
 
-        # but enterprise user can 
+        # but enterprise user can
         ent_user = migrated_enterprise_setup["tenant"].users[0]
-        r = uadmm.call('POST', 
-                       useradm.URL_LOGIN, 
+        r = uadmm.call('POST',
+                       useradm.URL_LOGIN,
                        auth=(ent_user.name, ent_user.pwd))
         assert r.status_code == 200
 
@@ -192,8 +192,8 @@ class TestEntMigration:
         # but even despite the 'dummy' tenant token
         # os devices can get into the deviceauth db for acceptance
         ent_user = migrated_enterprise_setup["tenant"].users[0]
-        r = uadmm.call('POST', 
-                       useradm.URL_LOGIN, 
+        r = uadmm.call('POST',
+                       useradm.URL_LOGIN,
                        auth=(ent_user.name, ent_user.pwd))
         assert r.status_code == 200
         utoken=r.text
@@ -201,7 +201,7 @@ class TestEntMigration:
         for d in migrated_enterprise_setup["os_devs"]:
             body, sighdr = deviceauth_v1.auth_req(
                                 d.id_data,
-                                d.authsets[0].pubkey,           
+                                d.authsets[0].pubkey,
                                 d.authsets[0].privkey,
                                 tenant_token='dummy')
 
@@ -223,7 +223,7 @@ class TestEntMigration:
 def ensure_conductor_ready(max_time=120, wfname='create_organization'):
     """
     Wait on:
-    - conductor api being up, not refusing conns 
+    - conductor api being up, not refusing conns
     - a particular workflow being available.
     """
     ip = get_mender_conductor()
@@ -231,7 +231,7 @@ def ensure_conductor_ready(max_time=120, wfname='create_organization'):
         try:
             r = requests.get("http://{}:8080/api/metadata/workflow/{}".format(ip, wfname))
             if r.status_code != 404:
-                return 
+                return
         except requests.ConnectionError:
             pass
 

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -14,6 +14,7 @@
 #    limitations under the License.
 import pytest
 import random
+import pymongo
 from pymongo import MongoClient
 
 from testutils.api.client import ApiClient
@@ -135,8 +136,8 @@ def create_authset(dauthd1, dauthm, id_data, pubkey, privkey, utoken, tenant_tok
 
     aset = aset[0]
 
-    assert aset['identity_data'] == id_data 
-    assert aset['status'] == 'pending' 
+    assert aset['identity_data'] == id_data
+    assert aset['status'] == 'pending'
 
     return Authset(aset['id'], api_dev['id'], id_data, pubkey, privkey, 'pending')
 
@@ -153,7 +154,13 @@ def create_tenant_user(idx, tenant, docker_prefix=None):
 
     return create_user(name, pwd, tenant.id, docker_prefix)
 
-def get_device_by_id_data(dauthm, id_data, utoken):
+def create_org(name, user, password):
+    cli = CliTenantadm()
+
+    return cli.create_org(name, user, password)
+
+
+def get_device_by_id_data(devauthm, id_data, utoken):
     page = 0
     per_page = 20
     qs_params = {}

--- a/testutils/infra/cli.py
+++ b/testutils/infra/cli.py
@@ -24,7 +24,7 @@ class CliUseradm:
 
         # is it an open useradm, or useradm-enterprise?
         for path in ['/usr/bin/useradm', '/usr/bin/useradm-enterprise']:
-            try: 
+            try:
                 docker.execute(self.cid, [path, '--version'])
                 self.path=path
             except:
@@ -32,6 +32,7 @@ class CliUseradm:
 
         if self.path is None:
             raise RuntimeError('no runnable binary found in mender-useradm')
+
 
     def create_user(self, username, password, tenant_id=''):
         cmd = [self.path,
@@ -44,6 +45,7 @@ class CliUseradm:
 
         uid=docker.execute(self.cid, cmd)
         return uid
+
 
     def migrate(self, tenant_id=None):
         cmd = [self.path,


### PR DESCRIPTION
I also made the `mongo_cleanup` fixture a little more graceful by deleting all documents instead of completely dropping all collections.