### PR TITLE
Set pytest to v2.x to fix strange error in backend integ tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,6 @@ tests/large_image.dat
 tests/results.xml
 tests/downloaded-tools
 
-backend-tests/results.xml
-backend-tests/report.html
-
 __pycache__
 .cache
 artifacts

--- a/backend-tests/docker/Dockerfile
+++ b/backend-tests/docker/Dockerfile
@@ -8,6 +8,6 @@ RUN apt-get -y -qq update && apt-get -qq -y install \
 RUN pip3 install --quiet requests==2.19 pymongo==3.6.1
 
 # NOTE: pytest-html 1.13 is the latest one compatible with Python 3.5 (Ubuntu 16.04 latest)
-RUN pip3 install pytest==5.2 pytest-html==1.13
+RUN pip3 install "pytest<3.0" pytest-html==1.13
 
 ENTRYPOINT ["bash", "/tests/run.sh"]


### PR DESCRIPTION
There seems to be a modification in the way the Exceptions are expected
and reported in pytest from v3 onward. The correct fix is to modify the
test, but meanwhile...

The failure was introduced in d8c4c6b, when pytest was indirectly upgraded
to latest, but has been hidden due to the development of the test
happening in an isolated feature branch.
