### PR TITLE
smoke test for minio

### DIFF
--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -22,6 +22,7 @@ from . import conftest
 from .MenderAPI import auth, auth_v2, reset_mender_api
 from .common import *
 from .common_docker import *
+import testutils.util.smoke as smoke
 
 def wait_for_containers(expected_containers, defined_in):
     for _ in range(60 * 5):
@@ -40,6 +41,7 @@ def standard_setup_one_client(request):
     reset_mender_api()
 
 
+
 def setup_set_client_number_bootstrapped(clients):
     docker_compose_cmd("scale mender-client=%d" % clients)
     ssh_is_opened()
@@ -52,6 +54,9 @@ def setup_set_client_number_bootstrapped(clients):
 def standard_setup_one_client_bootstrapped():
     restart_docker_compose()
     reset_mender_api()
+
+    smoke_test()
+
     auth_v2.accept_devices(1)
 
 
@@ -65,6 +70,9 @@ def standard_setup_one_rofs_client_bootstrapped():
     ssh_is_opened()
 
     auth.reset_auth_token()
+
+    smoke_test()
+
     auth_v2.accept_devices(1)
 
 
@@ -81,6 +89,8 @@ def standard_setup_one_docker_client_bootstrapped():
 
     ssh_is_opened()
 
+    smoke_test()
+
     auth.reset_auth_token()
     auth_v2.accept_devices(1)
 
@@ -88,6 +98,9 @@ def standard_setup_one_docker_client_bootstrapped():
 def standard_setup_two_clients_bootstrapped():
     restart_docker_compose(2)
     reset_mender_api()
+
+    smoke_test()
+
     auth_v2.accept_devices(2)
 
 @pytest.fixture(scope="function")
@@ -99,6 +112,8 @@ def standard_setup_without_client():
                         -f " + COMPOSE_FILES_PATH + "/docker-compose.storage.minio.yml \
                         -f " + COMPOSE_FILES_PATH + "/docker-compose.testing.yml up -d",
                        use_common_files=False)
+
+    smoke_test()
 
 @pytest.fixture(scope="function")
 def setup_with_legacy_client():
@@ -119,6 +134,9 @@ def setup_with_legacy_client():
                        use_common_files=False)
 
     ssh_is_opened()
+
+    smoke_test()
+
     auth_v2.accept_devices(1)
 
 @pytest.fixture(scope="function")
@@ -130,6 +148,9 @@ def standard_setup_with_signed_artifact_client(request):
 
     ssh_is_opened()
     auth.reset_auth_token()
+
+    smoke_test()
+
     auth_v2.accept_devices(1)
 
 
@@ -147,6 +168,9 @@ def standard_setup_with_short_lived_token():
 
     ssh_is_opened()
     auth.reset_auth_token()
+
+    smoke_test()
+
     auth_v2.accept_devices(1)
 
 @pytest.fixture(scope="function")
@@ -240,3 +264,7 @@ def get_host_ip():
     host_ip = s.getsockname()[0]
     s.close()
     return host_ip
+
+def smoke_test():
+    ip = docker_get_ip_of('minio')
+    smoke.minio(ip[0])

--- a/testutils/util/smoke.py
+++ b/testutils/util/smoke.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# Copyright 2019 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+"""
+Smoke tests for various components in our setup.
+
+Answer the question: is my particular component, that I'll soon rely on, really up and running (ports exposed, etc)."
+
+Compose these in e.g. test fixtures for the complete smoke test of your setup.
+"""
+
+import requests
+import logging
+
+def minio(ip):
+    for check in ['live', 'ready']:
+        r = requests.get("http://{}:9000/minio/health/{}".format(ip, check))
+        if r.status_code != 200:
+            m = "'{}' check for minio returned with http {}".format(check, r.status_code)
+            logging.error(m)
+            raise RuntimeError(m)
+        else:
+            logging.info("'{}' check for minio ok".format(check))


### PR DESCRIPTION
minio is the most probable culprit in our integration issues.

add a smoke test to every fixture which verifies that minio is indeed up and serving.

right now a single check is performed on 2 health-check endpoints, exposed by minio itself.
an alternative would be to curl some api endpoint, but this is cleaner (if the healthcheck endpoints actually work).

TODO:
- build timeout/retry logic into smoke tests?
- port some existing smoke tests for conductor to this module (long term)