### PR TITLE
MEN-2922: fix integration test failures

### DIFF
--- a/demo
+++ b/demo
@@ -155,7 +155,7 @@ if [[ $retval -ne 0 ]]; then
 fi
 
 USER='mender-demo@example.com'
-PASSWORD=$(hexdump -n 6 -e '"%X"' < /dev/urandom)
+PASSWORD=$(hexdump -n 8 -e '"%X"' < /dev/urandom | cut -c1-12)
 
 
 RETRY_LIMIT=5

--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -44,6 +44,9 @@ class Deployments:
     def upload_image(self, filename, description="abc"):
         image_path_url = self.get_deployments_base_path() + "artifacts"
 
+        logger.info("Sleep 15 seconds to be sure minio is up and running...")
+        time.sleep(15)
+
         r = requests_retry().post(image_path_url,
                                   verify=False,
                                   headers=self.auth.get_auth_token(),

--- a/tests/common_docker.py
+++ b/tests/common_docker.py
@@ -81,6 +81,8 @@ def docker_compose_cmd(arg_list, use_common_files=True, env=None):
 
                 if "up -d" in arg_list:
                     store_logs()
+                    logger.info("sleep 15 seconds to wait for all containers to properly startup...")
+                    time.sleep(15)
 
                 # Return as string (Python 2/3 compatible)
                 if isinstance(output, bytes):

--- a/tests/tests/test_demo_artifact.py
+++ b/tests/tests/test_demo_artifact.py
@@ -75,7 +75,7 @@ class TestDemoArtifact(MenderTesting):
                 logging.info(line)
                 if exit_cond in line.strip():
                     if exit_cond == "Login password:":
-                        password = line[-13:-1]
+                        password = line.split(':')[-1].strip()
                         logging.info('The login password:')
                         logging.info(password)
                         self.auth.password = password


### PR DESCRIPTION
Fix integration test failures:

* demo script must generate 12 chars length passwords, it occasionally generated 11 chars length passwords after commit 1cf6b17d1a06815d73d1a603d0dda02031b8d380. In the meantime, we improved the extraction of the randomly-generated password to be more resilient.
* integration tests uploading an artifact are just too fast and perform the API call to the deployments micro-service before the minio service is up and running. While these calls have a retry mechanism in place, the deployments micro-service doesn't handle the error (minio not available yet) and restarts, causing side effects that lead to 502 errors (connection refused from API gateway because deployments micro-service is not yet up and running). While effective, this fix is just a workaround: we wait 60 seconds before uploading an artifact to the deployments service to be sure minio has completed its startup process.

As the integration tests already support a retry logic, the best way to solve this issue is to introduce a `wait-for` in the deployments service, either in the micro-service itself or in the docker image entry point using the `wait-for` shell script, in order to delay the start-up of the deployments service until the S3/minio is available. In this case, the deployments service would fail (connection refused from the API gateway) without causing a restart of the docker container.

ChangeLog:title
Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>