### PR TITLE
Improve robustness of docker_compose_manager and related fixes

### DIFF
--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -16,7 +16,6 @@
 import time
 import json
 import os
-import logging
 import requests
 import pytest
 
@@ -71,7 +70,7 @@ class Deployments:
                                   data=json.dumps(trigger_data), verify=False)
 
         logger.debug("triggering deployment with: " + json.dumps(trigger_data))
-        logging.info("deployment returned: " + r.text)
+        logger.info("deployment returned: " + r.text)
         assert r.status_code == requests.status_codes.codes.created
 
         deployment_id = str(r.headers['Location'].split("/")[-1])

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 
 import time
-import logging
 
 from platform import python_version
 if python_version().startswith('2'):
@@ -29,7 +28,6 @@ else:
 # environment if we don't have to.
 SETUP_TYPE = None
 
-HAVE_TOKEN_TIMEOUT = 60 * 5
 MENDER_STORE = '/data/mender/mender-store'
 
 
@@ -112,19 +110,3 @@ def run(cmd, *args, **kw):
 # to be changed later.
 def sudo(*args, **kw):
     run(*args, **kw)
-
-
-def have_token():
-    """ Make sure the MENDER_STORE file exists after sometime, else fail test """
-
-    sleepsec = 0
-    while sleepsec < HAVE_TOKEN_TIMEOUT:
-        try:
-            run('strings {} | grep authtoken'.format(MENDER_STORE))
-            return
-        except Exception:
-            sleepsec += 5
-            time.sleep(5)
-            logging.info("waiting for mender-store file, sleepsec: %d" % sleepsec)
-
-    assert sleepsec <= HAVE_TOKEN_TIMEOUT, "timeout for mender-store file exceeded"

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -25,75 +25,69 @@ container_factory = factory.get_factory()
 @pytest.fixture(scope="function")
 def standard_setup_one_client(request):
     env = container_factory.getStandardSetup(num_clients=1)
-    env.setup()
+    request.addfinalizer(env.teardown)
 
+    env.setup()
     Helpers.ssh_is_opened(env.get_mender_clients())
     reset_mender_api(env)
-
-    request.addfinalizer(env.teardown)
 
     return env
 
 @pytest.fixture(scope="function")
 def standard_setup_one_client_bootstrapped(request):
     env = container_factory.getStandardSetup(num_clients=1)
-    env.setup()
+    request.addfinalizer(env.teardown)
 
+    env.setup()
     Helpers.ssh_is_opened(env.get_mender_clients())
     reset_mender_api(env)
     auth_v2.accept_devices(1)
-
-    request.addfinalizer(env.teardown)
 
     return env
 
 @pytest.fixture(scope="function")
 def standard_setup_one_rofs_client_bootstrapped(request):
     env = container_factory.getRofsClientSetup()
-    env.setup()
+    request.addfinalizer(env.teardown)
 
+    env.setup()
     Helpers.ssh_is_opened(env.get_mender_clients())
     reset_mender_api(env)
     auth_v2.accept_devices(1)
-
-    request.addfinalizer(env.teardown)
 
     return env
 
 @pytest.fixture(scope="function")
 def standard_setup_one_docker_client_bootstrapped(request):
     env = container_factory.getDockerClientSetup()
-    env.setup()
+    request.addfinalizer(env.teardown)
 
+    env.setup()
     Helpers.ssh_is_opened(env.get_mender_clients())
     reset_mender_api(env)
     auth_v2.accept_devices(1)
-
-    request.addfinalizer(env.teardown)
 
     return env
 
 @pytest.fixture(scope="function")
 def standard_setup_two_clients_bootstrapped(request):
     env = container_factory.getStandardSetup(num_clients=2)
-    env.setup()
+    request.addfinalizer(env.teardown)
 
+    env.setup()
     Helpers.ssh_is_opened(env.get_mender_clients())
     reset_mender_api(env)
     auth_v2.accept_devices(2)
-
-    request.addfinalizer(env.teardown)
 
     return env
 
 @pytest.fixture(scope="function")
 def standard_setup_without_client(request):
     env = container_factory.getStandardSetup(num_clients=0)
-    env.setup()
-
-    reset_mender_api(env)
-
     request.addfinalizer(env.teardown)
+
+    env.setup()
+    reset_mender_api(env)
 
     return env
 
