### PR TITLE
migrated gateway service to use traefik

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -72,7 +72,7 @@ git:
     - api-gateway
     docker_container:
     - mender-api-gateway
-    release_component: true
+    release_component: false
 
   mender-artifact:
     docker_image: []
@@ -240,7 +240,7 @@ docker_image:
     - mender-api-gateway-docker
     docker_container:
     - mender-api-gateway
-    release_component: true
+    release_component: false
 
   mender-conductor:
     git:
@@ -394,7 +394,7 @@ docker_container:
     - mender-api-gateway-docker
     docker_image:
     - api-gateway
-    release_component: true
+    release_component: false
 
   mender-conductor:
     git:

--- a/component-maps.yml
+++ b/component-maps.yml
@@ -164,6 +164,13 @@ git:
     - mtls-ambassador
     release_component: true
 
+  deviceconnect:
+    docker_image:
+    - deviceconnect
+    docker_container:
+    - mender-deviceconnect
+    release_component: true
+
 docker_image:
   deployments:
     git:
@@ -333,6 +340,13 @@ docker_image:
     - mtls-ambassador
     release_component: true
 
+  deviceconnect:
+    git:
+    - deviceconnect
+    docker_container:
+    - mender-deviceconnect
+    release_component: true
+
 docker_container:
   mender-deployments:
     git:
@@ -458,4 +472,11 @@ docker_container:
     - mtls-ambassador
     docker_image:
     - mtls-ambassador
+    release_component: true
+
+  mender-deviceconnect:
+    git:
+    - deviceconnect
+    docker_image:
+    - deviceconnect
     release_component: true

--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -22,6 +22,7 @@ services:
             - traefik.http.routers.auditlogs.tls=true
             - traefik.http.routers.auditlogs.service=auditlogs
             - traefik.http.services.auditlogs.loadbalancer.server.port=8080
+            - mender.testprefix=${MENDER_TESTPREFIX}
 
     mender-api-gateway:
         environment:

--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -19,7 +19,6 @@ services:
             - traefik.http.routers.auditlogs.entrypoints=https
             - traefik.http.routers.auditlogs.middlewares=userauth,sec-headers,json-error-responder1,json-error-responder4
             - traefik.http.routers.auditlogs.rule=PathPrefix(`/api/management/{(v[0-9]+)}/auditlogs`)
-            - traefik.http.middlewares.devauth.forwardAuth.authResponseHeaders=X-MEN-RequestID,X-MEN-RBAC-Inventory-Groups
             - traefik.http.routers.auditlogs.tls=true
             - traefik.http.routers.auditlogs.service=auditlogs
             - traefik.http.services.auditlogs.loadbalancer.server.port=8080

--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -6,11 +6,23 @@ services:
     #
     mender-auditlogs:
         image: registry.mender.io/mendersoftware/auditlogs:mender-master
+        extends:
+            file: common.yml
+            service: mender-base
         networks:
             - mender
         depends_on:
             - mender-mongo
         command: server --automigrate
+        labels:
+            - traefik.enable=true
+            - traefik.http.routers.auditlogs.entrypoints=https
+            - traefik.http.routers.auditlogs.middlewares=userauth,sec-headers,json-error-responder1,json-error-responder4
+            - traefik.http.routers.auditlogs.rule=PathPrefix(`/api/management/{(v[0-9]+)}/auditlogs`)
+            - traefik.http.middlewares.devauth.forwardAuth.authResponseHeaders=X-MEN-RequestID,X-MEN-RBAC-Inventory-Groups
+            - traefik.http.routers.auditlogs.tls=true
+            - traefik.http.routers.auditlogs.service=auditlogs
+            - traefik.http.services.auditlogs.loadbalancer.server.port=8080
 
     mender-api-gateway:
         environment:

--- a/docker-compose.connect.yml
+++ b/docker-compose.connect.yml
@@ -1,0 +1,24 @@
+version: '2.1'
+services:
+  #
+  # mender-deviceconnect
+  #
+  mender-deviceconnect:
+    image: mendersoftware/deviceconnect:mender-master
+    command: server --automigrate
+    extends:
+      file: common.yml
+      service: mender-base
+    networks:
+      - mender
+    depends_on:
+      - mender-mongo
+    environment:
+      DEVICECONNECT_MONGO_URL: "mongodb://mender-mongo"
+      DEVICECONNECT_NATS_URL: "nats://mender-nats"
+
+  mender-nats:
+    image: nats:2.1-alpine3.11
+    networks:
+      - mender
+

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -58,7 +58,6 @@ services:
             DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io
         depends_on:
             - mender-mongo
