### PR TITLE
Reuse docker-compose environments between tests

### DIFF
--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -24,7 +24,7 @@ from testutils.infra.container_manager import factory
 container_factory = factory.get_factory()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def standard_setup_one_client(request):
     env = container_factory.getStandardSetup(num_clients=1)
     request.addfinalizer(env.teardown)
@@ -39,7 +39,7 @@ def standard_setup_one_client(request):
     return env
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def standard_setup_one_client_bootstrapped(request):
     env = container_factory.getStandardSetup(num_clients=1)
     request.addfinalizer(env.teardown)
@@ -55,7 +55,7 @@ def standard_setup_one_client_bootstrapped(request):
     return env
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def standard_setup_one_rofs_client_bootstrapped(request):
     env = container_factory.getRofsClientSetup()
     request.addfinalizer(env.teardown)
@@ -71,7 +71,7 @@ def standard_setup_one_rofs_client_bootstrapped(request):
     return env
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def standard_setup_one_docker_client_bootstrapped(request):
     env = container_factory.getDockerClientSetup()
     request.addfinalizer(env.teardown)
@@ -87,7 +87,7 @@ def standard_setup_one_docker_client_bootstrapped(request):
     return env
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def standard_setup_two_clients_bootstrapped(request):
     env = container_factory.getStandardSetup(num_clients=2)
     request.addfinalizer(env.teardown)
@@ -103,18 +103,7 @@ def standard_setup_two_clients_bootstrapped(request):
     return env
 
 
-@pytest.fixture(scope="function")
-def standard_setup_without_client(request):
-    env = container_factory.getStandardSetup(num_clients=0)
-    request.addfinalizer(env.teardown)
-
-    env.setup()
-    reset_mender_api(env)
-
-    return env
-
-
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def setup_with_legacy_client(request):
     # The legacy 1.7.0 client was only built for qemux86-64, so skip tests using
     # it when running other platforms.
@@ -137,7 +126,7 @@ def setup_with_legacy_client(request):
     return env
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def standard_setup_with_signed_artifact_client(request):
     env = container_factory.getSignedArtifactClientSetup()
     request.addfinalizer(env.teardown)
@@ -154,7 +143,7 @@ def standard_setup_with_signed_artifact_client(request):
     return env
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def standard_setup_with_short_lived_token(request):
     env = container_factory.getShortLivedTokenSetup()
     request.addfinalizer(env.teardown)
@@ -171,7 +160,7 @@ def standard_setup_with_short_lived_token(request):
     return env
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def setup_failover(request):
     env = container_factory.getFailoverServerSetup()
     request.addfinalizer(env.teardown)
@@ -188,7 +177,7 @@ def setup_failover(request):
     return env
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def running_custom_production_setup(request):
     conftest.production_setup_lock.acquire()
 
@@ -205,20 +194,9 @@ def running_custom_production_setup(request):
     return env
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def enterprise_no_client(request):
     env = container_factory.getEnterpriseSetup(num_clients=0)
-    request.addfinalizer(env.teardown)
-
-    env.setup()
-    reset_mender_api(env)
-
-    return env
-
-
-@pytest.fixture(scope="function")
-def enterprise_no_client_smtp(request):
-    env = container_factory.getEnterpriseSMTPSetup()
     request.addfinalizer(env.teardown)
 
     env.setup()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,6 +2,19 @@
 #  see https://github.com/pytest-dev/pytest/issues/1585
 [pytest]
 addopts = --capture=no
+markers =
+    enterprise_no_client
+    migrated_enterprise_setup
+    running_custom_production_setup
+    setup_failover
+    setup_with_legacy_client
+    standard_setup_one_client
+    standard_setup_one_client_bootstrapped
+    standard_setup_one_docker_client_bootstrapped
+    standard_setup_one_rofs_client_bootstrapped
+    standard_setup_two_clients_bootstrapped
+    standard_setup_with_short_lived_token
+    standard_setup_with_signed_artifact_client
 #
 # Sets list of directories that should be searched for tests when no specific
 # directories, files or test ids are given in the command line when executing

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -169,10 +169,30 @@ if [[ -n $SPECIFIC_INTEGRATION_TEST ]]; then
     SPECIFIC_INTEGRATION_TEST_FLAG="-k"
 fi
 