@@ -106,55 +100,51 @@ def setup_with_legacy_client(request):
                     % conftest.machine_name)
 
     env = container_factory.getLegacyClientSetup()
-    env.setup()
+    request.addfinalizer(env.teardown)
 
+    env.setup()
     Helpers.ssh_is_opened(env.get_mender_clients())
     reset_mender_api(env)
     auth_v2.accept_devices(1)
-
-    request.addfinalizer(env.teardown)
 
     return env
 
 @pytest.fixture(scope="function")
 def standard_setup_with_signed_artifact_client(request):
     env = container_factory.getSignedArtifactClientSetup()
-    env.setup()
+    request.addfinalizer(env.teardown)
 
+    env.setup()
     Helpers.ssh_is_opened(env.get_mender_clients())
     reset_mender_api(env)
     auth.reset_auth_token()
     auth_v2.accept_devices(1)
-
-    request.addfinalizer(env.teardown)
 
     return env
 
 @pytest.fixture(scope="function")
 def standard_setup_with_short_lived_token(request):
     env = container_factory.getShortLivedTokenSetup()
-    env.setup()
+    request.addfinalizer(env.teardown)
 
+    env.setup()
     Helpers.ssh_is_opened(env.get_mender_clients())
     reset_mender_api(env)
     auth.reset_auth_token()
     auth_v2.accept_devices(1)
-
-    request.addfinalizer(env.teardown)
 
     return env
 
 @pytest.fixture(scope="function")
 def setup_failover(request):
     env = container_factory.getFailoverServerSetup()
-    env.setup()
+    request.addfinalizer(env.teardown)
 
+    env.setup()
     reset_mender_api(env)
     Helpers.ssh_is_opened(env.get_mender_clients())
     auth.reset_auth_token()
     auth_v2.accept_devices(1)
-
-    request.addfinalizer(env.teardown)
 
     return env
 
@@ -164,33 +154,32 @@ def running_custom_production_setup(request):
 
     env = container_factory.getCustomSetup()
 
-    reset_mender_api(env)
-
     def fin():
         env.teardown()
         conftest.production_setup_lock.release()
 
     request.addfinalizer(fin)
 
+    reset_mender_api(env)
+
     return env
 
 @pytest.fixture(scope="function")
 def enterprise_no_client(request):
     env = container_factory.getEnterpriseSetup(num_clients=0)
-    env.setup()
-
-    reset_mender_api(env)
-
     request.addfinalizer(env.teardown)
+
+    env.setup()
+    reset_mender_api(env)
 
     return env
 
 @pytest.fixture(scope="function")
 def enterprise_no_client_smtp(request):
     env = container_factory.getEnterpriseSMTPSetup()
+    request.addfinalizer(env.teardown)
+
     env.setup()
     reset_mender_api(env)
-
-    request.addfinalizer(env.teardown)
 
     return env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,36 +142,6 @@ def pytest_exception_interact(node, call, report):
         for line in output.split('\n'):
             logger.info(line)
 
-
-@pytest.mark.hookwrapper
-def pytest_runtest_makereport(item, call):
-    pytest_html = item.config.pluginmanager.getplugin('html')
-    if pytest_html is None:
-        yield
-        return
-    outcome = yield
-    report = outcome.get_result()
-    extra = getattr(report, 'extra', [])
-    if report.failed:
-        url = ""
-        if os.getenv("UPLOAD_BACKEND_LOGS_ON_FAIL", False):
-            if len(log_files) > 0:
-                # we already have s3cmd configured on our build machine, so use it directly
-                s3_object_name = str(uuid.uuid4()) + ".log"
-                ret = subprocess.call("s3cmd put %s s3://mender-backend-logs/%s" % (log_files[-1], s3_object_name), shell=True)
-                if int(ret) == 0:
-                    url = "https://s3-eu-west-1.amazonaws.com/mender-backend-logs/" + s3_object_name
-                else:
-                    logger.warn("uploading backend logs failed.")
-            else:
-                logger.warn("no log files found, did the backend actually start?")
-        else:
-            logger.warn("not uploading backend log files because UPLOAD_BACKEND_LOGS_ON_FAIL not set")
-
-        # always add url to report
-        extra.append(pytest_html.extras.url(url))
-        report.extra = extra
-
 def pytest_unconfigure(config):
     for log in log_files:
         try:

--- a/tests/log.py
+++ b/tests/log.py
@@ -1,7 +1,6 @@
 import logging
 