-            - minio
 
     minio:
         networks:

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -19,12 +19,13 @@ services:
             - 80:80
             - 443:443
             - 8080:8080
-        command: 
+        command:
             - --api.dashboard=true
             - --api.insecure=true
             - --accesslog=true
             - --log.level=DEBUG
             - --providers.file.filename=/config/tls.toml
+            - --providers.docker.constraints=Label(`mender.testprefix`,`${MENDER_TESTPREFIX}`)
             - --providers.docker=true
             - --providers.docker.exposedbydefault=false
             - --entrypoints.http.address=:80

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -16,38 +16,35 @@ services:
 
     mender-api-gateway:
         ports:
-            - "443:443"
+            - 80:80
+            - 443:443
+            - 8080:8080
+        command: 
+            - --api.dashboard=true
+            - --api.insecure=true
+            - --accesslog=true
+            - --log.level=DEBUG
+            - --providers.file.filename=/config/tls.toml
+            - --providers.docker=true
+            - --providers.docker.exposedbydefault=false
+            - --entrypoints.http.address=:80
+            - --entrypoints.https.address=:443
+            - --entryPoints.https.transport.respondingTimeouts.idleTimeout=7200
+            - --entryPoints.https.transport.respondingTimeouts.readTimeout=7200
+            - --entryPoints.https.transport.respondingTimeouts.writeTimeout=7200
+            - --entrypoints.http.http.redirections.entryPoint.to=https
+            - --entrypoints.http.http.redirections.entryPoint.scheme=https
         networks:
             mender:
                 aliases:
                     - docker.mender.io
-        volumes:
-            - ./certs/api-gateway/cert.crt:/var/www/mendersoftware/cert/cert.crt
-            - ./certs/api-gateway/private.key:/var/www/mendersoftware/cert/private.key
-        environment:
-            ALLOWED_HOSTS: localhost docker.mender.io
-            HSTS_MAX_AGE: 0
-
-    storage-proxy:
-        ports:
-            - "9000:9000"
-        networks:
-            mender:
-                aliases:
                     - s3.docker.mender.io
-        environment:
-
-            # use nginx syntax for rate limiting, see
-            # https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate
-            # Examples:
-            #   1m - 1MB/s
-            #   512k - 512kB/s
-            DOWNLOAD_SPEED: 3m
-            MAX_CONNECTIONS: 30
         volumes:
-            - ./certs/storage-proxy/cert.crt:/var/www/storage-proxy/cert/cert.crt
-            - ./certs/storage-proxy/private.key:/var/www/storage-proxy/cert/private.key
-            - ./storage-proxy/nginx.conf.demo:/usr/local/openresty/nginx/conf/nginx.conf
+            - ./tls.toml:/config/tls.toml
+            - ./certs/api-gateway/cert.crt:/certs/cert.crt
+            - ./certs/api-gateway/private.key:/certs/private.key
+            - ./certs/storage-proxy/cert.crt:/certs/s3.docker.mender.io.crt
+            - ./certs/storage-proxy/private.key:/certs/s3.docker.mender.io.key
 
     mender-deployments:
         command: server --automigrate
@@ -57,7 +54,10 @@ services:
             STORAGE_BACKEND_CERT: /etc/ssl/certs/s3.docker.mender.io.crt
             DEPLOYMENTS_AWS_AUTH_KEY: minio
             DEPLOYMENTS_AWS_AUTH_SECRET: minio123
-            DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io:9000
+            DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io
+        depends_on:
+            - mender-mongo
+            - minio
 
     minio:
         networks:
@@ -67,11 +67,18 @@ services:
         environment:
             MINIO_ACCESS_KEY: minio
             MINIO_SECRET_KEY: minio123
+        # use rate limiting, for more options see: https://docs.traefik.io/v2.2/middlewares/ratelimit/
+        # labels:
+        #     - traefik.http.middlewares.demo-ratelimit.ratelimit.average=30
+        #     - traefik.http.routers.minio.middlewares=demo-ratelimit
 
     mender-gui:
         environment:
             # enable demo mode for UI ["true"/"false"]
             DEMO: "true"
