### PR TITLE
Fix integration test failures: demo script

### DIFF
--- a/demo
+++ b/demo
@@ -155,7 +155,7 @@ if [[ $retval -ne 0 ]]; then
 fi
 
 USER='mender-demo@example.com'
-PASSWORD=$(hexdump -n 6 -e '"%X"' < /dev/urandom)
+PASSWORD=$(hexdump -n 8 -e '"%X"' < /dev/urandom | cut -c1-12)
 
 
 RETRY_LIMIT=5

--- a/tests/tests/test_demo_artifact.py
+++ b/tests/tests/test_demo_artifact.py
@@ -75,7 +75,7 @@ class TestDemoArtifact(MenderTesting):
                 logging.info(line)
                 if exit_cond in line.strip():
                     if exit_cond == "Login password:":
-                        password = line[-13:-1]
+                        password = line.split(':')[-1].strip()
                         logging.info('The login password:')
                         logging.info(password)
                         self.auth.password = password


### PR DESCRIPTION
Fix integration test failures: demo script

demo script must generate 12 chars length passwords, it occasionally generated
11 chars length passwords after commit 1cf6b17. In the meantime, we improved
the extraction of the randomly-generated password to be more resilient.

Changelog: None

Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>