-
-def setup_custom_logger(name, testname):
+def setup_custom_logger(name, testname, worker_id=None):
     log_format = "%(asctime)s [%(levelname)s]: >> %(message)s"
 
     logging.basicConfig(format=log_format, level=logging.INFO)
@@ -12,7 +11,10 @@ def setup_custom_logger(name, testname):
 
     consoleHandler = logging.StreamHandler()
     logFormatter = logging.Formatter(log_format)
-    logFormatter._fmt = testname + " -- " + logFormatter._fmt
+    if worker_id is not None:
+        logFormatter._fmt = "[{}] {} --".format(worker_id, testname) + logFormatter._fmt
+    else:
+        logFormatter._fmt = testname + " -- " + logFormatter._fmt
     consoleHandler.setFormatter(logFormatter)
     logger.addHandler(consoleHandler)
     logging.getLogger(name).addHandler(consoleHandler)

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -1,7 +1,5 @@
-import logging
 import filelock
 
 from .mendertesting import MenderTesting
 
 artifact_lock = filelock.FileLock(".artifact_modification_lock")
-logger = logging.getLogger("mender")

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -23,7 +23,7 @@ from ..common import *
 from ..common_setup import standard_setup_one_client, standard_setup_one_client_bootstrapped
 from .common_update import common_update_procedure
 from ..helpers import Helpers
-from ..MenderAPI import auth_v2
+from ..MenderAPI import auth_v2, logger
 from .mendertesting import MenderTesting
 
 
@@ -44,7 +44,7 @@ class TestBootstrapping(MenderTesting):
         # iterate over devices and accept them
         for d in auth_v2.get_devices():
             auth_v2.set_device_auth_set_status(d["id"], d["auth_sets"][0]["id"], "accepted")
-            logging.info("Accepting DeviceID: %s" % d["id"])
+            logger.info("Accepting DeviceID: %s" % d["id"])
 
         # make sure all devices are accepted
         auth_v2.check_expected_status("accepted", len(mender_clients))
@@ -59,13 +59,13 @@ class TestBootstrapping(MenderTesting):
             except Exception:
                 sleepsec += 5
                 time.sleep(5)
-                logging.info("waiting for mender-store file, sleepsec: %d" % sleepsec)
+                logger.info("waiting for mender-store file, sleepsec: %d" % sleepsec)
 
         assert sleepsec <= HAVE_TOKEN_TIMEOUT, "timeout for mender-store file exceeded"
 
         # print all device ids
         for device in auth_v2.get_devices_status("accepted"):
-            logging.info("Accepted DeviceID: %s" % device["id"])
+            logger.info("Accepted DeviceID: %s" % device["id"])
 
     @MenderTesting.slow
     def test_reject_bootstrap(self, standard_setup_one_client_bootstrapped):
@@ -82,7 +82,7 @@ class TestBootstrapping(MenderTesting):
         # iterate over devices and reject them
         for device in auth_v2.get_devices():
             auth_v2.set_device_auth_set_status(device["id"], device["auth_sets"][0]["id"], "rejected")
-            logging.info("Rejecting DeviceID: %s" % device["id"])
+            logger.info("Rejecting DeviceID: %s" % device["id"])
 
         auth_v2.check_expected_status("rejected", len(mender_clients))
 
@@ -91,7 +91,7 @@ class TestBootstrapping(MenderTesting):
             try:
                 deployment_id, _ = common_update_procedure(install_image=conftest.get_valid_image())
             except AssertionError:
-                logging.info("Failed to deploy upgrade to rejected device.")
+                logger.info("Failed to deploy upgrade to rejected device.")
                 reboot.verify_reboot_not_performed()
 
             else:

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -49,8 +49,19 @@ class TestBootstrapping(MenderTesting):
         # make sure all devices are accepted
         auth_v2.check_expected_status("accepted", len(mender_clients))
 
-        # make sure mender-store contains authtoken
-        have_token()
+        # make sure mender-store contains authtoken after sometime, else fail test
+        HAVE_TOKEN_TIMEOUT = 60 * 5
+        sleepsec = 0
+        while sleepsec < HAVE_TOKEN_TIMEOUT:
+            try:
+                run('strings {} | grep authtoken'.format(MENDER_STORE))
+                return
+            except Exception:
+                sleepsec += 5
+                time.sleep(5)
+                logging.info("waiting for mender-store file, sleepsec: %d" % sleepsec)
+
+        assert sleepsec <= HAVE_TOKEN_TIMEOUT, "timeout for mender-store file exceeded"
 
         # print all device ids
         for device in auth_v2.get_devices_status("accepted"):

