### PR TITLE
Fix a flag typo in integration tests

### DIFF
--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -161,7 +161,7 @@ class TestBasicIntegration(MenderTesting):
                 wait_count = 0
 
         def deployment_triggered_callback():
-            output = run("mender --check-update")
+            output = run("mender -check-update")
             if output.return_code != 0:
                 logger.error(output)
                 pytest.fail("Forcing the update check failed")


### PR DESCRIPTION
The typo was previously automatically corrected by the flag package in
mender, but becomes a problem for the upgraded CLI package.

changelog: none

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>