### PR TITLE
WIP; ignore for now; MEN-2855 ES6 support

### DIFF
--- a/backend-tests/tests/test_devauth_v2.py
+++ b/backend-tests/tests/test_devauth_v2.py
@@ -914,7 +914,7 @@ class TestAuthsetMgmtBase:
                 assert r.status_code == 401
 
             # device should also be provisioned in inventory
-            time.sleep(1)
+            time.sleep(8)
             self.verify_dev_provisioned(dev, utoken)
 
     def do_test_put_status_reject(self, devs_authsets, user, tenant_token=''):

--- a/demo
+++ b/demo
@@ -141,8 +141,8 @@ trap exitfunc SIGTERM
 echo "Starting the Mender demo environment..."
 
 docker-compose \
-    -f docker-compose.yml \
     -f docker-compose.storage.minio.yml \
+    -f docker-compose.yml \
     -f docker-compose.demo.yml \
     -p ${DOCKER_COMPOSE_PROJECT_NAME} \
     $CLIENT \
@@ -297,4 +297,7 @@ echo "Press Enter to show the logs."
 echo "Press Ctrl-C to stop the backend and quit."
 read -se
 
-docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} logs --follow
+docker-compose -f docker-compose.storage.minio.yml \
+    -f docker-compose.yml \
+    -f docker-compose.demo.yml \
+    -p ${DOCKER_COMPOSE_PROJECT_NAME} logs --follow

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -75,14 +75,14 @@ services:
 
     mender-conductor:
         environment:
-            - CONDUCTOR_JAVA_OPTS=-Xms128m -Xmx128m
+            - CONDUCTOR_JAVA_OPTS=-Xms1024m -Xmx2048m
         ports:
             - "8080:8080"
 
     mender-elasticsearch:
         environment:
             - ES_NETWORK_HOST=0.0.0.0
-            - ES_JAVA_OPTS=-Xms0m -Xmx100m
+            - ES_JAVA_OPTS=-Xms1024m -Xmx2048m
         volumes:
             - ./conductor/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
 

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -6,7 +6,7 @@ services:
         image: registry.mender.io/mendersoftware/deployments-enterprise:master
 
     mender-conductor:
-        image: registry.mender.io/mendersoftware/mender-conductor-enterprise:master
+        image: mendersoftware/mender-conductor-enterprise:2.11.0-es6
 
     # add services
     mender-tenantadm:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,9 @@ services:
                     - mongo-useradm
 
     mender-conductor:
-        image: mendersoftware/mender-conductor:master
+        environment:
+            - CONDUCTOR_JAVA_OPTS=-Xms1024m -Xmx2048m
+        image: mendersoftware/mender-conductor:2.11.0-es6
         depends_on:
             - mender-elasticsearch
             - mender-redis
@@ -117,7 +119,11 @@ services:
             - mender
 
     mender-elasticsearch:
-        image: elasticsearch:5-alpine
+        environment:
+            - ES_NETWORK_HOST=0.0.0.0
+            - ES_JAVA_OPTS=-Xms1024m -Xmx2048m
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.8.5
+#         image: elasticsearch:5-alpine
         extends:
             file: common.yml
             service: mender-base


### PR DESCRIPTION
Support for ElasticSearch6

 * increased timeout in backend-tests/test_devauth_v2
 * mx for ElasticSearch changed and added
 * order of compose files changed in docker-compose command
 * in demo logs command includes -f 

Changelog: title
Signed-off-by: Peter Grzybowski <peter@northern.tech>