### PR TITLE
QA-99: Add xUnit/HTML reports to backend-tests execution

### DIFF
--- a/backend-tests/docker/Dockerfile
+++ b/backend-tests/docker/Dockerfile
@@ -2,10 +2,12 @@ FROM ubuntu:16.04
 
 RUN apt-get -y -qq update && apt-get -qq -y install \
     python3-pip \
-    python3-pytest \
     docker.io \
     python3-crypto
 
 RUN pip3 install --quiet requests==2.19 pymongo==3.6.1
+
+# NOTE: pytest-html 1.13 is the latest one compatible with Python 3.5 (Ubuntu 16.04 latest)
+RUN pip3 install "pytest<3.0" pytest-html==1.13
 
 ENTRYPOINT ["bash", "/tests/run.sh"]

--- a/backend-tests/run
+++ b/backend-tests/run
@@ -102,6 +102,37 @@ get_container_exit_code() {
     docker inspect --format '{{.State.ExitCode}}' $1
 }
 
+copy_test_reports_if_args() {
+    while [ -n "$1" ]; do
+        case "$1" in
+            --junit-xml=*)
+                RESULTS_FILE="${1#--junit-xml=}"
+                ;;
+            --junit-xml)
+                shift
+                RESULTS_FILE="$1"
+                ;;
+            --html=*)
+                REPORT_FILE="${1#--html=}"
+                ;;
+            --html)
+                shift
+                REPORT_FILE="$1"
+                ;;
+        esac
+        shift
+    done
+
+    if [ -n "$RESULTS_FILE" ]; then
+        echo "-- copying file $RESULTS_FILE"
+        docker cp ${cid}:/$RESULTS_FILE . || true
+    fi
+    if [ -n "$REPORT_FILE" ]; then
+        echo "-- copying file $REPORT_FILE"
+        docker cp ${cid}:/$REPORT_FILE . || true
+    fi
+}
+
 cleanup(){
     [ -z $SKIP_CLEANUP ] && $COMPOSE_CMD down && $COMPOSE_CMD rm || true
 }
@@ -115,6 +146,8 @@ if [ -n "$failed" ]; then
     echo "-- tests failed, dumping logs to $tmppath"
     $COMPOSE_CMD logs > $tmppath
 fi
+
+copy_test_reports_if_args $PYTEST_ARGS
 
 cleanup
 

--- a/backend-tests/tests/run.sh
+++ b/backend-tests/tests/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 sleep 30
 
-py.test-3 -s /tests/test_*.py "$@"
+python3 -m pytest -s /tests/test_*.py "$@"


### PR DESCRIPTION
Porting this functionality to 2.1.x no to break the build with latest
mender-qa. Fixing it properly (i.e. detecting from mender-qa when
integration supports or not html reports) is really hard...

Changeset based on cherry-picking and cleaning commits:
  d8c4c6bde741869924bb2f8260e51cf520f6ff72
  4d0488f36fa4b2d54b2535e74c5dc3662bba8db0