### PR TITLE
Fix backend-tests warnings

### DIFF
--- a/backend-tests/requirements-py3.txt
+++ b/backend-tests/requirements-py3.txt
@@ -1,8 +1,8 @@
-requests==2.22
-pymongo==3.6.1
+requests==2.22.0
+pymongo==3.10.1
 cryptography==2.8
-pytest==5.2
-pytest-html==2.0
+pytest==5.3.4
+pytest-html==2.0.1
 pyzbar==0.1.8
 pyotp==2.3.0
-pillow==6.2.0 
+pillow==7.0.0

--- a/backend-tests/tests/pytest.ini
+++ b/backend-tests/tests/pytest.ini
@@ -1,0 +1,5 @@
+# The default value of junit_family option will change to xunit2 in pytest 6.0
+# see https://docs.pytest.org/en/latest/deprecations.html#junit-family-default-value-change-to-xunit2
+# We keep it in xunit1 until we align the tooling between test fraemworks
+[pytest]
+junit_family = xunit1

--- a/backend-tests/tests/test_deployments.py
+++ b/backend-tests/tests/test_deployments.py
@@ -1040,11 +1040,10 @@ class TestPhasedRolloutConcurrencyEnterprise:
                                 (map(lambda sc: sc == s, status_codes))
                             )
                         # Check that all requests received an empty response
-                        assert (
-                            status_code_map[204] == len(status_codes),
+                        assert status_code_map[204] == len(status_codes), (
                             "Expected empty response (204) during inactive "
                             + "phase, but received the following status "
-                            + "code frequencies: %s" % status_code_map,
+                            + "code frequencies: %s" % status_code_map
                         )
                         now = datetime.utcnow()
                 # Sleep the last 500ms to let the next phase start

--- a/testutils/infra/mongo.py
+++ b/testutils/infra/mongo.py
@@ -19,7 +19,7 @@ class MongoClient:
         self.client = PyMongoClient(addr)
 
     def cleanup(self):
-        dbs = self.client.database_names()
+        dbs = self.client.list_database_names()
         dbs = [d for d in dbs if d not in ['local', 'admin', 'config']]
         for d in dbs:
             self.client.drop_database(d)


### PR DESCRIPTION
```
commit 0e15ad87cae407f490ed329f387622e4ebf6d64e
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Fri Jan 24 13:13:53 2020 +0100

    Fix wrong parentheses assert in test_deployments
    
    Which was producing an always true assertion. Fixes warning:
    PytestAssertRewriteWarning: assertion is always true, perhaps remove
    parentheses?

commit a18daf665253c251bb7eccf98ceacc805558601a
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Fri Jan 24 13:16:19 2020 +0100

    Upgrade all pip dependencies in backend-tests
    
    Update all deps to latest stable today. The intention is to remove a
    warning from pymongo being printed 1722 times.
```