### PR TITLE
Fix docker-compose logs call specifying the project name

### DIFF
--- a/demo
+++ b/demo
@@ -295,4 +295,4 @@ echo "Press Enter to show the logs."
 echo "Press Ctrl-C to stop the backend and quit."
 read -se
 
-docker-compose logs --follow
+docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} logs --follow


### PR DESCRIPTION
Otherwise, the call will exit abruptly when the project name is not the
same as the folder name.

Changelog: Fix issue when demo script exists abruptly on user request
for logs. The issue only showed up when the folder name contained "-"
or "." characters.

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit e2165fbb69e61c7ce1cf5776e3a658af2f035ab3)