### PR TITLE
MEN-3146: spelling of opensource plan is "os" in tenantadm

### DIFF
--- a/backend-tests/tests/test_deployments.py
+++ b/backend-tests/tests/test_deployments.py
@@ -111,7 +111,7 @@ def upload_image(filename, auth_token, description="abc"):
 
 
 def create_tenant_test_setup(
-    user_name, tenant_name, nr_deployments=3, nr_devices=100, plan="opensource"
+    user_name, tenant_name, nr_deployments=3, nr_devices=100, plan="os"
 ):
     """
     Creates a tenant, and a user belonging to the tenant
@@ -590,7 +590,7 @@ def setup_devices_and_management(nr_devices=100):
     """
     Sets up user and tenant and creates authorized devices.
     """
-    tenant = create_org("acme", "bugs@bunny.org", "correcthorse")
+    tenant = create_org("acme", "bugs@bunny.org", "correcthorse", plan="enterprise")
     user = tenant.users[0]
     useradmm = ApiClient(useradm.URL_MGMT)
     devauthd = ApiClient(deviceauth_v1.URL_DEVICES)

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -124,7 +124,7 @@ def create_user(name, pwd, tid="", containers_namespace="backend-tests"):
     return User(uid, name, pwd)
 
 
-def create_org(name, username, password, plan="opensource"):
+def create_org(name, username, password, plan="os"):
     cli = CliTenantadm()
     user_id = None
     tenant_id = cli.create_org(name, username, password, plan=plan)

--- a/testutils/infra/cli.py
+++ b/testutils/infra/cli.py
@@ -67,7 +67,7 @@ class CliTenantadm(BaseCli):
     def __init__(self, containers_namespace="backend-tests", container_manager=None):
         BaseCli.__init__(self, "mender-tenantadm", containers_namespace, container_manager)
 
-    def create_org(self, name, username, password, plan='opensource'):
+    def create_org(self, name, username, password, plan='os'):
         cmd = ['/usr/bin/tenantadm',
                'create-org',
                '--name', name,


### PR DESCRIPTION
Changelog: none
Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>