### PR TITLE
Change Enterprise Docker links to registry.mender.io.

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -19,10 +19,8 @@ git:
     release_component: true
 
   deviceadm:
-    docker_image:
-    - deviceadm
-    docker_container:
-    - mender-device-adm
+    docker_image: []
+    docker_container: []
     release_component: false
 
   deviceauth:
@@ -130,13 +128,6 @@ docker_image:
     docker_container:
     - mender-deployments
     release_component: true
-
-  deviceadm:
-    git:
-    - deviceadm
-    docker_container:
-    - mender-device-adm
-    release_component: false
 
   deviceauth:
     git:
@@ -252,13 +243,6 @@ docker_container:
     docker_image:
     - deviceauth
     release_component: true
-
-  mender-device-adm:
-    git:
-    - deviceadm
-    docker_image:
-    - deviceadm
-    release_component: false
 
   mender-gui:
     git:

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -3,14 +3,14 @@ services:
 
     # subsitute services with 'enterprise' versions
     mender-deployments:
-        image: mendersoftware/deployments-enterprise:master
+        image: registry.mender.io/mendersoftware/deployments-enterprise:master
 
     mender-conductor:
-        image: mendersoftware/mender-conductor-enterprise:master
+        image: registry.mender.io/mendersoftware/mender-conductor-enterprise:master
 
     # add services
     mender-tenantadm:
-        image: mendersoftware/tenantadm:master
+        image: registry.mender.io/mendersoftware/tenantadm:master
         extends:
             file: common.yml
             service: mender-base
@@ -22,7 +22,7 @@ services:
             TENANTADM_CONDUCTOR_ADDR: http://mender-conductor:8080
 
     mender-org-welcome-email-preparer:
-        image: mendersoftware/org-welcome-email-preparer:master
+        image: registry.mender.io/mendersoftware/org-welcome-email-preparer:master
         extends:
             file: common.yml
             service: mender-base
@@ -63,7 +63,7 @@ services:
             DEVICEAUTH_TENANTADM_ADDR: 'http://mender-tenantadm:8080'
 
     mender-useradm:
-        image: mendersoftware/useradm-enterprise:master
+        image: registry.mender.io/mendersoftware/useradm-enterprise:master
         environment:
             USERADM_TENANTADM_ADDR: 'http://mender-tenantadm:8080'
 

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -188,7 +188,7 @@ GIT_TO_BUILDPARAM_MAP = {
 
 # categorize backend services wrt open/enterprise versions
 # important for test suite selection
-BACKEND_SERVICES_OPEN = {"deviceadm", "deviceauth", "inventory"}
+BACKEND_SERVICES_OPEN = {"deviceauth", "inventory"}
 BACKEND_SERVICES_ENT = {"deployments-enterprise", "mender-conductor-enterprise", "tenantadm", "useradm-enterprise"}
 BACKEND_SERVICES_OPEN_ENT = {"deployments", "mender-conductor", "useradm"}
 BACKEND_SERVICES = BACKEND_SERVICES_OPEN | BACKEND_SERVICES_ENT | BACKEND_SERVICES_OPEN_ENT


### PR DESCRIPTION
```
commit 724b7538da54503be2cdbbb5a4659f8c2cb03a48
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 14 14:40:18 2019

    Change Enterprise Docker links to registry.mender.io.
    
    This will be our gateway to serve the Enterprise images, not Docker
    Hub. Those who are using Enterprise will need to log into this
    gateway:
    ```
    docker login -u $USERNAME registry.mender.io
    ```
    where `$USERNAME` is the username given to you from Northern.tech. You
    will be prompted for the password.
    
    Changelog: Commit
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 35c705b8b377826b3ab9d3e9a836d0a13dadaca1
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 14 11:38:43 2019

    release_tool: Support for mapping services and non-mendersoftware links
    
    Add support for mapping a service of one type, to the same service of
    a different type, including the docker_url.
    
    Also add support for non-mendersoftware Docker image URLs.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 7fbea234aa9f5c9aa838c9f19d4e18f2c160d3f0
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 14 11:37:35 2019

    release_tool: Remove deviceadm from list of active containers.
    
    It can still be queried as a git repo and Docker image.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```