### PR TITLE
Add support for LibreSSL in keygen

### DIFF
--- a/keygen
+++ b/keygen
@@ -15,11 +15,11 @@ FILE_NAME_CERT="cert.crt"
 # verify openssl is present and sufficiently recent (genpkey seems to require openssl 1.0+)
 command -v openssl >/dev/null 2>&1 || { echo >&2 "ERROR: Please install the openssl utility version 1.0.0 or newer to generate keys."; exit 1; }
 
-OPENSSL_VERSION_REGEX_MAJOR_BACKREF="OpenSSL ([0-9]+).*"
+OPENSSL_VERSION_REGEX_MAJOR_BACKREF="(Open|Libre)SSL ([0-9]+).*"
 OPENSSL_VERSION_STRING=$(openssl version)
-OPENSSL_VERSION_MAJOR=$(echo "$OPENSSL_VERSION_STRING" | sed -En "s/$OPENSSL_VERSION_REGEX_MAJOR_BACKREF/\1/p")
+OPENSSL_VERSION_MAJOR=$(echo "$OPENSSL_VERSION_STRING" | sed -En "s/$OPENSSL_VERSION_REGEX_MAJOR_BACKREF/\2/p")
 
-if [ "$OPENSSL_VERSION_MAJOR" != "1" ]; then
+if [ "$OPENSSL_VERSION_MAJOR" -lt 1 ]; then
   echo "ERROR: openssl is too old, need version 1.0.0 or newer"
   echo "ERROR: OPENSSL_VERSION_STRING=$OPENSSL_VERSION_STRING"
   exit 1


### PR DESCRIPTION
keygen script verifies if the version of OpenSSL is 1.0.0 or greater.
On recent Mac OS X systems LibreSSL is installed. We update the keygen
script to support LibreSSL.

Changelog: none
Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>