-python3 -m pytest \
-    $EXTRA_TEST_ARGS \
-    --verbose \
-    --junitxml=results.xml \
-    $HTML_REPORT \
-    "$@" \
-    $SPECIFIC_INTEGRATION_TEST_FLAG "$SPECIFIC_INTEGRATION_TEST"
+SETUPS="standard_setup_one_client
+standard_setup_one_client_bootstrapped
+standard_setup_one_rofs_client_bootstrapped
+standard_setup_one_docker_client_bootstrapped
+standard_setup_two_clients_bootstrapped
+setup_with_legacy_client
+standard_setup_with_signed_artifact_client
+standard_setup_with_short_lived_token
+setup_failover
+running_custom_production_setup
+enterprise_no_client
+migrated_enterprise_setup"
+
+for setup in $SETUPS; do 
+    date
+    python3 -m pytest \
+        $EXTRA_TEST_ARGS \
+        --verbose \
+        --junitxml=results.xml \
+        $HTML_REPORT \
+        "$@" \
+        -m $setup \
+        -n 0 \
+        $SPECIFIC_INTEGRATION_TEST_FLAG "$SPECIFIC_INTEGRATION_TEST" || true
+    [ -f results.xml ] && cp results.xml results-$setup.xml || true
+    [ -f results.html ] && cp results.html results-$setup.html || true
+done

--- a/tests/tests/test_00_multi_tenancy.py
+++ b/tests/tests/test_00_multi_tenancy.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import pytest
 import tempfile
 import time
 
@@ -26,6 +27,7 @@ from testutils.infra.device import MenderDevice
 
 
 class TestMultiTenancyEnterprise(MenderTesting):
+    @pytest.mark.enterprise_no_client
     def test_token_validity(self, enterprise_no_client):
         """ verify that only devices with valid tokens can bootstrap
             successfully to a multitenancy setup """
@@ -59,6 +61,7 @@ class TestMultiTenancyEnterprise(MenderTesting):
 
         auth_v2.get_devices(expected_devices=1)
 
+    @pytest.mark.enterprise_no_client
     def test_artifacts_exclusive_to_user(self, enterprise_no_client, valid_image):
         # extra long sleep to make sure all services ran their migrations
         # maybe conductor fails because some services are still in a migration phase,
@@ -99,6 +102,7 @@ class TestMultiTenancyEnterprise(MenderTesting):
             assert len(artifacts_for_user)
             assert artifacts_for_user[0]["name"] == user["email"]
 
+    @pytest.mark.enterprise_no_client
     def test_clients_exclusive_to_user(self, enterprise_no_client):
         users = [
             {
@@ -160,6 +164,7 @@ class TestMultiTenancyEnterprise(MenderTesting):
             else:
                 assert False, "decommissioned device still available in inventory"
 
+    @pytest.mark.enterprise_no_client
     def test_multi_tenancy_deployment(self, enterprise_no_client, valid_image):
         """ Simply make sure we are able to run the multi tenancy setup and
            bootstrap 2 different devices to different tenants """
@@ -210,6 +215,7 @@ class TestMultiTenancyEnterprise(MenderTesting):
                     skip_reboot_verification=True,
                 )
 
+    @pytest.mark.enterprise_no_client
     def test_multi_tenancy_deployment_aborting(self, enterprise_no_client, valid_image):
         """ Simply make sure we are able to run the multi tenancy setup and
            bootstrap 2 different devices to different tenants """

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -32,6 +32,7 @@ from .mendertesting import MenderTesting
 
 class TestBasicIntegration(MenderTesting):
     @MenderTesting.fast
+    @pytest.mark.standard_setup_one_rofs_client_bootstrapped
     def test_double_update_rofs(
         self, standard_setup_one_rofs_client_bootstrapped, valid_image_rofs
     ):
@@ -67,6 +68,7 @@ class TestBasicIntegration(MenderTesting):
         mender_device.run("mount | fgrep 'on / ' | fgrep '(ro,'")
 
     @MenderTesting.fast
+    @pytest.mark.standard_setup_with_short_lived_token
     def test_update_jwt_expired(
         self, standard_setup_with_short_lived_token, valid_image
     ):
@@ -79,6 +81,7 @@ class TestBasicIntegration(MenderTesting):
         )
 
     @MenderTesting.fast
