### PR TITLE
backend-tests: fix devauth test logic

### DIFF
--- a/backend-tests/tests/test_devauth_v2.py
+++ b/backend-tests/tests/test_devauth_v2.py
@@ -1079,8 +1079,8 @@ class TestAuthsetMgmtBase:
             # authset should be gone
             dev.authsets.remove(aset)
 
-            # if it's the last authset of a preauth'd device - the device should be completely gone
-            if dev.status == 'preauthorized' and len(dev.authsets) == 0:
+            # removing preauth authset - the device should be completely gone
+            if dev.status == 'preauthorized':
                 r = devauthm.with_auth(utoken).call('GET',
                                           deviceauth_v2.URL_DEVICE,
                                           path_params={'id': dev.id})


### PR DESCRIPTION
If the device is in the preauthorization state and we are removing
authentication set with preauthorization status the devices should be
removed completely no matter if there are pending or rejected
authentication sets for the device or not.

The reason why the test was passing is that we were retrieving the device
which was just removed. It was possible with mongo 3.4 and the old
driver and it's still possible with mongo 3.6 and the new driver, but
the probability is lower.
