### PR TITLE
[DON'T MERGE/DEBUG] backend-integration: wait for docker setup before running workflows

### DIFF
--- a/tests/tests/test_00_multi_tenancy.py
+++ b/tests/tests/test_00_multi_tenancy.py
@@ -100,6 +100,11 @@ class TestMultiTenancyEnterprise(MenderTesting):
 
     @pytest.mark.usefixtures("enterprise_no_client")
     def test_artifacts_exclusive_to_user(self):
+        # extra long sleep to make sure all services ran their migrations
+        # maybe conductor fails because some services are still in a migration phase,
+        # and not serving the API yet?
+        time.sleep(30)
+
         users = [
             {"email": "foo1@foo1.com", "password": "hunter2hunter2", "username": "foo1"},
             {"email": "bar2@bar2.com", "password": "hunter2hunter2", "username": "bar2"},

--- a/tests/tests/test_os_ent_migration.py
+++ b/tests/tests/test_os_ent_migration.py
@@ -132,6 +132,11 @@ def migrate_ent_setup():
     """
     ensure_conductor_ready(60, 'create_organization')
 
+    # extra long sleep to make sure all services ran their migrations
+    # maybe conductor fails because some services are still in a migration phase,
+    # and not serving the API yet?
+    time.sleep(30)
+
     u = User('', 'baz@tenant.com', 'correcthorse')
 
     cli = CliTenantadm(docker_prefix=docker_compose_instance)


### PR DESCRIPTION
_**this actually worked and the build is: https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/350512985.**_

_**do we want to merge it or do sth more fancy, like - add the extra sleep in docker setup fixtures, so that any test has it? the downside is that not all tests need it, and all will take extra time...**_

---

trying this out as a possible solution to:
https://tracker.mender.io/browse/MEN-2914

maybe conductor timing out on various services is simply because
they're not fully up yet?

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>