### PR TITLE
Test logging to files

### DIFF
--- a/tests/MenderAPI/__init__.py
+++ b/tests/MenderAPI/__init__.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 api_version = os.getenv("MENDER_API_VERSION", "v1")
-logger = logging.getLogger('root')
+logger = logging.getLogger()
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,19 +92,25 @@ def pytest_configure(config):
 
     MenderTesting.set_test_conditions(config)
 
+def unique_test_name(request):
+    """Generate unique test names by prepending the class to the method name"""
+    if request.node.cls is not None:
+        return request.node.cls.__name__ + "__" + request.node.name
+    else:
+        return request.node.name
 
 # If we have xdist installed, the testlogger fixture will include the thread id
 try:
     import xdist
     @pytest.fixture(scope="function", autouse=True)
     def testlogger(request, worker_id):
-        test_name = request.node.name
+        test_name = unique_test_name(request)
         log.setup_test_logger(test_name, worker_id)
         logger.info("%s is starting.... " % test_name)
 except ImportError:
     @pytest.fixture(scope="function", autouse=True)
     def testlogger(request):
-        test_name = request.node.name
+        test_name = unique_test_name(request)
         log.setup_test_logger(test_name)
         logger.info("%s is starting.... " % test_name)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -31,7 +31,7 @@ from .common import *
 
 from MenderAPI import auth_v2
 
-logger = logging.getLogger("root")
+logger = logging.getLogger()
 
 class FabricFatalException(BaseException):
     pass

--- a/testutils/infra/container_manager/__init__.py
+++ b/testutils/infra/container_manager/__init__.py
@@ -12,6 +12,3 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 """container_manager module encapsulates interactios with container orchestrators"""
-
-# Global list of log files
-log_files = []


### PR DESCRIPTION
```
Create log files per test and append all containers logs at teardown

Redeisgn the way the logging is being done around the test framework.

The idea is for all tests and helpers to use the same default logger (in
effect this was the case before also) but now adding a per test file
handler that can log at debug level.

Then, instead of having a background process dumping docker logs to /tmp
files, just append all containers logs to the logger (i.e. to the file)
at teardown time.

This will avoid 1) printing enormous logs into console on test failures
and 2) not having control on which docker log corresponds to which test.

All test logs will be saved at <integration>/tests/mender_test_logs/
```