+        labels:
+            - traefik.http.middlewares.sec-headers.headers.stsSeconds=0
+            - traefik.http.middlewares.sec-headers.headers.isDevelopment=true
 
     mender-workflows-server:
         command: server --automigrate

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -36,6 +36,7 @@ services:
             - traefik.http.routers.tenantadmMgmt.tls=true
             - traefik.http.routers.tenantadmMgmt.service=tenantadmMgmt
             - traefik.http.services.tenantadmMgmt.loadbalancer.server.port=8080
+            - mender.testprefix=${MENDER_TESTPREFIX}
         networks:
             - mender
         depends_on:

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -22,6 +22,20 @@ services:
         extends:
             file: common.yml
             service: mender-base
+        labels:
+            - traefik.enable=true
+            - traefik.http.routers.tenantadm.entrypoints=https
+            - traefik.http.routers.tenantadm.middlewares=userauth
+            - traefik.http.routers.tenantadm.rule=PathPrefix(`/api/management/{(v[0-9]+)}/tenantadm`)
+            - traefik.http.routers.tenantadm.tls=true
+            - traefik.http.routers.tenantadm.service=tenantadm
+            - traefik.http.services.tenantadm.loadbalancer.server.port=8080
+
+            - traefik.http.routers.tenantadmMgmt.entrypoints=https
+            - traefik.http.routers.tenantadmMgmt.rule=PathPrefix(`/api/management/{(v[0-9]+)}/tenantadm/tenants`) && Method(`OPTIONS`,`POST`,`PUT`,`DELETE`)
+            - traefik.http.routers.tenantadmMgmt.tls=true
+            - traefik.http.routers.tenantadmMgmt.service=tenantadmMgmt
+            - traefik.http.services.tenantadmMgmt.loadbalancer.server.port=8080
         networks:
             - mender
         depends_on:

--- a/docker-compose.no-ssl.yml
+++ b/docker-compose.no-ssl.yml
@@ -4,12 +4,15 @@ services:
     mender-api-gateway:
         ports:
             - "80:80"
-        environment:
-            SSL: "false"
-
-    storage-proxy:
-        volumes:
-            - ./storage-proxy/no-ssl.nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
+        command:
+            - --accesslog=true
+            - --providers.docker=true
+            - --providers.docker.exposedbydefault=false
+            - --entrypoints.http.address=:80
+            - --entrypoints.https.address=:443
+            - --entryPoints.https.transport.respondingTimeouts.idleTimeout=7200
+            - --entryPoints.https.transport.respondingTimeouts.readTimeout=7200
+            - --entryPoints.https.transport.respondingTimeouts.writeTimeout=7200
 
     mender-deployments:
         environment:

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -13,26 +13,18 @@ services:
                     - minio.s3.docker.mender.io
         environment:
             MINIO_HTTP_TRACE: /dev/stdout
+        labels:
+            - "traefik.enable=true"
+            - "traefik.http.routers.minio.entrypoints=https"
+            - "traefik.http.routers.minio.rule=Host(`s3.docker.mender.io`)||PathPrefix(`/mender-artifact-storage`)"
+            - "traefik.http.routers.minio.tls=true"
+            - "traefik.http.services.minio.loadbalancer.server.port=9000"
         command: server /export
 
     #
-    # storage backend proxy used in conjunction with minio, applies
-    # rate & connection limiting
-    #
-    storage-proxy:
-        image: openresty/openresty:1.13.6.2-0-alpine
-        restart: on-failure
-        networks:
-            mender:
-                aliases:
-                    - s3.docker.mender.io
-        depends_on:
-            minio:
-                condition: service_healthy
-
-    #
-    # mender-deployments depends on storage-proxy if minio is in use
+    # mender-deployments depends on minio if minio is in use
     #
     mender-deployments:
         depends_on:
-            - storage-proxy
+            minio:
+                condition: service_healthy

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -19,6 +19,7 @@ services:
             - "traefik.http.routers.minio.rule=Host(`s3.docker.mender.io`)||PathPrefix(`/mender-artifact-storage`)"
             - "traefik.http.routers.minio.tls=true"
             - "traefik.http.services.minio.loadbalancer.server.port=9000"
+            - mender.testprefix=${MENDER_TESTPREFIX}
         command: server /export
 
     #

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -25,6 +25,11 @@ services:
     #
     # mender-deployments depends on minio if minio is in use
     #
