### PR TITLE
Backend integration tests: update to latest pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tags
 /release-state.yml
 
 /docker-compose.testing.yml
+/docker-compose.testing.enterprise.yml
 tests/.cache/
 tests/broken_update.ext4
 tests/core-image-full-cmdline-vexpress-qemu-broken-network.ext4

--- a/backend-tests/docker/Dockerfile
+++ b/backend-tests/docker/Dockerfile
@@ -2,12 +2,11 @@ FROM ubuntu:16.04
 
 RUN apt-get -y -qq update && apt-get -qq -y install \
     python3-pip \
-    docker.io \
-    python3-crypto
+    docker.io
 
-RUN pip3 install --quiet requests==2.19 pymongo==3.6.1
+RUN pip3 install --quiet requests==2.19 pymongo==3.6.1 pycrypto==2.6
 
 # NOTE: pytest-html 1.13 is the latest one compatible with Python 3.5 (Ubuntu 16.04 latest)
-RUN pip3 install "pytest<3.0" pytest-html==1.13
+RUN pip3 install --quiet pytest==5.2 pytest-html==1.13
 
 ENTRYPOINT ["bash", "/tests/run.sh"]

--- a/backend-tests/docker/Dockerfile
+++ b/backend-tests/docker/Dockerfile
@@ -1,12 +1,10 @@
-FROM ubuntu:16.04
+FROM python:3.7
 
 RUN apt-get -y -qq update && apt-get -qq -y install \
-    python3-pip \
     docker.io
 
-RUN pip3 install --quiet requests==2.19 pymongo==3.6.1 pycrypto==2.6
+COPY requirements-py3.txt .
 
-# NOTE: pytest-html 1.13 is the latest one compatible with Python 3.5 (Ubuntu 16.04 latest)
-RUN pip3 install --quiet pytest==5.2 pytest-html==1.13
+RUN pip3 install -r requirements-py3.txt
 
 ENTRYPOINT ["bash", "/tests/run.sh"]

--- a/backend-tests/requirements-py3.txt
+++ b/backend-tests/requirements-py3.txt
@@ -1,0 +1,5 @@
+requests==2.19
+pymongo==3.6.1
+pycrypto==2.6
+pytest==5.2
+pytest-html==2.0

--- a/backend-tests/tests/conftest.py
+++ b/backend-tests/tests/conftest.py
@@ -13,6 +13,10 @@
 #    limitations under the License.
 import requests
 import urllib3
+import pytest
 
 from requests.packages import urllib3
 urllib3.disable_warnings()
+
+# See https://docs.pytest.org/en/latest/writing_plugins.html#assertion-rewriting
+pytest.register_assert_rewrite("testutils")


### PR DESCRIPTION
```
commit 6fa7d1d28b84357438b2b4684c13ca222314ce75
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Fri Oct 4 09:48:51 2019 +0200

    Set Assertion Rewriting for our common.py file
    
    Some tets, namely test_invalid_tenant_token_added_to_default_account,
    expect and verify asserts happening in common.py. This function tells
    pytest to treat the file as test code and rewrite the asserts.
    
    See https://docs.pytest.org/en/latest/writing_plugins.html#assertion-rewriting
    
    It turned out to be that this is the correct behaviour, while v2.x of
    pytest was having a bug (which we were taking advantage of).
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit 9bbeb42b6955b1dd6a3b2585b2d6a7761aab10b9
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Fri Oct 4 09:53:04 2019 +0200

    Update to latest pytest and fix pycrypto version as well
    
    Now that the test framework is ready for latest pytest, let's update.
    
    Fix pycrypto also, so that we don't rely on Ubuntu packaging for it.
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```

New commit:
```
commit 87a1d56aa74d4c58826086846aeb435bf7d64e2b
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Thu Oct 17 16:58:28 2019 +0200

    Update backend integ tests image base to Python 3
    
    Arrange also the dependencies in an external file and upgrade now the
    components that were not compatible with Python 3.7 (pytest-html).
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```