### PR TITLE
Add create-artifact-worker service to docker-compose

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -121,6 +121,13 @@ git:
     - mender-workflows-server
     release_component: true
 
+  create-artifact-worker:
+    docker_image:
+    - create-artifact-worker
+    docker_container:
+    - mender-create-artifact-worker
+    release_component: true
+
 docker_image:
   deployments:
     git:
@@ -241,6 +248,13 @@ docker_image:
     - mender-workflows-server
     release_component: true
 
+  create-artifact-worker:
+    git:
+    - create-artifact-worker
+    docker_container:
+    - mender-create-artifact-worker
+    release_component: true
+
 docker_container:
   mender-deployments:
     git:
@@ -332,4 +346,11 @@ docker_container:
     - workflows
     docker_image:
     - workflows
+    release_component: true
+
+  mender-create-artifact-worker:
+    git:
+    - create-artifact-worker
+    docker_image:
+    - create-artifact-worker
     release_component: true

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -95,3 +95,6 @@ services:
 
     mender-workflows-server:
         command: server --automigrate
+
+    mender-create-artifact-worker:
+        command: --automigrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,23 @@ services:
         extends:
             file: common.yml
             service: mender-base
+        environment:
+            - WORKFLOWS_MONGO_URL=mongodb://mongo-workflows:27017
+        networks:
+            - mender
+        depends_on:
+            - mender-mongo
+
+    #
+    # mender-create-artifact-worker
+    #
+    mender-create-artifact-worker:
+        image: mendersoftware/create-artifact-worker:master
+        extends:
+            file: common.yml
+            service: mender-base
+        environment:
+            - WORKFLOWS_MONGO_URL=mongodb://mongo-workflows:27017
         networks:
             - mender
         depends_on:

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -176,6 +176,7 @@ GIT_TO_BUILDPARAM_MAP = {
     "useradm": "USERADM_REV",
     "useradm-enterprise": "USERADM_ENTERPRISE_REV",
     "workflows": "WORKFLOWS_REV",
+    "create-artifact-worker": "CREATE_ARTIFACT_WORKER_REV",
 
     "mender": "MENDER_REV",
     "mender-artifact": "MENDER_ARTIFACT_REV",

--- a/production/config/prod.yml.template
+++ b/production/config/prod.yml.template
@@ -22,6 +22,9 @@ services:
     mender-workflows-server:
         command: server --automigrate
 
+    mender-create-artifact-worker:
+        command: --automigrate
+
     mender-useradm:
         command: server --automigrate
         volumes:

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -71,8 +71,8 @@ class DockerComposeNamespace(DockerNamespace):
         COMPOSE_FILES_PATH + "/extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml",
     ]
 
-    NUM_SERVICES_OPENSOURCE = 12
-    NUM_SERVICES_ENTERPRISE = 16
+    NUM_SERVICES_OPENSOURCE = 13
+    NUM_SERVICES_ENTERPRISE = 17
 
     def __init__(self, name, extra_files=[]):
         DockerNamespace.__init__(self, name)


### PR DESCRIPTION
We introduce a new Mender component, named create-artifact-worker, that requires
a new container in the docker composition:

- mender-create-artifact-worker: workflows worker creating artifacts

Changelog: None

Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>