+    mender-api-gateway:
+        depends_on:
+            minio:
+                condition: service_healthy
+
     mender-deployments:
         depends_on:
             minio:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,13 +128,11 @@ services:
     #
     mender-create-artifact-worker:
         image: mendersoftware/create-artifact-worker:mender-master
-        environment:
-            WORKFLOWS_MONGO_URL: mongodb://mender-mongo:27017
         extends:
             file: common.yml
             service: mender-base
         environment:
-            - WORKFLOWS_MONGO_URL=mongodb://mongo-workflows:27017
+            - WORKFLOWS_MONGO_URL=mongodb://mender-mongo:27017
             - CREATE_ARTIFACT_GATEWAY_URL=https://mender-api-gateway
             - CREATE_ARTIFACT_DEPLOYMENTS_URL=http://mender-deployments:8080
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
             - traefik.http.services.useradm.loadbalancer.server.port=8080
 
             - traefik.http.routers.useradmLogin.entrypoints=https
-            - traefik.http.routers.useradmLogin.rule=Path(`/api/management/{(v[0-9]+)}/useradm/auth/login`)||PathPrefix(`/api/management/{(v[0-9]+)}/useradm/(oauth2|auth/password-reset)`)
+            - traefik.http.routers.useradmLogin.rule=Path(`/api/management/{(v[0-9]+)}/useradm/auth/login`)||PathPrefix(`/api/management/{(v[0-9]+)}/useradm/{(oauth2|auth\/password-reset)}`)
             # traefik should automatically forward the x-forwarded-host header
             - traefik.http.routers.useradmLogin.middlewares=sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.useradmLogin.tls=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
             # errorhandling 
             - traefik.http.middlewares.json-error-responder1.errors.service=error-responder
             - traefik.http.middlewares.json-error-responder1.errors.query=/{status}.json
-            - traefik.http.middlewares.json-error-responder1.errors.status=400-404
+            - traefik.http.middlewares.json-error-responder1.errors.status=401-404
             - traefik.http.middlewares.json-error-responder2.errors.service=error-responder
             - traefik.http.middlewares.json-error-responder2.errors.query=/{status}.json
             - traefik.http.middlewares.json-error-responder2.errors.status=500-504

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,14 @@ services:
             - traefik.http.routers.deploymentsMgmt.tls=true
             - traefik.http.routers.deploymentsMgmt.service=deploymentsMgmt
             - traefik.http.services.deploymentsMgmt.loadbalancer.server.port=8080
+            - traefik.http.services.deploymentsMgmt.loadbalancer.healthcheck.path=/api/internal/v1/deployments/health
+            - traefik.http.services.deploymentsMgmt.loadbalancer.healthcheck.port=8080
+            - traefik.http.services.deploymentsMgmt.loadbalancer.healthcheck.interval=5s
+            - traefik.http.services.deploymentsMgmt.loadbalancer.healthcheck.timeout=3s
+            - traefik.http.services.deployments.loadbalancer.healthcheck.path=/api/internal/v1/deployments/health
+            - traefik.http.services.deployments.loadbalancer.healthcheck.port=8080
+            - traefik.http.services.deployments.loadbalancer.healthcheck.interval=5s
+            - traefik.http.services.deployments.loadbalancer.healthcheck.timeout=3s
             - mender.testprefix=${MENDER_TESTPREFIX}
         networks:
             - mender
@@ -123,7 +131,6 @@ services:
         # these servers and exits with 'upstream server not found'
         depends_on:
             - mender-device-auth
-            - mender-deployments
             - mender-gui
             - mender-useradm
             - mender-inventory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
             - traefik.http.routers.deviceauthMgmt.tls=true
             - traefik.http.routers.deviceauthMgmt.service=deviceauthMgmt
             - traefik.http.services.deviceauthMgmt.loadbalancer.server.port=8080
-            # the X-Original-URI and X-Original-Method headers are added by træfik automatically, however as X-Forwarded-Uri and X-Forwarded-Method
+            # the X-Original-URI and X-Original-Method headers are added by traefik automatically, however as X-Forwarded-Uri and X-Forwarded-Method
             # https://github.com/containous/traefik/blob/125470f1106373ff42cf03ae28467055a8186de5/pkg/middlewares/forwardedheaders/forwarded_header.go#L12-L38
         networks:
             - mender

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
             - traefik.http.routers.deploymentsMgmt.tls=true
             - traefik.http.routers.deploymentsMgmt.service=deploymentsMgmt
             - traefik.http.services.deploymentsMgmt.loadbalancer.server.port=8080
