### PR TITLE
QA-121: Unify the pytest environment variables passed to run.sh

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -148,16 +148,16 @@ debugfs -w -R "rm /lib/systemd/systemd-networkd" core-image-full-cmdline-$MACHIN
 
 dd if=/dev/urandom of=broken_update.ext4 bs=10M count=5
 
-XDIST_ARGS="${XDIST_ARGS:--n ${XDIST_PARALLEL_ARG:-auto}}"
-MAX_FAIL_ARG="--maxfail=1"
+# Contains either the arguments to xdists, or '--maxfail=1', if xdist not found.
+EXTRA_TEST_ARGS=
 HTML_REPORT="--html=report.html --self-contained-html"
 
 if ! pip2 list |grep -e pytest-xdist >/dev/null 2>&1; then
-    XDIST_ARGS=""
+    EXTRA_TEST_ARGS="--maxfail=1"
     echo "WARNING: install pytest-xdist for running tests in parallel"
 else
     # run all tests when running in parallel
-    MAX_FAIL_ARG=""
+    EXTRA_TEST_ARGS="${XDIST_ARGS:--n ${XDIST_PARALLEL_ARG:-auto}}"
 fi
 
 if ! pip2 list|grep -e pytest-html >/dev/null 2>&1; then
@@ -170,8 +170,7 @@ if [[ -n $SPECIFIC_INTEGRATION_TEST ]]; then
 fi
 
 python2 -m pytest \
-    $XDIST_ARGS \
-    $MAX_FAIL_ARG \
+    $EXTRA_TEST_ARGS \
     --verbose \
     --junitxml=results.xml \
     $HTML_REPORT \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -157,7 +157,7 @@ if ! pip2 list |grep -e pytest-xdist >/dev/null 2>&1; then
     echo "WARNING: install pytest-xdist for running tests in parallel"
 else
     # run all tests when running in parallel
-    EXTRA_TEST_ARGS="${XDIST_ARGS:--n ${XDIST_PARALLEL_ARG:-auto}}"
+    EXTRA_TEST_ARGS="${XDIST_ARGS:--n ${TESTS_IN_PARALLEL:-auto}}"
 fi
 
 if ! pip2 list|grep -e pytest-html >/dev/null 2>&1; then


### PR DESCRIPTION
Previously two environment variables were used, although the functionality was
complementary of eachother. The functionality was set, depending on whether or
not xdists was installed. If it was installed then either the XDISTS_ARGS
variables was passed to pytest. It xdist was not installed then pytest would be
given a --maxfail=1 parameter.

This commit unifies these options into one variable, the EXTRA_TEST_ARGS
variable, which is set according to the functionality described above.

Changelog: Commit

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>