### PR TITLE
[changelog-generator] Fix bogus changelog entries with "None" text

### DIFF
--- a/extra/changelog-generator/changelog-generator
+++ b/extra/changelog-generator/changelog-generator
@@ -164,6 +164,8 @@ for repo in repos:
                     log_entry = title
                 elif re.match("^Commit[ .]*$", match.group(1), re.IGNORECASE):
                     log_entry_commit = True
+                elif re.match("^None[ .]*$", match.group(1), re.IGNORECASE):
+                    log_entry_commit = False
                 else:
                     log_entry_local = True
                     log_entry = match.group(1)

--- a/extra/changelog-generator/test-changelog-generator
+++ b/extra/changelog-generator/test-changelog-generator
@@ -344,6 +344,15 @@ Signed-off-by: Joe Average <joe@average.com>'
 
 ################################################################################
 
+git commit --allow-empty -m 'Commit with no changelog N70
+
+Changelog: None
+This line should not generate a changelog entry N71
+
+Signed-off-by: Hacker'
+
+################################################################################
+
 "$SRC_DIR/changelog-generator" --repo --sort-changelog HEAD > result.txt 2>stderr.txt || {
     echo "Script failed with $?"
     echo "--------"


### PR DESCRIPTION
Make the tool ignore message following a "Changelog: None" type of tag.
The previous logic was creating a bogus None entry if a text line was
found directly after the "Changelog: None" one.

Added a test case to test-changelog-entry to show the problem