### PR TITLE
Fix[demo]: Move the password generation to use hexdump

### DIFF
--- a/demo
+++ b/demo
@@ -155,7 +155,7 @@ if [[ $retval -ne 0 ]]; then
 fi
 
 USER='mender-demo@example.com'
-PASSWORD=$(base64 /dev/urandom | head -c 12)
+PASSWORD=$(hexdump -n 6 -e '"%X"' < /dev/urandom)
 
 
 RETRY_LIMIT=5


### PR DESCRIPTION
Previously the script would base64 read from /dev/urandom, and pipe the output
to head, which would cut it off at 12 characters, resulting in base64 writing to
a broken pipe, after head exits. This in itself is not a problem, but not the
best programmer etiquette, especially since the error would show up in the
integration test logs, causing unwarranted concern.

Therefore, move the script to use the formatting directive of hexdump, reading
bytes, and printing their hex-values.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>