### PR TITLE
Migrate from python-pycrypto to python-cryptography

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tags
 /release-state.yml
 
 /docker-compose.testing.yml
+/docker-compose.testing.enterprise.yml
 tests/.cache/
 tests/broken_update.ext4
 tests/core-image-full-cmdline-vexpress-qemu-broken-network.ext4

--- a/backend-tests/docker/Dockerfile
+++ b/backend-tests/docker/Dockerfile
@@ -2,12 +2,11 @@ FROM ubuntu:16.04
 
 RUN apt-get -y -qq update && apt-get -qq -y install \
     python3-pip \
-    docker.io \
-    python3-crypto
+    docker.io
 
-RUN pip3 install --quiet requests==2.19 pymongo==3.6.1
+RUN pip3 install --quiet requests==2.19 pymongo==3.6.1 pycrypto==2.6
 
 # NOTE: pytest-html 1.13 is the latest one compatible with Python 3.5 (Ubuntu 16.04 latest)
-RUN pip3 install "pytest<3.0" pytest-html==1.13
+RUN pip3 install --quiet pytest==5.2 pytest-html==1.13
 
 ENTRYPOINT ["bash", "/tests/run.sh"]

--- a/backend-tests/docker/Dockerfile
+++ b/backend-tests/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 
 RUN apt-get -y -qq update && apt-get -qq -y install \
     docker.io

--- a/backend-tests/docker/Dockerfile
+++ b/backend-tests/docker/Dockerfile
@@ -1,12 +1,10 @@
-FROM ubuntu:16.04
+FROM python:3.7
 
 RUN apt-get -y -qq update && apt-get -qq -y install \
-    python3-pip \
     docker.io
 
-RUN pip3 install --quiet requests==2.19 pymongo==3.6.1 pycrypto==2.6
+COPY requirements-py3.txt .
 
-# NOTE: pytest-html 1.13 is the latest one compatible with Python 3.5 (Ubuntu 16.04 latest)
-RUN pip3 install --quiet pytest==5.2 pytest-html==1.13
+RUN pip3 install -r requirements-py3.txt
 
 ENTRYPOINT ["bash", "/tests/run.sh"]

--- a/backend-tests/requirements-py3.txt
+++ b/backend-tests/requirements-py3.txt
@@ -1,0 +1,5 @@
+requests==2.19
+pymongo==3.6.1
+pycrypto==2.6
+pytest==5.2
+pytest-html==2.0

--- a/backend-tests/requirements-py3.txt
+++ b/backend-tests/requirements-py3.txt
@@ -1,5 +1,5 @@
 requests==2.19
 pymongo==3.6.1
-pycrypto==2.6
+cryptography==2.8
 pytest==5.2
 pytest-html==2.0

--- a/backend-tests/tests/conftest.py
+++ b/backend-tests/tests/conftest.py
@@ -13,6 +13,10 @@
 #    limitations under the License.
 import requests
 import urllib3
+import pytest
 
 from requests.packages import urllib3
 urllib3.disable_warnings()
+
+# See https://docs.pytest.org/en/latest/writing_plugins.html#assertion-rewriting
+pytest.register_assert_rewrite("testutils")

--- a/testutils/api/deviceauth_v2.py
+++ b/testutils/api/deviceauth_v2.py
@@ -11,12 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-from Crypto.PublicKey import RSA
-from Crypto.Signature import PKCS1_v1_5
-from Crypto.Hash import SHA256
-from base64 import b64encode, urlsafe_b64decode, urlsafe_b64encode
-import json
-
 import testutils.api.client
 
 URL_MGMT = testutils.api.client.GATEWAY_URL + '/api/management/v2/devauth'

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -125,14 +125,14 @@ def create_authset(dauthd1, dauthm, id_data, pubkey, privkey, utoken, tenant_tok
                      deviceauth_v1.URL_AUTH_REQS,
                      body,
                      headers=sighdr)
-    assert r.status_code == 401
+    assert r.status_code == 401, r.text
 
     # dev must exist and have *this* aset
     api_dev = get_device_by_id_data(dauthm, id_data, utoken)
     assert api_dev is not None
 
     aset = [a for a in api_dev['auth_sets'] if testutils.util.crypto.rsa_compare_keys(a['pubkey'], pubkey)]
-    assert len(aset) == 1
+    assert len(aset) == 1, str(aset)
 
     aset = aset[0]
 


### PR DESCRIPTION
Python pycrypto uses deprecated functions not supported in python 3.8.

changelog: none

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>