### PR TITLE
[backend-tests] Dump logs to a local path on failures

### DIFF
--- a/backend-tests/run
+++ b/backend-tests/run
@@ -148,7 +148,7 @@ build_backend_tests_runner
 run_tests
 
 if [ "$failed" != "" ]; then
-    tmppath=$(mktemp /tmp/acceptance.XXXXXX)
+    tmppath=$(mktemp ${HERE}/acceptance.XXXXXX)
     echo "-- tests failed, dumping logs to $tmppath"
     $COMPOSE_CMD logs > $tmppath
 fi


### PR DESCRIPTION
Dump logs to a local path on failures so that the CI can collect them in the aftermath.

See also https://github.com/mendersoftware/mender-qa/pull/368