### PR TITLE
Infra encapsulation: backwards compatible changes

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,4 @@
+# Disable stdout capture, as it conflicts with Fabric
+#  see https://github.com/pytest-dev/pytest/issues/1585
+[pytest]
+addopts = --capture=no

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -1,5 +1,6 @@
-import filelock
 import logging
+import filelock
+
 from .mendertesting import MenderTesting
 
 artifact_lock = filelock.FileLock(".artifact_modification_lock")

--- a/tests/tests/common_update.py
+++ b/tests/tests/common_update.py
@@ -13,15 +13,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from ..common_docker import *
+import tempfile
+import random
+
+from fabric.api import *
+import pytest
+
+from .. import conftest
 from ..common import *
 from ..helpers import Helpers
 from ..MenderAPI import auth_v2, deploy, image, logger
-import random
-from fabric.api import *
-import tempfile
 from . import artifact_lock
-import pytest
 
 
 def common_update_procedure(install_image=None,
@@ -154,7 +156,6 @@ def update_image_failed(install_image="broken_update.ext4",
         The resulting upgrade will be considered a failure.
     """
 
-    devices_accepted = get_mender_clients()
     original_image_id = Helpers.yocto_id_installed_on_machine()
 
     previous_active_part = Helpers.get_active_partition()

--- a/tests/tests/conductor.py
+++ b/tests/tests/conductor.py
@@ -12,7 +12,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-import requests
 from ..MenderAPI.requests_helpers import requests_retry
 
 

--- a/tests/tests/test_00_multi_tenancy.py
+++ b/tests/tests/test_00_multi_tenancy.py
@@ -13,15 +13,19 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import tempfile
+
 from fabric.api import *
 import pytest
+
+from .. import conftest
 from ..common import *
-from ..common_docker import *
-from ..common_setup import *
-from ..helpers import Helpers
-from ..MenderAPI import auth, auth_v2, deploy, image, logger, inv
+from ..common_setup import enterprise_no_client
+from ..common_docker import get_mender_clients, get_mender_client_by_container_name, \
+                            ssh_is_opened, new_tenant_client
 from .common_update import update_image_successful, update_image_failed, \
-                          common_update_procedure
+                           common_update_procedure
+from ..MenderAPI import auth, auth_v2, deploy, image, logger, inv
 from .mendertesting import MenderTesting
 from . import artifact_lock
 

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -13,16 +13,21 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from fabric.api import *
-import pytest
-from ..common import *
-from ..common_setup import *
-from ..helpers import Helpers
-from .common_update import update_image_successful, update_image_failed
-from ..MenderAPI import deploy, image, inv
-from .mendertesting import MenderTesting
 import shutil
 import os
+
+from fabric.api import *
+import pytest
+
+from .. import conftest
+from ..common import *
+from ..common_setup import standard_setup_one_rofs_client_bootstrapped, \
+                           standard_setup_with_short_lived_token, setup_failover, \
+                           standard_setup_one_client_bootstrapped
+from ..common_docker import get_mender_clients
+from .common_update import update_image_successful, update_image_failed
+from ..MenderAPI import image, inv, logger
+from .mendertesting import MenderTesting
 
 class TestBasicIntegration(MenderTesting):
 

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -13,17 +13,19 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import time
+
 from fabric.api import *
 import pytest
-import time
-from ..common import *
-from ..common_docker import *
-from ..common_setup import *
-from ..helpers import Helpers
-from ..MenderAPI import auth, auth_v2, deploy, image, logger
-from .common_update import common_update_procedure
-from .mendertesting import MenderTesting
 
+from .. import conftest
+from ..common import *
+from ..common_setup import standard_setup_one_client, standard_setup_one_client_bootstrapped
+from ..common_docker import get_mender_clients
+from .common_update import common_update_procedure
+from ..helpers import Helpers
+from ..MenderAPI import auth_v2
+from .mendertesting import MenderTesting
 
 
 class TestBootstrapping(MenderTesting):

--- a/tests/tests/test_create_organization.py
+++ b/tests/tests/test_create_organization.py
@@ -13,21 +13,21 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from fabric.api import *
-from requests.auth import HTTPBasicAuth
-import pytest
-from ..common import *
-from ..common_docker import *
-from ..common_setup import *
-from ..MenderAPI.requests_helpers import requests_retry
-from .mendertesting import MenderTesting
-
 import time
-import requests
-import smtpd_mock
 from threading import Thread
 import asyncore
-from ..MenderAPI import *
+
+from requests.auth import HTTPBasicAuth
+from fabric.api import *
+import pytest
+
+import smtpd_mock
+from ..common import *
+from ..common_setup import enterprise_no_client_smtp
+from ..common_docker import get_mender_gateway
+from ..MenderAPI.requests_helpers import requests_retry
+from .mendertesting import MenderTesting
+from ..MenderAPI import api_version
 
 class TestCreateOrganizationEnterprise(MenderTesting):
     @pytest.mark.usefixtures("enterprise_no_client_smtp")

--- a/tests/tests/test_db_migration.py
+++ b/tests/tests/test_db_migration.py
@@ -13,14 +13,21 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import os
+import tempfile
+import logging
+import shutil
+
 from fabric.api import *
 import pytest
-from ..common_setup import *
+
+from .. import conftest
+from ..common_setup import setup_with_legacy_client
+from ..common_docker import get_mender_clients
+from .common_update import update_image_successful, common_update_procedure
 from ..helpers import Helpers
 from ..MenderAPI import deploy
-from .common_update import update_image_successful, common_update_procedure
 from .mendertesting import MenderTesting
-import shutil
 
 class TestDBMigration(MenderTesting):
 

--- a/tests/tests/test_decommission.py
+++ b/tests/tests/test_decommission.py
@@ -13,15 +13,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from fabric.api import *
 import time
+
+from fabric.api import *
 import pytest
-from ..common_setup import *
-from ..helpers import Helpers
+
+from ..common_setup import standard_setup_one_client
+from ..common_docker import get_mender_clients, get_mender_conductor
 from .common_update import common_update_procedure
-from ..MenderAPI import inv, auth_v2
+from ..MenderAPI import inv, auth_v2, logger
 from .mendertesting import MenderTesting
-from conductor import Conductor
+from .conductor import Conductor
 
 
 class TestDeviceDecommissioning(MenderTesting):

--- a/tests/tests/test_demo_artifact.py
+++ b/tests/tests/test_demo_artifact.py
@@ -17,14 +17,14 @@ import logging
 import os
 import signal
 import subprocess
+import time
 
 import pytest
-import requests
 
 from .. import conftest
-from ..common_docker import *
 from ..common_setup import running_custom_production_setup
-from ..MenderAPI import *
+from ..common_docker import stop_docker_compose
+from ..MenderAPI import authentication, deployments, DeviceAuthV2
 from .mendertesting import MenderTesting
 
 

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -13,15 +13,19 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import time
+
 from fabric.api import *
 import pytest
+
+from .. import conftest
 from ..common import *
-from ..common_setup import *
-from ..helpers import Helpers
+from ..common_setup import standard_setup_one_client_bootstrapped
+from ..common_docker import get_mender_clients
 from .common_update import common_update_procedure
-from ..MenderAPI import auth_v2, deploy, image
+from ..helpers import Helpers
+from ..MenderAPI import auth_v2, deploy
 from .mendertesting import MenderTesting
-import time
 
 @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
 class TestDeploymentAborting(MenderTesting):

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -13,20 +13,24 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from fabric.api import *
+import os
 import json
-import pytest
 import re
 import shutil
-import subprocess
 import tempfile
 import time
-from ..common_setup import *
-from ..helpers import Helpers
-from ..MenderAPI import deploy, image, logger
-from .common_update import *
-from .mendertesting import MenderTesting
+
+import pytest
+from fabric.api import *
+
+from .. import conftest
 from ..common import *
+from ..common_setup import standard_setup_one_client_bootstrapped
+from ..common_docker import get_mender_clients
+from .common_update import common_update_procedure, update_image_failed
+from ..helpers import Helpers
+from ..MenderAPI import deploy
+from .mendertesting import MenderTesting
 
 DOWNLOAD_RETRY_TIMEOUT_TEST_SETS = [
     {

--- a/tests/tests/test_grouping.py
+++ b/tests/tests/test_grouping.py
@@ -15,13 +15,15 @@
 
 from fabric.api import *
 import pytest
-import time
+
+from .. import conftest
 from ..common import *
-from ..common_setup import *
-from ..helpers import Helpers
+from ..common_setup import standard_setup_two_clients_bootstrapped
+from ..common_docker import get_mender_clients
 from .common_update import common_update_procedure
-from ..MenderAPI import deploy, inv
+from ..MenderAPI import inv, deploy
 from .mendertesting import MenderTesting
+from ..helpers import Helpers
 
 @MenderTesting.fast
 @pytest.mark.usefixtures("standard_setup_two_clients_bootstrapped")

--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -15,12 +15,14 @@
 
 from fabric.api import *
 import pytest
-import time
+
+from .. import conftest
 from ..common import *
-from ..common_setup import *
-from ..helpers import Helpers
-from ..MenderAPI import auth_v2, deploy, image, logger
+from ..common_setup import standard_setup_one_client_bootstrapped
+from ..common_docker import get_mender_clients
 from .common_update import common_update_procedure
+from ..helpers import Helpers
+from ..MenderAPI import auth_v2, deploy
 from .mendertesting import MenderTesting
 
 @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")

--- a/tests/tests/test_inventory.py
+++ b/tests/tests/test_inventory.py
@@ -13,14 +13,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from fabric.api import *
 import json
+
+from fabric.api import *
 import pytest
-import time
+
+from .. import conftest
 from ..common import *
-from ..common_setup import *
-from ..helpers import Helpers
-from ..MenderAPI import auth_v2, deploy, image, inv
+from ..common_setup import standard_setup_one_client_bootstrapped
+from ..MenderAPI import auth_v2, inv
 from .mendertesting import MenderTesting
 
 @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")

--- a/tests/tests/test_os_ent_migration.py
+++ b/tests/tests/test_os_ent_migration.py
@@ -12,25 +12,24 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-import pytest
-import logging
 import subprocess
-import requests
 import time
 import json
+import os
 
-from ..conftest import docker_compose_instance
+import requests
+import pytest
 
-from ..common_docker import *
-from .conductor import Conductor
-
-from testutils.common import create_user, make_accepted_device, Device, User, Tenant
+from testutils.common import create_user, make_accepted_device, User, Tenant
 from testutils.api.client import ApiClient
 from testutils.infra.cli import CliTenantadm
 import testutils.api.deviceauth as deviceauth_v1
 import testutils.api.deviceauth_v2 as deviceauth_v2
 import testutils.api.deployments as deployments
 import testutils.api.useradm as useradm
+from ..conftest import docker_compose_instance
+from ..common_docker import docker_compose_cmd, stop_docker_compose, stop_docker_compose_exclude, \
+                            get_mender_gateway, get_mender_conductor, COMPOSE_FILES_PATH
 
 @pytest.fixture(scope="class")
 def initial_os_setup():

--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -13,19 +13,19 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from fabric.api import *
-from .mendertesting import MenderTesting
-from ..common_setup import *
-from ..MenderAPI import auth_v2, inv
-import pytest
 import json
 import logging
-
+import time
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 
-import time
+from fabric.api import *
+import pytest
+
+from ..common_setup import standard_setup_one_client, enterprise_no_client
+from ..common_docker import get_mender_clients, new_tenant_client, ssh_is_opened
+from .mendertesting import MenderTesting
+from ..MenderAPI import auth, auth_v2, inv
 
 
 class TestPreauthBase(MenderTesting):

--- a/tests/tests/test_security.py
+++ b/tests/tests/test_security.py
@@ -13,23 +13,22 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from fabric.api import *
-import pytest
-from ..common import *
-from ..common_docker import *
-from ..common_setup import *
-from ..helpers import Helpers
-from ..MenderAPI import auth, deploy, image, logger
-from .common_update import common_update_procedure
-from .mendertesting import MenderTesting
-import subprocess
 import sys
-sys.path.insert(0, '..')
-from .. import conftest
+import subprocess
 import contextlib
 import ssl
 import socket
 import time
+
+from fabric.api import *
+import pytest
+
+from .. import conftest
+from ..common import *
+from ..common_setup import running_custom_production_setup, standard_setup_with_short_lived_token
+from ..common_docker import get_mender_clients
+from .common_update import common_update_procedure
+from .mendertesting import MenderTesting
 
 class TestSecurity(MenderTesting):
 

--- a/tests/tests/test_signed_image_update.py
+++ b/tests/tests/test_signed_image_update.py
@@ -15,12 +15,13 @@
 
 from fabric.api import *
 import pytest
-import time
+
+from .. import conftest
 from ..common import *
-from ..common_setup import *
-from ..helpers import Helpers
-from ..MenderAPI import auth_v2, deploy, image, logger
-from .common_update import update_image_successful, update_image_failed, common_update_procedure
+from ..common_setup import standard_setup_with_signed_artifact_client
+from ..common_docker import get_mender_clients
+from .common_update import update_image_successful, common_update_procedure
+from ..MenderAPI import auth_v2, deploy
 from .mendertesting import MenderTesting
 
 @MenderTesting.fast

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -13,20 +13,23 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import json
 import logging
 import shutil
 import time
+import os
+import subprocess
 
 from fabric.api import *
 import pytest
+
+from .. import conftest
+from ..common import *
+from ..common_setup import standard_setup_one_client_bootstrapped
+from ..common_docker import get_mender_clients
+from .common_update import common_update_procedure
 from ..helpers import Helpers
 from ..MenderAPI import deploy
 from .mendertesting import MenderTesting
-from ..common_docker import *
-from ..common_setup import *
-from .common_update import *
-from ..common import *
 
 logger = logging.getLogger("root")
 

--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -13,15 +13,22 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import os
+import subprocess
+import tempfile
+import shutil
+
 from fabric.api import *
 import pytest
-from ..helpers import Helpers
-from .common_update import *
-from ..MenderAPI import deploy, image
-from .mendertesting import MenderTesting
-from ..common_setup import *
-import shutil
+
+from .. import conftest
 from ..common import *
+from ..common_setup import standard_setup_one_docker_client_bootstrapped, \
+                           standard_setup_one_client_bootstrapped
+from ..common_docker import docker_compose_cmd, get_mender_clients
+from .common_update import common_update_procedure, update_image_successful
+from ..MenderAPI import deploy, logger
+from .mendertesting import MenderTesting
 
 class TestUpdateModules(MenderTesting):
     @MenderTesting.fast


### PR DESCRIPTION
Collecting in this PR some changes I am making in the test framework that are backwards compatible. This will ease the final review.

The main change is the imports clean-up