### PR TITLE
Enable tenantadm as an Enterprise release component.

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -98,7 +98,7 @@ git:
     - tenantadm
     docker_container:
     - mender-tenantadm
-    release_component: false
+    release_component: true
 
   useradm:
     docker_image:
@@ -211,7 +211,7 @@ docker_image:
     - tenantadm
     docker_container:
     - mender-tenantadm
-    release_component: false
+    release_component: true
 
   useradm:
     git:
@@ -302,7 +302,7 @@ docker_container:
     - tenantadm
     docker_image:
     - tenantadm
-    release_component: false
+    release_component: true
 
   mender-useradm:
     git:

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -172,6 +172,7 @@ GIT_TO_BUILDPARAM_MAP = {
     "deviceauth": "DEVICEAUTH_REV",
     "gui": "GUI_REV",
     "inventory": "INVENTORY_REV",
+    "tenantadm": "TENANTADM_REV",
     "useradm": "USERADM_REV",
     "useradm-enterprise": "USERADM_ENTERPRISE_REV",
 


### PR DESCRIPTION
This is already part of MEN-2648, but I'm submitting this littl piece just to get our integration-test-runner to select the correct branch from tenantadm when we build.