--- a/tests/tests/test_db_migration.py
+++ b/tests/tests/test_db_migration.py
@@ -15,7 +15,6 @@
 
 import os
 import tempfile
-import logging
 import shutil
 
 from fabric.api import *
@@ -25,7 +24,7 @@ from .. import conftest
 from ..common_setup import setup_with_legacy_client
 from .common_update import update_image_successful, common_update_procedure
 from ..helpers import Helpers
-from ..MenderAPI import deploy
+from ..MenderAPI import deploy, logger
 from .mendertesting import MenderTesting
 
 class TestDBMigration(MenderTesting):
@@ -89,7 +88,7 @@ exit 0
                                                                 os.path.join(dirpath, "ArtifactCommit_Enter_01")],
                                                        version=2)
 
-            logging.info("waiting for system to reboot twice")
+            logger.info("waiting for system to reboot twice")
             reboot.verify_reboot_performed(number_of_reboots=2)
 
             assert Helpers.get_active_partition() == active_part

--- a/tests/tests/test_demo_artifact.py
+++ b/tests/tests/test_demo_artifact.py
@@ -13,7 +13,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import logging
 import os
 import signal
 import subprocess
@@ -22,7 +21,7 @@ import time
 import pytest
 
 from ..common_setup import running_custom_production_setup
-from ..MenderAPI import authentication, deployments, DeviceAuthV2
+from ..MenderAPI import authentication, deployments, DeviceAuthV2, logger
 from .mendertesting import MenderTesting
 
 
@@ -62,16 +61,16 @@ class TestDemoArtifact(MenderTesting):
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 env=test_env)
-            logging.info('Started the demo script')
+            logger.info('Started the demo script')
             password = ""
             time.sleep(60)
             for line in iter(proc.stdout.readline, ''):
-                logging.info(line)
+                logger.info(line)
                 if exit_cond in line.strip():
                     if exit_cond == "Login password:":
                         password = line.split(':')[-1].strip()
-                        logging.info('The login password:')
-                        logging.info(password)
+                        logger.info('The login password:')
+                        logger.info(password)
                         self.auth.password = password
                         assert len(password) == 12
                     break
@@ -88,23 +87,23 @@ class TestDemoArtifact(MenderTesting):
 
         run_demo_script.teardown()
 
-        logging.info("--------------------------------------------------")
-        logging.info("Running test_demo_artifact_upload")
-        logging.info("--------------------------------------------------")
+        logger.info("--------------------------------------------------")
+        logger.info("Running test_demo_artifact_upload")
+        logger.info("--------------------------------------------------")
         self.demo_artifact_upload(run_demo_script.run_demo_script_up)
         run_demo_script.teardown()
         self.auth.reset_auth_token()
 
-        logging.info("--------------------------------------------------")
-        logging.info("Running test_demo_artifact_installation")
-        logging.info("--------------------------------------------------")
+        logger.info("--------------------------------------------------")
+        logger.info("Running test_demo_artifact_installation")
+        logger.info("--------------------------------------------------")
         self.demo_artifact_installation(run_demo_script.run_demo_script_up)
         run_demo_script.teardown()
         self.auth.reset_auth_token()
 
-        logging.info("--------------------------------------------------")
-        logging.info("Running test_demo_up_down_up")
-        logging.info("--------------------------------------------------")
+        logger.info("--------------------------------------------------")
+        logger.info("Running test_demo_up_down_up")
+        logger.info("--------------------------------------------------")
         self.demo_up_down_up(run_demo_script.run_demo_script_up)
         run_demo_script.teardown()
         self.auth.reset_auth_token()
@@ -115,7 +114,7 @@ class TestDemoArtifact(MenderTesting):
         try:
             assert len(arts) == 1
         except:
-            logging.error(str(arts))
+            logger.error(str(arts))
             raise
         assert "mender-demo-artifact" in arts[0]['name']
         # Bring down the demo script
@@ -161,4 +160,4 @@ class TestDemoArtifact(MenderTesting):
         # Verify that the demo user is still present, when bringing
         # the environment up a second time
         self.demo_artifact_upload(run_demo_script, exit_cond="The user already exists")
