### PR TITLE
QA-129: Enforce Python3 code formatting 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,9 +2,15 @@
 include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-commits.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-python3-format.yml'
 
 stages:
   - test
+
+test:check-python3-formatting:
+  variables:
+    FORMAT_DIRECTORIES: "tests/acceptance"
 
 test:extra-tools:
   image: "python:3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+# Simple configuration for the Black Python code formatter
+[tool.black]
+target-version = ['py38']


### PR DESCRIPTION
This commit adds a Gitlab Pipeline to the repository, which verifies that all
the code in the tests/acceptance directory is formatted according to the Black
Python3 code formatter.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>