### PR TITLE
[DON'T MERGE/DEBUG] backend-integration: wait for workflows instead of sleeping

### DIFF
--- a/tests/tests/conductor.py
+++ b/tests/tests/conductor.py
@@ -18,9 +18,21 @@ from ..MenderAPI.requests_helpers import requests_retry
 
 class Conductor:
     API_WF_SEARCH = '/api/workflow/search'
+    API_WF_RUNNING = '/api/workflow/running/{}'
+    API_WF = '/api/workflow/{}'
 
     def __init__(self, host):
         self.addr = 'http://%s:8080' % (host,)
+
+    def get_running_wfs(self, name):
+        rsp = requests.get(self.addr+self.API_WF_SEARCH.format(name))
+        assert rsp.status_code == 200
+        return rsp.json()
+
+    def get_wf(self, wfid):
+        rsp = requests.get(self.addr+self.API_WF.format(wfid))
+        assert rsp.status_code == 200
+        return rsp.json()
 
     def get_decommission_device_wfs(self, device_id, state='COMPLETED'):
         """

--- a/tests/tests/test_os_ent_migration.py
+++ b/tests/tests/test_os_ent_migration.py
@@ -32,6 +32,8 @@ import testutils.api.deviceauth_v2 as deviceauth_v2
 import testutils.api.deployments as deployments
 import testutils.api.useradm as useradm
 
+from conductor import Conductor
+
 @pytest.fixture(scope="class")
 def initial_os_setup():
     """ Start the minimum OS setup, create some uses and devices.
@@ -137,6 +139,20 @@ def migrate_ent_setup():
     cli = CliTenantadm(docker_prefix=docker_compose_instance)
     tid = cli.create_org('tenant', u.name, u.pwd)
     time.sleep(10)
+
+    c = Conductor(get_mender_conductor())
+    wfs = c.get_running_wfs('create_organization')
+    print('RUNNING WFS: \n {}'.format(wfs))
+    assert len(wfs['results']) == 1
+
+    time.sleep(10)
+
+    wfid = wfs['results'][0]['workflowId']
+    wf = c.get_wf(wfid)
+    print('OUR WF {}'.format(wf))
+
+    # always fails ?!
+    assert wf['status'] == 'COMPLETED'
 
     tenant = cli.get_tenant(tid)
 


### PR DESCRIPTION
the sleep is causing us issues. if the workflow doesn't complete, it's
a silent failure.

this is an attempt to actually monitor the status of the started
workflow. it's POC quality.

unfortunately, the create_organization workflow never completes. even
when it 'completes', and all the workflow steps have been executed, and
tests pass... the wf status is still 'running', despite very generous
timeouts (2 x 10s).

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>

https://tracker.mender.io/browse/MEN-2914