### PR TITLE
backend-tests: sort randomly created devices by device id

### DIFF
--- a/backend-tests/tests/test_devauth_v2.py
+++ b/backend-tests/tests/test_devauth_v2.py
@@ -362,7 +362,7 @@ def make_devs_with_authsets(user, tenant_token=''):
     for i in range(2):
         dev = make_preauthd_device_with_pending(utoken, num_pending=2, tenant_token=tenant_token)
         devices.append(dev)
-
+    devices.sort(key=lambda dev: dev.id)
     return devices
 
 @pytest.yield_fixture(scope="function")


### PR DESCRIPTION
tests based on make_devs_with_authsets method were passing accidentally in the past, just because the method used for generating dev ids was producing increasing monotonically values which is no longer true