### PR TITLE
[MEN-3090] Fix setup for running without SSL termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,19 +201,17 @@ how to modify it.
 
 ### Enabling non-SSL access
 
-For debugging purposes, it may be useful to temporarily enable non-SSL access.
-API Gateway configuration enables plain HTTP on port 80, however the port is not
-published by default, thus it remains inaccessible from the outside. For
-convenience, an overlay compose file is provided that publishes port 80 of API
-Gateway to port 8090 on current host. The overlay file has to be explicitly
-included when setting up the environment like this:
+For debugging purposes or when using third party SSL reverse proxy, it may be useful to enable non-SSL access.  
+API Gateway configuration enables plain HTTP on port 80 when setting the `SSL` environment variable to `'false'`.  
+The nginx configuration will only be changed on container creation. If you previously ran with SSL, delete and re-create the container.  
+An example compose file can be included like this:
 
 ```
-docker-compose ... -f docker-compose.no-ssl.yml ...
+./demo -f docker-compose.no-ssl.yml up
 ```
 
 **NOTE** make sure that plain HTTP port is not published in production
-deployment.
+deployment. Use a reverse proxy for example.
 
 ## Demo client
 

--- a/demo
+++ b/demo
@@ -123,6 +123,12 @@ fi
 
 MENDER_SERVER_URI="https://localhost"
 
+# use http when providing no-ssl config
+if [[ "$@" == *"-f docker-compose.no-ssl.yml"* ]]
+then
+    MENDER_SERVER_URI="http://localhost"
+fi
+
 # Make sure that the demo environment is brought down on SIGINT
 exitfunc() {
     retval=$(docker-compose \

--- a/docker-compose.no-ssl.yml
+++ b/docker-compose.no-ssl.yml
@@ -3,13 +3,14 @@ services:
 
     mender-api-gateway:
         ports:
-            - "8090:80"
+            - "80:80"
+        environment:
+            SSL: "false"
+
+    storage-proxy:
+        volumes:
+            - ./storage-proxy/no-ssl.nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
 
     mender-deployments:
         environment:
-            DEPLOYMENTS_AWS_URI: http://minio.s3.docker.mender.io:9001
-
-    minio:
-        ports:
-            - "9001:9001"
-        command: server --address ":9001" /export
+            DEPLOYMENTS_AWS_URI: http://s3.docker.mender.io:9000

--- a/storage-proxy/no-ssl.nginx.conf
+++ b/storage-proxy/no-ssl.nginx.conf
@@ -1,0 +1,101 @@
+worker_processes  auto;
+
+error_log  /dev/stdout warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+env DOWNLOAD_SPEED;
+env MAX_CONNECTIONS;
+
+http {
+
+    init_by_lua_block {
+        ngx.log(ngx.WARN, "download speed limit: " .. (os.getenv("DOWNLOAD_SPEED") or "not set"))
+        ngx.log(ngx.WARN, "max connections: " .. (os.getenv("MAX_CONNECTIONS") or "not set"))
+    }
+
+    upstream minio_backend {
+        server minio:9000 max_fails=0;
+    }
+
+    lua_shared_dict my_limit_conn_store 100m;
+
+    server {
+
+        proxy_max_temp_file_size 0;
+
+        listen 9000;
+
+        add_header X-Frame-Options DENY;
+        add_header X-Content-Type-Options nosniff;
+
+        location / {
+            access_by_lua_block {
+                -- rate and connection limiting is applied only to GET requests
+                if ngx.req.get_method() == "GET" then
+
+                   local max_connections = tonumber(os.getenv("MAX_CONNECTIONS"))
+                   if max_connections ~= nil then
+                      local limit_conn = require "resty.limit.conn"
+
+                      local lim, err = limit_conn.new("my_limit_conn_store", max_connections, 0, 1)
+                      if not lim then
+                         ngx.log(ngx.ERR,
+                                 "failed to instantiate a resty.limit.conn object: ", err)
+                         return ngx.exit(500)
+                      end
+
+                      local key = ngx.var.binary_remote_addr
+                      local delay, err = lim:incoming(key, true)
+                      if not delay and err ~= "rejected" then
+                         ngx.log(ngx.ERR, "failed to limit req: ", err)
+                         return ngx.exit(500)
+                      elseif not delay or delay > 0 then
+                         ngx.log(ngx.WARN, "connection rejected")
+                         return ngx.exit(503)
+                      end
+
+                      if lim:is_committed() then
+                         local ctx = ngx.ctx
+                         ctx.limit_conn = lim
+                         ctx.limit_conn_key = key
+                         ctx.limit_conn_delay = delay
+                      end
+                   end
+
+                   local download_speed = os.getenv("DOWNLOAD_SPEED")
+                   if download_speed ~= nil then
+                      ngx.var.limit_rate = download_speed
+                   end
+                end
+            }
+
+            log_by_lua_block {
+                local ctx = ngx.ctx
+                local lim = ctx.limit_conn
+                if lim then
+                    local latency = tonumber(ngx.var.request_time)
+                    local key = ctx.limit_conn_key
+                    assert(key)
+                    local conn, err = lim:leaving(key, latency)
+                    if not conn then
+                        ngx.log(ngx.ERR,
+                                "failed to record the connection leaving ",
+                                "request: ", err)
+                        return
+                    end
+                end
+            }
+
+            client_max_body_size 0;
+            proxy_request_buffering off;
+            proxy_http_version 1.1;
+
+            proxy_set_header Host $http_host;
+            proxy_pass http://minio_backend;
+        }
+    }
+}


### PR DESCRIPTION
How could this setup be optimized ?

- Create a new GitHub Repo for the storage proxy and bake the nginx.conf into a docker image
  - disable / enable SSL via entrypoint.sh just like api-gateway
  - idea: do the same for elasticsearch and redis, this will clean the integration repo alot
- Use non-SSL setup for the demo setup
  - We would get rid of nginx.conf.demo
  - Get rid of generated Certificates
  - Get rid of "Do you want to trust this website ?" for demo setup

There is some duplicated code in `docker-compose.non-ssl.yml` and `docker-compose.demo.yml`.  
I could create a new file called `docker-compose.mounts.yml` for example. Non-ssl and demo will inherit from this file also.

These are all ideas in my head, I would love to know what you think about that !

P.S. this PR requires [this](https://github.com/mendersoftware/mender-api-gateway-docker/pull/109) to be merged.