### PR TITLE
Alllow workflows-worker and create-artifact-worker to coexist

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -90,7 +90,7 @@ services:
         command: server --automigrate
 
     mender-workflows-worker:
-        command: worker --automigrate
+        command: worker --automigrate --excluded-workflows generate_artifact
 
     mender-create-artifact-worker:
         command: --automigrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
     #
     mender-workflows-worker:
         image: mendersoftware/workflows-worker:master
+        command: worker --excluded-workflows generate_artifact
         environment:
             WORKFLOWS_MONGO_URL: mongodb://mender-mongo:27017
         extends:

--- a/production/config/prod.yml.template
+++ b/production/config/prod.yml.template
@@ -23,7 +23,7 @@ services:
         command: server --automigrate
 
     mender-workflows-worker:
-        command: worker --automigrate
+        command: worker --automigrate --excluded-workflows generate_artifact
 
     mender-create-artifact-worker:
         command: --automigrate


### PR DESCRIPTION
workflows-worker and create-artifact-worker are both workflows worker,
the first generic, the latter specialized. To avoid processing the
generate_artifact workflows with the generic workflow worker, we need to
use the `--workflows` and `--excluded-workflows` CLI options when
starting the docker container.