### PR TITLE
[2.3.x] MEN-3166: Fix create-artifact-worker service restarting over and over.

### DIFF
--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -46,17 +46,6 @@ services:
             CONDUCTOR: "http://mender-conductor:8080"
             DEMO: "true"
 
-    # add service aliases
-    mender-mongo:
-        networks:
-            mender:
-                aliases:
-                    - mongo-tenantadm
-                    - mongo-deployments
-                    - mongo-device-auth
-                    - mongo-inventory
-                    - mongo-useradm
-
     # configure the rest
     mender-device-auth:
         environment:


### PR DESCRIPTION
The mongo-workflows host alias was missing in the enterprise docker-
compose file. However, this is the only difference between the two, so
decided to remove this section completely and let it inherit the
entries from the main docker-compose.yml file.

Changelog: Fix broken artifact creation in the UI.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit af2a068baddd31548f86ff3d18bf8ffd9a027f13)