### PR TITLE
release_tool: Fix typo in Docker pushing logic.

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -1433,7 +1433,7 @@ def push_latest_docker_tags(state, tag_avail):
             else:
                 minor_version = state[repo.git()]['version'][0:state[repo.git()]['version'].rindex('.')]
 
-            prefix = compose_data[image]["image_prefix"]
+            prefix = compose_data[image.docker_image()]["image_prefix"]
 
             exec_list.append(["docker", "pull",
                               "%s/%s:%s" % (prefix, image.docker_image(), tag_avail[repo.git()]['build_tag'])])


### PR DESCRIPTION
Since it is only used during releases it was not caught during the
original fix.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>