+            - mender.testprefix=${MENDER_TESTPREFIX}
         networks:
             - mender
         depends_on:
@@ -83,6 +84,7 @@ services:
             - traefik.http.middlewares.json-error-responder4.errors.service=error-responder
             - traefik.http.middlewares.json-error-responder4.errors.query=/{status}.json
             - traefik.http.middlewares.json-error-responder4.errors.status=429
+            - mender.testprefix=${MENDER_TESTPREFIX}
         networks:
             - mender
         environment:
@@ -152,6 +154,7 @@ services:
             - traefik.http.services.deviceauthMgmt.loadbalancer.server.port=8080
             # the X-Original-URI and X-Original-Method headers are added by traefik automatically, however as X-Forwarded-Uri and X-Forwarded-Method
             # https://github.com/containous/traefik/blob/125470f1106373ff42cf03ae28467055a8186de5/pkg/middlewares/forwardedheaders/forwarded_header.go#L12-L38
+            - mender.testprefix=${MENDER_TESTPREFIX}
         networks:
             - mender
         depends_on:
@@ -192,6 +195,7 @@ services:
             - traefik.http.routers.oldDeviceInventory.service=oldDeviceInventory
             - traefik.http.routers.oldDeviceInventory.tls=true
             - traefik.http.services.oldDeviceInventory.loadbalancer.server.port=8080
+            - mender.testprefix=${MENDER_TESTPREFIX}
         networks:
             - mender
         depends_on:
@@ -221,6 +225,7 @@ services:
             - traefik.http.routers.useradmLogin.tls=true
             - traefik.http.routers.useradmLogin.service=useradmLogin
             - traefik.http.services.useradmLogin.loadbalancer.server.port=8080
+            - mender.testprefix=${MENDER_TESTPREFIX}
         networks:
             - mender
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,21 @@ services:
         extends:
             file: common.yml
             service: mender-base
+        labels:
+            - traefik.enable=true
+            - traefik.http.routers.deployments.entrypoints=https
+            - traefik.http.routers.deployments.rule=PathPrefix(`/api/devices/{(v[0-9]+)}/deployments`)
+            - traefik.http.routers.deployments.middlewares=devauth,sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deployments.tls=true
+            - traefik.http.routers.deployments.service=deployments
+            - traefik.http.services.deployments.loadbalancer.server.port=8080
+            
+            - traefik.http.routers.deploymentsMgmt.entrypoints=https
+            - traefik.http.routers.deploymentsMgmt.rule=PathPrefix(`/api/management/{(v[0-9]+)}/deployments`)
+            - traefik.http.routers.deploymentsMgmt.middlewares=userauth,sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deploymentsMgmt.tls=true
+            - traefik.http.routers.deploymentsMgmt.service=deploymentsMgmt
+            - traefik.http.services.deploymentsMgmt.loadbalancer.server.port=8080
         networks:
             - mender
         depends_on:
@@ -22,6 +37,52 @@ services:
         extends:
             file: common.yml
             service: mender-base