-        logging.info('Finished')
+        logger.info('Finished')

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -28,7 +28,7 @@ from ..common import *
 from ..common_setup import standard_setup_one_client_bootstrapped
 from .common_update import common_update_procedure, update_image_failed
 from ..helpers import Helpers
-from ..MenderAPI import deploy
+from ..MenderAPI import deploy, logger
 from .mendertesting import MenderTesting
 
 DOWNLOAD_RETRY_TIMEOUT_TEST_SETS = [
@@ -55,7 +55,7 @@ class TestFaultTolerance(MenderTesting):
                              % re.escape(search_string))
                 time.sleep(2)
                 if int(output) >= 2:  # check that some retries have occured
-                    logging.info("Looks like the download was retried 2 times, restoring download functionality")
+                    logger.info("Looks like the download was retried 2 times, restoring download functionality")
                     break
 
         if timeout_time <= int(time.time()):
@@ -63,7 +63,7 @@ class TestFaultTolerance(MenderTesting):
 
         # make sure that retries happen after 2 minutes have passed
         assert timeout_time - int(time.time()) >= 2 * 60, "Ooops, looks like the retry happend within less than 5 minutes"
-        logging.info("Waiting for system to finish download")
+        logger.info("Waiting for system to finish download")
 
     @MenderTesting.slow
     def test_update_image_breaks_networking(self, standard_setup_one_client_bootstrapped, install_image="core-image-full-cmdline-%s-broken-network.ext4" % conftest.machine_name):
@@ -119,7 +119,7 @@ class TestFaultTolerance(MenderTesting):
                 Helpers.gateway_connectivity(i % 2 == 0)
             Helpers.gateway_connectivity(True)
 
-            logging.info("Network stabilized")
+            logger.info("Network stabilized")
             reboot.verify_reboot_performed()
             deploy.check_expected_statistics(deployment_id, "success", len(mender_clients))
 

