### PR TITLE
Fix race condition creating dir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ except ImportError:
 
 def pytest_exception_interact(node, call, report):
     if report.failed:
-        logger.error("Test %s failed with exception:\n%s" % (str(node), call.excinfo.getrepr()))
+        logger.error("Test %s failed with exception:\n%s" % (node.name, call.excinfo.getrepr()))
         try:
             logger.info("Printing client deployment log, if possible:")
             output = execute(run, "cat /data/mender/deployment*.log || true", hosts=get_mender_clients())

--- a/tests/log.py
+++ b/tests/log.py
@@ -2,8 +2,16 @@ import os
 import logging
 import unicodedata
 import re
+import errno
 
 TEST_LOGS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mender_test_logs")
+
+# Create dir if does not exist
+try:
+    os.makedirs(TEST_LOGS_PATH)
+except OSError as e:
+    if e.errno != errno.EEXIST:
+        raise
 
 # Default logger deafult level to DEBUG
 logging.getLogger().setLevel(logging.DEBUG)
@@ -36,8 +44,6 @@ def setup_test_logger(test_name, worker_id=None):
     logger.addHandler(console_handler)
 
     # Add file handler
-    if not os.path.exists(TEST_LOGS_PATH):
-        os.makedirs(TEST_LOGS_PATH)
     filename = os.path.join(TEST_LOGS_PATH, slugify(test_name) + ".log")
     file_handler = logging.FileHandler(filename)
     file_handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
Fix race condition when creating the logs dir
    
The previous implementation was not thread safe and would run into a
race condition if another thread created the dir between exists and
make_dirs calls.