+        labels:
+            - traefik.enable=true
+            - traefik.http.routers.gui.entrypoints=https
+            - traefik.http.routers.gui.middlewares=ensure-ui-path,signup-redirect,ui-stripprefix,sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.gui.rule=PathPrefix(`/`)
+            - traefik.http.routers.gui.service=gui
+            - traefik.http.routers.gui.tls=true
+            - traefik.http.services.gui.loadbalancer.server.port=80
+            
+            - traefik.http.routers.error-responder.entrypoints=https,http
+            # - traefik.http.routers.error-responder.rule=HostRegexp(`{host:.+}`)
+            - traefik.http.routers.error-responder.service=error-responder
+            - traefik.http.routers.error-responder.tls=true
+            - traefik.http.services.error-responder.loadbalancer.server.port=8080
+
+            - traefik.http.middlewares.ui-stripprefix.stripprefix.prefixes=/ui
+            - traefik.http.middlewares.ensure-ui-path.redirectregex.regex=^(https?://[^/]+)(/[a-z]*)?$$
+            - traefik.http.middlewares.ensure-ui-path.redirectregex.replacement=$${1}/ui/
+            - traefik.http.middlewares.ensure-ui-path.redirectregex.permanent=true
+            - traefik.http.middlewares.signup-redirect.redirectregex.regex=^(https://[^/]+)/signup
+            - traefik.http.middlewares.signup-redirect.redirectregex.replacement=$${1}/ui/#/signup
+            # definitions of shared middlewares
+            - traefik.http.middlewares.sec-headers.headers.referrerPolicy=no-referrer
+            - traefik.http.middlewares.sec-headers.headers.stsSeconds=31536000
+            - traefik.http.middlewares.sec-headers.headers.forceSTSHeader=true
+            - traefik.http.middlewares.sec-headers.headers.stsPreload=true
+            - traefik.http.middlewares.sec-headers.headers.stsIncludeSubdomains=true
+            - traefik.http.middlewares.sec-headers.headers.browserXssFilter=true
+            - traefik.http.middlewares.sec-headers.headers.customRequestHeaders.X-Forwarded-Proto=https
+            - traefik.http.middlewares.devauth.forwardAuth.address=http://mender-device-auth:8080/api/internal/v1/devauth/tokens/verify
+            - traefik.http.middlewares.devauth.forwardAuth.authResponseHeaders=X-MEN-RequestID
+            - traefik.http.middlewares.userauth.forwardAuth.address=http://mender-useradm:8080/api/internal/v1/useradm/auth/verify
+            - traefik.http.middlewares.userauth.forwardAuth.authResponseHeaders=X-MEN-RequestID,X-MEN-RBAC-Inventory-Groups,X-MEN-RBAC-Deployments-Groups
+            # errorhandling 
+            - traefik.http.middlewares.json-error-responder1.errors.service=error-responder
+            - traefik.http.middlewares.json-error-responder1.errors.query=/{status}.json
+            - traefik.http.middlewares.json-error-responder1.errors.status=400-404
+            - traefik.http.middlewares.json-error-responder2.errors.service=error-responder
+            - traefik.http.middlewares.json-error-responder2.errors.query=/{status}.json
+            - traefik.http.middlewares.json-error-responder2.errors.status=500-504
+            - traefik.http.middlewares.json-error-responder3.errors.service=error-responder
+            - traefik.http.middlewares.json-error-responder3.errors.query=/{status}.json
+            - traefik.http.middlewares.json-error-responder3.errors.status=408
+            - traefik.http.middlewares.json-error-responder4.errors.service=error-responder
+            - traefik.http.middlewares.json-error-responder4.errors.query=/{status}.json
+            - traefik.http.middlewares.json-error-responder4.errors.status=429
         networks:
             - mender
         environment:
@@ -35,10 +96,25 @@ services:
     # mender-api-gateway
     #
     mender-api-gateway:
-        image: mendersoftware/api-gateway:master
+        image: traefik:v2.2
         extends:
             file: common.yml
             service: mender-base
+        # Enables the web UI and tells Traefik to listen to docker
+        command: 
+            - --accesslog=true
+            - --providers.docker=true
+            - --providers.docker.exposedbydefault=false
+            - --entrypoints.http.address=:80
+            - --entrypoints.https.address=:443
+            - --entryPoints.https.transport.respondingTimeouts.idleTimeout=7200
+            - --entryPoints.https.transport.respondingTimeouts.readTimeout=7200
+            - --entryPoints.https.transport.respondingTimeouts.writeTimeout=7200
+            - --entrypoints.http.http.redirections.entryPoint.to=https
+            - --entrypoints.http.http.redirections.entryPoint.scheme=https
+        volumes:
+            # So that Traefik can listen to the Docker events
+            - /var/run/docker.sock:/var/run/docker.sock:ro
         networks:
             - mender
         # critical - otherwise nginx may not detect
@@ -60,6 +136,22 @@ services:
         extends:
             file: common.yml
             service: mender-base
+        labels:
+            - traefik.enable=true
+            - traefik.http.routers.deviceauth.entrypoints=https
+            - traefik.http.routers.deviceauth.rule=PathPrefix(`/api/devices/{(v[0-9]+)}/authentication`)
+            - traefik.http.routers.deviceauth.tls=true
+            - traefik.http.routers.deviceauth.service=deviceauth
+            - traefik.http.services.deviceauth.loadbalancer.server.port=8080
+            
+            - traefik.http.routers.deviceauthMgmt.entrypoints=https
+            - traefik.http.routers.deviceauthMgmt.rule=PathPrefix(`/api/management/{(v[0-9]+)}/devauth`)
+            - traefik.http.routers.deviceauthMgmt.middlewares=userauth,sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deviceauthMgmt.tls=true
+            - traefik.http.routers.deviceauthMgmt.service=deviceauthMgmt
+            - traefik.http.services.deviceauthMgmt.loadbalancer.server.port=8080
+            # the X-Original-URI and X-Original-Method headers are added by træfik automatically, however as X-Forwarded-Uri and X-Forwarded-Method
+            # https://github.com/containous/traefik/blob/125470f1106373ff42cf03ae28467055a8186de5/pkg/middlewares/forwardedheaders/forwarded_header.go#L12-L38
         networks:
             - mender
         depends_on:
@@ -74,6 +166,32 @@ services:
         extends:
             file: common.yml
             service: mender-base
+        labels:
+            - traefik.enable=true
+            - traefik.http.routers.newInventory.entrypoints=https
+            - traefik.http.routers.newInventory.rule=PathPrefix(`/api/management/v2/inventory`)
+            - traefik.http.routers.newInventory.service=newInventory
+            - traefik.http.routers.newInventory.middlewares=userauth,sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.newInventory.tls=true
+            - traefik.http.services.newInventory.loadbalancer.server.port=8080
+
+            - traefik.http.middlewares.oldInventory-replacepathregex.replacepathregex.regex=^/api/management/v1/inventory/(.*)
+            - traefik.http.middlewares.oldInventory-replacepathregex.replacepathregex.replacement=/api/0.1.0/$$1
+            - traefik.http.routers.oldInventory.entrypoints=https
+            - traefik.http.routers.oldInventory.middlewares=userauth,oldInventory-replacepathregex,sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.oldInventory.rule=PathPrefix(`/api/management/v1/inventory`)
+            - traefik.http.routers.oldInventory.service=oldInventory
+            - traefik.http.routers.oldInventory.tls=true
+            - traefik.http.services.oldInventory.loadbalancer.server.port=8080
+
+            - traefik.http.middlewares.oldDeviceInventory-replacepathregex.replacepathregex.regex=^/api/devices/v1/inventory/(.*)
+            - traefik.http.middlewares.oldDeviceInventory-replacepathregex.replacepathregex.replacement=/api/0.1.0/attributes
+            - traefik.http.routers.oldDeviceInventory.entrypoints=https
+            - traefik.http.routers.oldDeviceInventory.middlewares=devauth,oldDeviceInventory-replacepathregex,sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.oldDeviceInventory.rule=PathPrefix(`/api/devices/v1/inventory`)
+            - traefik.http.routers.oldDeviceInventory.service=oldDeviceInventory
+            - traefik.http.routers.oldDeviceInventory.tls=true
+            - traefik.http.services.oldDeviceInventory.loadbalancer.server.port=8080
         networks:
             - mender
         depends_on:
@@ -87,6 +205,22 @@ services:
         extends:
             file: common.yml
             service: mender-base
+        labels:
+            - traefik.enable=true
+            - traefik.http.routers.useradm.entrypoints=https
+            - traefik.http.routers.useradm.middlewares=userauth,sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.useradm.rule=PathPrefix(`/api/management/{(v[0-9]+)}/useradm`)
+            - traefik.http.routers.useradm.tls=true
+            - traefik.http.routers.useradm.service=useradm
+            - traefik.http.services.useradm.loadbalancer.server.port=8080
+
+            - traefik.http.routers.useradmLogin.entrypoints=https
+            - traefik.http.routers.useradmLogin.rule=Path(`/api/management/{(v[0-9]+)}/useradm/auth/login`)||PathPrefix(`/api/management/{(v[0-9]+)}/useradm/(oauth2|auth/password-reset)`)
+            # traefik should automatically forward the x-forwarded-host header
+            - traefik.http.routers.useradmLogin.middlewares=sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.useradmLogin.tls=true
+            - traefik.http.routers.useradmLogin.service=useradmLogin
+            - traefik.http.services.useradmLogin.loadbalancer.server.port=8080
         networks:
             - mender
         depends_on:

--- a/extra/mtls/mtls-ambassador-test.yml
+++ b/extra/mtls/mtls-ambassador-test.yml
@@ -13,3 +13,5 @@ services:
       MTLS_MENDER_BACKEND: "https://mender-api-gateway"
       MTLS_DEBUG_LOG: "true"
       MTLS_INSECURE_SKIP_VERIFY: "true"
+    labels:
+        - mender.testprefix=${MENDER_TESTPREFIX}

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -224,11 +224,12 @@ GIT_TO_BUILDPARAM_MAP = {
     "mender-qa": "MENDER_QA_REV",
     "auditlogs": "AUDITLOGS_REV",
     "mtls-ambassador": "MTLS_AMBASSADOR_REV",
+    "deviceconnect": "DEVICECONNECT_REV",
 }
 
 # categorize backend services wrt open/enterprise versions
 # important for test suite selection
-BACKEND_SERVICES_OPEN = {"deviceauth", "create-artifact-worker"}
+BACKEND_SERVICES_OPEN = {"deviceauth", "deviceconnect", "create-artifact-worker"}
 BACKEND_SERVICES_ENT = {
     "tenantadm",
     "deployments-enterprise",

--- a/git-versions.yml
+++ b/git-versions.yml
@@ -25,6 +25,9 @@ services:
     mender-useradm:
         image: mendersoftware/useradm:master
 
+    mender-deviceconnect:
+        image: mendersoftware/deviceconnect:master
+
     mender-workflows-server:
         image: mendersoftware/workflows:master
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -68,7 +68,7 @@ echo "Detected Mender artifact branch: $MENDER_ARTIFACT_BRANCH"
 
 function modify_services_for_testing() {
     # Remove all published ports for testing
-    sed -e '/9000:9000/d' -e '/8080:8080/d' -e '/443:443/d' -e '/ports:/d' ../docker-compose.demo.yml > ../docker-compose.testing.yml
+    sed -e '/9000:9000/d' -e '/8080:8080/d' -e '/443:443/d' -e '/80:80/d' -e '/ports:/d' ../docker-compose.demo.yml > ../docker-compose.testing.yml
     # disable download speed limits
     sed -e 's/DOWNLOAD_SPEED/#DOWNLOAD_SPEED/' -i ../docker-compose.testing.yml
     # whitelist *all* IPs/DNS names in the gateway (will be accessed via dynamically assigned IP in tests)

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -109,7 +109,7 @@ class DockerComposeNamespace(DockerNamespace):
         """
         files_args = "".join([" -f %s" % file for file in self.docker_compose_files])
 
-        cmd = "docker-compose -p %s %s %s" % (self.name, files_args, arg_list)
+        cmd = "MENDER_TESTPREFIX=%s docker-compose -p %s %s %s" % (self.name, self.name, files_args, arg_list)
 
         logger.info("running with: %s" % cmd)
 

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -91,8 +91,8 @@ class DockerComposeNamespace(DockerNamespace):
         COMPOSE_FILES_PATH + "/extra/integration-testing/docker-compose.compat.yml"
     ]
 
-    NUM_SERVICES_OPENSOURCE = 11
-    NUM_SERVICES_ENTERPRISE = 13
+    NUM_SERVICES_OPENSOURCE = 10
+    NUM_SERVICES_ENTERPRISE = 12
 
     def __init__(self, name, extra_files=[]):
         DockerNamespace.__init__(self, name)

--- a/tls.toml
+++ b/tls.toml
@@ -1,0 +1,10 @@
+[tls.stores]
+[tls.stores.default]
+  [tls.stores.default.defaultCertificate]
+    certFile = "/certs/cert.crt"
+    keyFile  = "/certs/private.key"
+
+[[tls.certificates]]
+  # the following is required if minio is used but won't break if minio or the crt files aren't present
+  certFile = "/certs/s3.docker.mender.io.crt"
+  keyFile = "/certs/s3.docker.mender.io.key"


### PR DESCRIPTION
this is done using service labels and straight docker socket listening
the socket access could be proxied for good measure, but since the corresponding container isn't exposed outside of a demo setup, it is not strictly required

to align the `X-Original-Method` and `X-Original-URI` headers with the headers traefik forwards by default, https://github.com/mendersoftware/deviceauth/pull/379 and https://github.com/mendersoftware/useradm/pull/179 / https://github.com/mendersoftware/useradm-enterprise/pull/114
 
Changelog: Title
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>