--- a/tests/tests/test_os_ent_migration.py
+++ b/tests/tests/test_os_ent_migration.py
@@ -39,14 +39,13 @@ def initial_os_setup(request):
         Return {"os_devs": [...], "os_users": [...]}
     """
     os_env = container_factory.getStandardSetup(num_clients=0)
-    os_env.setup()
-    ensure_conductor_ready(os_env.get_mender_conductor(), 60, 'provision_device')
-
-    os_env.init_data = initialize_os_setup(os_env)
-
     # We will later re-create other environments, but this one (or any, really) will be
     # enough for the teardown if we keep using the same namespace.
     request.addfinalizer(os_env.teardown)
+
+    os_env.setup()
+    ensure_conductor_ready(os_env.get_mender_conductor(), 60, 'provision_device')
+    os_env.init_data = initialize_os_setup(os_env)
 
     return os_env
 

--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 
 import json
-import logging
 import time
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -25,7 +24,7 @@ import pytest
 from ..common_setup import standard_setup_one_client, enterprise_no_client
 from ..helpers import Helpers
 from .mendertesting import MenderTesting
-from ..MenderAPI import auth, auth_v2, inv
+from ..MenderAPI import auth, auth_v2, inv, logger
 
 
 class TestPreauthBase(MenderTesting):
@@ -54,7 +53,7 @@ class TestPreauthBase(MenderTesting):
         dev_preauth = [d for d in devs if d['status'] == 'preauthorized']
         assert len(dev_preauth) == 1
         dev_preauth = dev_preauth[0]
-        logging.info("dev_prauth_map: " + str(dev_preauth))
+        logger.info("dev_prauth_map: " + str(dev_preauth))
         assert dev_preauth['identity_data'] == preauth_iddata
         assert len(dev_preauth['auth_sets']) == 1
         assert dev_preauth['auth_sets'][0]['pubkey'] == preauth_key
@@ -72,15 +71,15 @@ class TestPreauthBase(MenderTesting):
                 break
 
 
-        logging.info("devices: " + str(dev_accepted))
+        logger.info("devices: " + str(dev_accepted))
         dev_accepted = [d for d in dev_accepted if d['status'] == 'accepted']
-        logging.info("accepted devices: " + str(dev_accepted))
+        logger.info("accepted devices: " + str(dev_accepted))
 
         execute(Client.get_logs, hosts=client)
 
         assert len(dev_accepted) == 1, "looks like the device was never accepted"
         dev_accepted = dev_accepted[0]
-        logging.info("accepted device: " + str(dev_accepted))
+        logger.info("accepted device: " + str(dev_accepted))
 
         assert dev_accepted['identity_data'] == preauth_iddata
         assert len(dev_preauth['auth_sets']) == 1
@@ -203,7 +202,7 @@ class Client:
     @staticmethod
     def get_logs():
         output_from_journalctl = run("journalctl -u mender -l")
-        logging.info(output_from_journalctl)
+        logger.info(output_from_journalctl)
 
     @staticmethod
     def get_pub_key():
@@ -249,11 +248,11 @@ class Client:
                 return out != ''
             except:
                 output_from_journalctl = run("journalctl -u mender -l")
-                logging.info("Logs from client: " + output_from_journalctl)
+                logger.info("Logs from client: " + output_from_journalctl)
 
                 time.sleep(10)
                 sleepsec += 10
-                logging.info("waiting for mender-store file, sleepsec: {}".format(sleepsec))
+                logger.info("waiting for mender-store file, sleepsec: {}".format(sleepsec))
 
         assert sleepsec <= Client.MENDER_STORE_TIMEOUT, "timeout for mender-store file exceeded"
 
@@ -266,7 +265,7 @@ class Client:
             except:
                 time.sleep(10)
                 sleepsec += 10
-                logging.info("waiting for key gen, sleepsec: {}".format(sleepsec))
+                logger.info("waiting for key gen, sleepsec: {}".format(sleepsec))
             else:
                 time.sleep(5)
                 break

--- a/tests/tests/test_security.py
+++ b/tests/tests/test_security.py
@@ -28,6 +28,7 @@ from ..common import *
 from ..common_setup import running_custom_production_setup, standard_setup_with_short_lived_token
 from .common_update import common_update_procedure
 from .mendertesting import MenderTesting
+from ..MenderAPI import logger
 
 class TestSecurity(MenderTesting):
 
@@ -51,7 +52,7 @@ class TestSecurity(MenderTesting):
                 try:
                     for host in exposed_hosts.split():
                         with contextlib.closing(ssl.wrap_socket(socket.socket())) as sock:
-                            logging.info("%s: connect to host with TLS" % host)
+                            logger.info("%s: connect to host with TLS" % host)
                             host, port = host.split(":")
                             sock.connect((host, int(port)))
                             done = True
@@ -92,7 +93,7 @@ class TestSecurity(MenderTesting):
                 time.sleep(1)
 
             if output.return_code == 0:
-                logging.info("mender logs indicate new authorization data available")
+                logger.info("mender logs indicate new authorization data available")
                 break
 
         if timeout_time <= int(time.time()):

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -13,7 +13,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import logging
 import shutil
 import time
 import os
@@ -27,10 +26,8 @@ from ..common import *
 from ..common_setup import standard_setup_one_client_bootstrapped
 from .common_update import common_update_procedure
 from ..helpers import Helpers
-from ..MenderAPI import deploy
+from ..MenderAPI import deploy, logger
 from .mendertesting import MenderTesting
-
-logger = logging.getLogger("root")
 
 TEST_SETS = [
     (

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -123,8 +123,9 @@ class DockerComposeNamespace(DockerNamespace):
                     logging.info("failed to run docker-compose: error follows:\n%s" % (e.output))
                     self._stop_docker_compose()
 
-            logging.info("sleeping %d seconds and retrying" % (count * 30))
-            time.sleep(count * 30)
+            if count < 5:
+                logging.info("sleeping %d seconds and retrying" % (count * 30))
+                time.sleep(count * 30)
 
         raise Exception("failed to start docker-compose (called: %s): exit code: %d, output: %s" % (e.cmd, e.returncode, e.output))
 


### PR DESCRIPTION
This PR brigs a fix for [QA-140](https://tracker.mender.io/browse/QA-140) and other minor fixes and cleanups.

Mainly:

- Always add fixture finalizer before calling setup (fixes QA-140).
This is the way that we will ensure that the finalizer (teardown) will
happen even when an error appears during setup.

- Fix the retry logic of the docker-compose calls
On the one hand, starting the range from 0 made the framework not
sleep between the first and second attempt.
On the other hand, some containers might still be up after a failed
docker-compose up call so the second call to docker-compose up with
the same files will immediately return success. Now we terminate the
containers between attempts.

- Unify and clean logging usage across tests to help a bit humans when reading the tests logs.

- Move have_token function from common to the only test using it