+    @pytest.mark.setup_failover
     def test_update_failover_server(self, setup_failover, valid_image):
         """
         Client is initially set up against server A, and then receives an update
@@ -113,6 +116,7 @@ class TestBasicIntegration(MenderTesting):
             os.remove(tmp_image)
 
     @MenderTesting.fast
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_failed_updated_and_valid_update(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):
@@ -124,6 +128,7 @@ class TestBasicIntegration(MenderTesting):
         update_image_failed(mender_device, host_ip)
         update_image(mender_device, host_ip, install_image=valid_image)
 
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_update_no_compression(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):
@@ -136,6 +141,7 @@ class TestBasicIntegration(MenderTesting):
             compression_type="none",
         )
 
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_forced_update_check_from_client(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):
@@ -185,6 +191,7 @@ class TestBasicIntegration(MenderTesting):
         )
 
     @pytest.mark.timeout(1000)
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_forced_inventory_update_from_client(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -30,6 +30,7 @@ class TestBootstrapping(MenderTesting):
     MENDER_STORE = "/data/mender/mender-store"
 
     @MenderTesting.fast
+    @pytest.mark.standard_setup_one_client
     def test_bootstrap(self, standard_setup_one_client):
         """Simply make sure we are able to bootstrap a device"""
 
@@ -68,6 +69,7 @@ class TestBootstrapping(MenderTesting):
             logger.info("Accepted DeviceID: %s" % device["id"])
 
     @MenderTesting.slow
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_reject_bootstrap(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):

--- a/tests/tests/test_db_migration.py
+++ b/tests/tests/test_db_migration.py
@@ -50,6 +50,7 @@ exit 0
         return name
 
     @pytest.mark.usefixtures("setup_with_legacy_client")
+    @pytest.mark.setup_with_legacy_client
     def test_migrate_from_legacy_mender_v1_failure(
         self, setup_with_legacy_client, valid_image
     ):
@@ -102,6 +103,7 @@ exit 0
         )
 
     @pytest.mark.usefixtures("setup_with_legacy_client")
+    @pytest.mark.setup_with_legacy_client
     def test_migrate_from_legacy_mender_v1_success(
         self, setup_with_legacy_client, valid_image
     ):

--- a/tests/tests/test_demo_artifact.py
+++ b/tests/tests/test_demo_artifact.py
@@ -90,6 +90,7 @@ class TestDemoArtifact(MenderTesting):
     # Give the test a timeframe, as the script might run forever,
     # if something goes awry, or the script is not brought down properly.
     @pytest.mark.timeout(3000)
+    @pytest.mark.running_custom_production_setup
     def test_demo_artifact(self, run_demo_script):
         """Tests that the demo script does indeed upload the demo Artifact to the server."""
 
@@ -116,6 +117,7 @@ class TestDemoArtifact(MenderTesting):
         run_demo_script.teardown()
         self.auth.reset_auth_token()
 
+    @pytest.mark.running_custom_production_setup
     def demo_artifact_upload(self, run_demo_script, exit_cond="Login password:"):
         proc = run_demo_script(exit_cond)
         arts = self.deploy.get_artifacts()
@@ -130,6 +132,7 @@ class TestDemoArtifact(MenderTesting):
         proc.wait()
         assert proc.returncode == 0
 
+    @pytest.mark.running_custom_production_setup
     def demo_artifact_installation(self, run_demo_script):
         """Tests that the demo-artifact is successfully deployed to a client device."""
         run_demo_script()
@@ -160,6 +163,7 @@ class TestDemoArtifact(MenderTesting):
         # Verify the deployment
         self.deploy.check_expected_status("finished", deployment_id)
 
+    @pytest.mark.running_custom_production_setup
     def demo_up_down_up(self, run_demo_script):
         """Test that bringing the demo environment up, then down, then up succeeds"""
 

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -72,6 +72,7 @@ class TestDeploymentAborting(MenderTesting):
         deploy.check_expected_status("finished", deployment_id)
 
     @MenderTesting.fast
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_deployment_abortion_instantly(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):
@@ -82,6 +83,7 @@ class TestDeploymentAborting(MenderTesting):
     # Because the install step is over almost instantly, this test is very
     # fragile, it breaks at the slightest timing issue: MEN-1364
     @pytest.mark.skip
+    @pytest.mark.standard_setup_one_client_bootstrapped
     @MenderTesting.fast
     def test_deployment_abortion_downloading(
         self, standard_setup_one_client_bootstrapped, valid_image
@@ -91,6 +93,7 @@ class TestDeploymentAborting(MenderTesting):
         )
 
     @MenderTesting.fast
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_deployment_abortion_rebooting(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):
@@ -102,6 +105,7 @@ class TestDeploymentAborting(MenderTesting):
         )
 
     @MenderTesting.slow
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_deployment_abortion_success(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -96,6 +96,7 @@ class TestFaultTolerance(MenderTesting):
         logger.info("Waiting for system to finish download")
 
     @MenderTesting.slow
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_update_image_breaks_networking(
         self,
         standard_setup_one_client_bootstrapped,
@@ -118,6 +119,7 @@ class TestFaultTolerance(MenderTesting):
             deploy.check_expected_statistics(deployment_id, "failure", 1)
 
     @MenderTesting.slow
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_deployed_during_network_outage(
         self, standard_setup_one_client_bootstrapped, valid_image,
     ):
@@ -153,6 +155,7 @@ class TestFaultTolerance(MenderTesting):
         assert mender_device.yocto_id_installed_on_machine() == expected_yocto_id
 
     @MenderTesting.slow
+    @pytest.mark.standard_setup_one_client_bootstrapped
     @pytest.mark.parametrize("test_set", DOWNLOAD_RETRY_TIMEOUT_TEST_SETS)
     def test_image_download_retry_timeout(
         self, standard_setup_one_client_bootstrapped, test_set, valid_image,
@@ -208,6 +211,7 @@ class TestFaultTolerance(MenderTesting):
             reboot.verify_reboot_not_performed()
 
     @MenderTesting.slow
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_image_download_retry_hosts_broken(
         self, standard_setup_one_client_bootstrapped, valid_image,
     ):
@@ -239,6 +243,7 @@ class TestFaultTolerance(MenderTesting):
             assert mender_device.yocto_id_installed_on_machine() == new_yocto_id
             reboot.verify_reboot_not_performed()
 
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_rootfs_conf_missing_from_new_update(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):

--- a/tests/tests/test_grouping.py
+++ b/tests/tests/test_grouping.py
@@ -12,6 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import pytest
+
 from .. import conftest
 from ..common_setup import standard_setup_two_clients_bootstrapped
 from .common_update import common_update_procedure
@@ -60,6 +62,7 @@ class TestGrouping(MenderTesting):
         for device in device_map:
             assert inv.get_device_group(device)["group"] == device_map[device]
 
+    @pytest.mark.standard_setup_two_clients_bootstrapped
     def test_basic_groups(self, standard_setup_two_clients_bootstrapped):
         """Tests various group operations."""
 
@@ -91,6 +94,7 @@ class TestGrouping(MenderTesting):
         inv.delete_device_from_group(bravo, "Red")
         self.validate_group_responses({alpha: None, bravo: None})
 
+    @pytest.mark.standard_setup_two_clients_bootstrapped
     def test_update_device_group(
         self, standard_setup_two_clients_bootstrapped, valid_image
     ):

--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -24,6 +24,7 @@ from .mendertesting import MenderTesting
 @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
 class TestFailures(MenderTesting):
     @MenderTesting.slow
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_update_image_id_already_installed(
         self, standard_setup_one_client_bootstrapped, valid_image,
     ):
@@ -51,6 +52,7 @@ class TestFailures(MenderTesting):
         deploy.check_expected_status("finished", deployment_id)
 
     @MenderTesting.fast
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_large_update_image(self, standard_setup_one_client_bootstrapped):
         """Installing an image larger than the passive/active parition size should result in a failure."""
 

--- a/tests/tests/test_inventory.py
+++ b/tests/tests/test_inventory.py
@@ -23,10 +23,10 @@ from ..MenderAPI import auth_v2, inv, logger
 from .mendertesting import MenderTesting
 
 
-@pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
 class TestInventory(MenderTesting):
     @MenderTesting.fast
-    def test_inventory(self):
+    @pytest.mark.standard_setup_one_client_bootstrapped
+    def test_inventory(self, standard_setup_one_client_bootstrapped):
         """Test that device reports inventory after having bootstrapped."""
 
         attempts = 10

--- a/tests/tests/test_os_ent_migration.py
+++ b/tests/tests/test_os_ent_migration.py
@@ -160,6 +160,7 @@ def migrate_ent_setup(env):
 
 
 @pytest.mark.usefixtures("migrated_enterprise_setup")
+@pytest.mark.migrated_enterprise_setup
 class TestEntMigration:
     def test_users_ok(self, migrated_enterprise_setup):
         mender_gateway = migrated_enterprise_setup.get_mender_gateway()

--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -13,7 +13,9 @@
 #    limitations under the License.
 
 import json
+import pytest
 import time
+
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
@@ -153,25 +155,31 @@ UwIDAQAB
 
 
 class TestPreauth(TestPreauthBase):
+    @pytest.mark.standard_setup_one_client
     def test_ok_preauth_and_bootstrap(self, standard_setup_one_client):
         self.do_test_ok_preauth_and_bootstrap(standard_setup_one_client)
 
+    @pytest.mark.standard_setup_one_client
     def test_ok_preauth_and_remove(self, standard_setup_one_client):
         self.do_test_ok_preauth_and_remove()
 
+    @pytest.mark.standard_setup_one_client
     def test_fail_preauth_existing(self, standard_setup_one_client):
         self.do_test_fail_preauth_existing()
 
 
 class TestPreauthEnterprise(TestPreauthBase):
+    @pytest.mark.enterprise_no_client
     def test_ok_preauth_and_bootstrap(self, enterprise_no_client):
         self.__create_tenant_and_container(enterprise_no_client)
         self.do_test_ok_preauth_and_bootstrap(enterprise_no_client)
 
+    @pytest.mark.enterprise_no_client
     def test_ok_preauth_and_remove(self, enterprise_no_client):
         self.__create_tenant_and_container(enterprise_no_client)
         self.do_test_ok_preauth_and_remove()
 
+    @pytest.mark.enterprise_no_client
     def test_fail_preauth_existing(self, enterprise_no_client):
         self.__create_tenant_and_container(enterprise_no_client)
         self.do_test_fail_preauth_existing()

--- a/tests/tests/test_security.py
+++ b/tests/tests/test_security.py
@@ -31,6 +31,7 @@ from ..MenderAPI import logger
 
 
 class TestSecurity(MenderTesting):
+    @pytest.mark.running_custom_production_setup
     def test_ssl_only(self, running_custom_production_setup):
         """ make sure we are not exposing any non-ssl connections in production environment """
         done = False
@@ -87,6 +88,7 @@ class TestSecurity(MenderTesting):
                 ]
             )
 
+    @pytest.mark.standard_setup_with_short_lived_token
     def test_token_token_expiration(
         self, standard_setup_with_short_lived_token, valid_image
     ):

--- a/tests/tests/test_signed_image_update.py
+++ b/tests/tests/test_signed_image_update.py
@@ -28,6 +28,7 @@ class TestSignedUpdates(MenderTesting):
         we will only test basic backend integration with signed images here.
     """
 
