### PR TITLE
dump-gitlab-env: pull and display gitlab envvars

### DIFF
--- a/extra/dump-gitlab-env.py
+++ b/extra/dump-gitlab-env.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import os
+import requests
+import argparse
+
+GITLAB_TOKEN = os.environ.get("GITLAB_TOKEN")
+if GITLAB_TOKEN is None:
+    raise RuntimeError("provide the GITLAB_TOKEN variable!")
+
+# not every var is interesting for local dev
+DEV_VARS = ["STRIPE_API_KEY", "AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY_ID"]
+
+
+def main(args):
+    v = get_gitlab_vars(GITLAB_TOKEN)
+    if args.all:
+        f = format_vars(v)
+    else:
+        f = format_vars(v, DEV_VARS)
+
+    print(f)
+
+
+def get_gitlab_vars(token):
+    res = requests.get(
+        # project id = mender-qa
+        "https://gitlab.com/api/v4/projects/12501706/variables",
+        headers={"PRIVATE-TOKEN": token},
+    )
+    if res.status_code != 200:
+        msg = "http {} \n{}".format(res.status_code, res.json())
+        raise RuntimeError("gitlab request failed: \n{}".format(msg))
+
+    return res.json()
+
+
+def format_vars(json, names=None):
+    selected = json
+
+    if names is not None:
+        selected = [x for x in json if x["key"] in names]
+
+    s = ""
+    for v in selected:
+        s += "{}={}\n".format(v["key"], v["value"])
+    return s
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+            description="Pull and dump interesting env vars from gitlab - ready for sourcing for your local test runs:\n\n"
+        "GITLAB_TOKEN=<your gitlab access token> ./dump-gitlab-env.py\n\n"+
+        "(see: https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)",
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--all",
+        default=False,
+        action="store_true",
+        help="grab the full set of env vars (many are irrelevant to local dev though!)",
+    )
+
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
some of the env is out there in compose files, but
some is hidden in gitlab (mender-qa).

to get reliable local test runs it's good to have
them pulled from the single source of truth.

this util pulls the env vars from the gitlab project and
dumps them in a format suitable for sourcing to your shell.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>