### PR TITLE
Misc fixes during release

### DIFF
--- a/extra/gitdm/company-map
+++ b/extra/gitdm/company-map
@@ -1,6 +1,8 @@
 northern.tech Northern.tech
 mender.io Northern.tech
 cfengine.com Northern.tech
+tranchitella.eu Northern.tech
+users.noreply.github.com Northern.tech
 rndity.com RnDity
 amarulasolutions.com Amarula Solutions
 essvote.com Election Systems & Software
@@ -24,3 +26,4 @@ reachtest.com Reach Technologies Inc
 trellis-logic.com Trellis-Logic
 walkbase.com walkbase
 ni.com National Instruments
+baylibre.com BayLibre

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -1280,7 +1280,7 @@ def do_license_generation(state, tag_avail):
             gui_tag = "mendersoftware/gui:tmp"
             for tmpdir in tmpdirs:
                 if os.path.basename(tmpdir) == "gui":
-                    query_execute_list([["docker", "build", "-t", gui_tag, tmpdir]])
+                    query_execute_list([["docker", "build", "-t", gui_tag, "-f", os.path.join(tmpdir, "Dockerfile.disclaimer"), tmpdir]])
                     break
         elif reply == "2":
             gui_tag = "mendersoftware/gui:%s" % tag_or_followed_branch("gui")
@@ -1289,9 +1289,8 @@ def do_license_generation(state, tag_avail):
             return
 
         executed = query_execute_list([
-            ["docker", "run", "-d", "--name", "release_tool_gui_licenses", gui_tag],
-            ["docker", "cp", "release_tool_gui_licenses:/var/www/mender-gui/dist/disclaimer.txt", "gui-licenses.txt"],
-            ["docker", "rm", "-f", "release_tool_gui_licenses"],
+            ["docker", "run", "--rm", "--entrypoint", "/bin/sh", "-v", os.getcwd() + ":/extract", gui_tag,
+            "-c", "cp disclaimer.txt /extract/gui-licenses.txt"]
         ])
         if not executed:
             return


### PR DESCRIPTION
```
[release_tool] Update instructions to build/extract gui disclaimer
The gui docker image does not longer contain the disclaimer, it is built
separately.

[statistics-generator] Add companies to Company Map
Note that:
- tranchitella.eu is the personal domain of Fabio Tranchitella, but he
has been used this signature for NT work.
- Alex Miliukov has authored commits with users.noreply.github.com, so
we assume from now on that all these GitHub aliases are NT.
```

For the first commit, see also https://github.com/mendersoftware/gui/pull/624