+    @pytest.mark.standard_setup_with_signed_artifact_client
     def test_signed_artifact_success(
         self, standard_setup_with_signed_artifact_client, valid_image
     ):
@@ -39,6 +40,7 @@ class TestSignedUpdates(MenderTesting):
             signed=True,
         )
 
+    @pytest.mark.standard_setup_with_signed_artifact_client
     @pytest.mark.parametrize(
         "standard_setup_with_signed_artifact_client", ["force_new"], indirect=True
     )

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -534,6 +534,7 @@ class TestStateScripts(MenderTesting):
         "ArtifactFailure_Error_55",  # Error for this state doesn't exist, should never run.
     ]
 
+    @pytest.mark.standard_setup_one_client_bootstrapped
     @pytest.mark.parametrize("description,test_set", REBOOT_TEST_SET)
     def test_reboot_recovery(
         self, standard_setup_one_client_bootstrapped, description, test_set, valid_image
@@ -667,6 +668,7 @@ class TestStateScripts(MenderTesting):
                 )
 
     @MenderTesting.slow
+    @pytest.mark.standard_setup_one_client_bootstrapped
     @pytest.mark.parametrize("description,test_set", TEST_SETS)
     def test_state_scripts(
         self, standard_setup_one_client_bootstrapped, valid_image, description, test_set

--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import os
+import pytest
 import subprocess
 import tempfile
 import shutil
@@ -29,6 +30,7 @@ from .mendertesting import MenderTesting
 
 class TestUpdateModules(MenderTesting):
     @MenderTesting.fast
+    @pytest.mark.standard_setup_one_docker_client_bootstrapped
     def test_file_update_module(self, standard_setup_one_docker_client_bootstrapped):
         """Test the file based update module, first with a failed update, then
         a successful one."""
@@ -90,6 +92,7 @@ class TestUpdateModules(MenderTesting):
             shutil.rmtree(file_tree)
 
     @MenderTesting.fast
+    @pytest.mark.standard_setup_one_docker_client_bootstrapped
     def test_rootfs_image_rejected(self, standard_setup_one_docker_client_bootstrapped):
         """Test that a rootfs-image update is rejected when such a setup isn't
         present."""
@@ -130,6 +133,7 @@ class TestUpdateModules(MenderTesting):
             shutil.rmtree(file_tree)
 
     @MenderTesting.fast
+    @pytest.mark.standard_setup_one_client_bootstrapped
     def test_rootfs_update_module_success(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):

--- a/testutils/infra/container_manager/factory.py
+++ b/testutils/infra/container_manager/factory.py
@@ -65,10 +65,6 @@ class ContainerManagerFactory:
         """Setup with enterprise versions for the applicable services"""
         pass
 
-    def getEnterpriseSMTPSetup(self, name=None):
-        """Enterprise setup with SMTP enabled"""
-        pass
-
     def getCustomSetup(self, name=None):
         """A noop setup for tests that use custom setups
 
@@ -102,9 +98,6 @@ class DockerComposeManagerFactory(ContainerManagerFactory):
 
     def getEnterpriseSetup(self, name=None, num_clients=0):
         return DockerComposeEnterpriseSetup(name, num_clients)
-
-    def getEnterpriseSMTPSetup(self, name=None):
-        return DockerComposeEnterpriseSMTPSetup(name)
 
     def getCustomSetup(self, name=None):
         return DockerComposeCustomSetup(name)


### PR DESCRIPTION
This commit modifies the scope of the fixtures setting up the
docker-compose environment between test runs. Setting the scope
to session makes the tests reuse the environment between runs.