### PR TITLE
Format all integration and testutils Python code with black formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,15 @@
 
 [tool.black]
 target-version = ['py38']
-include = '.*/backend-tests/.*\.py$'
+include = '''
+(
+  /(
+      backend-tests
+    | testutils
+    | tests
+  )/.*\.py$
+)
+'''
 exclude = '''
 (
   /(
@@ -13,6 +21,7 @@ exclude = '''
     | _build
     | build
     | dist
+    | extra/gitdm
   )/
 )
 '''

--- a/tests/MenderAPI/__init__.py
+++ b/tests/MenderAPI/__init__.py
@@ -12,8 +12,11 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 # Define get funtion before the below imports to avoid circular dependency
 container_manager = None
+
+
 def get_container_manager():
     return container_manager
+
 
 from .authentication import Authentication
 from .deployments import Deployments

--- a/tests/MenderAPI/auth_v2.py
+++ b/tests/MenderAPI/auth_v2.py
@@ -22,8 +22,8 @@ from . import logger
 from . import get_container_manager
 from .requests_helpers import requests_retry
 
-class DeviceAuthV2():
 
+class DeviceAuthV2:
     def __init__(self, auth):
         self.reset()
         self.auth = auth
@@ -33,11 +33,15 @@ class DeviceAuthV2():
         pass
 
     def get_auth_v2_base_path(self):
-        return "https://%s/api/management/v2/devauth/" % (get_container_manager().get_mender_gateway())
+        return "https://%s/api/management/v2/devauth/" % (
+            get_container_manager().get_mender_gateway()
+        )
 
     def get_device(self, device_id):
         url = self.get_auth_v2_base_path() + device_id
-        return requests_retry().get(url, verify=False, headers=self.auth.get_auth_token())
+        return requests_retry().get(
+            url, verify=False, headers=self.auth.get_auth_token()
+        )
 
     def get_devices(self, expected_devices=1):
         return self.get_devices_status(expected_devices=expected_devices)
@@ -46,7 +50,7 @@ class DeviceAuthV2():
     def get_devices_status(self, status=None, expected_devices=1):
         device_status_path = self.get_auth_v2_base_path() + "devices"
         devices = None
-        max_wait = 10*60
+        max_wait = 10 * 60
         starttime = time.time()
         sleeptime = 5
 
@@ -56,17 +60,26 @@ class DeviceAuthV2():
             # Linear backoff
             sleeptime += 5
             logger.info("getting all devices from: %s" % (device_status_path))
-            devices = requests_retry().get(device_status_path, headers=self.auth.get_auth_token(), verify=False)
-            if devices.status_code == requests.status_codes.codes.ok and len(devices.json()) == expected_devices:
+            devices = requests_retry().get(
+                device_status_path, headers=self.auth.get_auth_token(), verify=False
+            )
+            if (
+                devices.status_code == requests.status_codes.codes.ok
+                and len(devices.json()) == expected_devices
+            ):
                 got_devices = True
                 break
             else:
                 if devices is not None and getattr(devices, "text"):
-                    logger.info("fail to get devices (payload: %s), will try for at least %d more seconds"
-                                % (devices.text, starttime + max_wait - time.time()))
+                    logger.info(
+                        "fail to get devices (payload: %s), will try for at least %d more seconds"
+                        % (devices.text, starttime + max_wait - time.time())
+                    )
                 else:
-                    logger.info("failed to get devices, will try for at least %d more seconds"
-                                % (starttime + max_wait - time.time()))
+                    logger.info(
+                        "failed to get devices, will try for at least %d more seconds"
+                        % (starttime + max_wait - time.time())
+                    )
 
         assert got_devices, "Not able to get devices"
 
@@ -85,13 +98,18 @@ class DeviceAuthV2():
         headers = {"Content-Type": "application/json"}
         headers.update(self.auth.get_auth_token())
 
-        r = requests_retry().put(self.get_auth_v2_base_path() + "devices/%s/auth/%s/status" % (device_id, auth_set_id),
-                                 verify=False,
-                                 headers=headers,
-                                 data=json.dumps({"status": status}))
+        r = requests_retry().put(
+            self.get_auth_v2_base_path()
+            + "devices/%s/auth/%s/status" % (device_id, auth_set_id),
+            verify=False,
+            headers=headers,
+            data=json.dumps({"status": status}),
+        )
         assert r.status_code == requests.status_codes.codes.no_content
 
-    def check_expected_status(self, status, expected_value, max_wait=60*60, polling_frequency=1):
+    def check_expected_status(
+        self, status, expected_value, max_wait=60 * 60, polling_frequency=1
+    ):
         timeout = time.time() + max_wait
         seen = set()
 
@@ -112,21 +130,35 @@ class DeviceAuthV2():
                 return
 
         if time.time() > timeout:
-            pytest.fail("Never found: %s:%s, only seen: %s" % (status, expected_value, str(seen)))
+            pytest.fail(
+                "Never found: %s:%s, only seen: %s"
+                % (status, expected_value, str(seen))
+            )
 
     def accept_devices(self, expected_devices):
-        if len(self.get_devices_status("accepted", expected_devices=expected_devices)) == len(get_container_manager().get_mender_clients()):
+        if len(
+            self.get_devices_status("accepted", expected_devices=expected_devices)
+        ) == len(get_container_manager().get_mender_clients()):
             return
 
         # iterate over devices and accept them
         for d in self.get_devices(expected_devices=expected_devices):
-            self.set_device_auth_set_status(d["id"], d["auth_sets"][0]["id"], "accepted")
+            self.set_device_auth_set_status(
+                d["id"], d["auth_sets"][0]["id"], "accepted"
+            )
 
         # block until devices are actually accepted
         timeout = time.time() + 30
         while time.time() <= timeout:
             time.sleep(1)
-            if len(self.get_devices_status(status="accepted", expected_devices=expected_devices)) == expected_devices:
+            if (
+                len(
+                    self.get_devices_status(
+                        status="accepted", expected_devices=expected_devices
+                    )
+                )
+                == expected_devices
+            ):
                 break
 
         if time.time() > timeout:
@@ -135,15 +167,23 @@ class DeviceAuthV2():
         logger.info("Successfully bootstrap all clients")
 
     def preauth(self, device_identity, pubkey):
-        path = "https://%s/api/management/v2/devauth/devices" % (get_container_manager().get_mender_gateway())
-        req = {'identity_data': device_identity, 'pubkey': pubkey}
+        path = "https://%s/api/management/v2/devauth/devices" % (
+            get_container_manager().get_mender_gateway()
+        )
+        req = {"identity_data": device_identity, "pubkey": pubkey}
         headers = {"Content-Type": "application/json"}
         headers.update(self.auth.get_auth_token())
 
-        return requests_retry().post(path, data=json.dumps(req), headers=headers, verify=False)
+        return requests_retry().post(
+            path, data=json.dumps(req), headers=headers, verify=False
+        )
 
     def delete_auth_set(self, did, aid):
-        path = "https://%s/api/management/v2/devauth/devices/%s/auth/%s" % (get_container_manager().get_mender_gateway(), did, aid)
+        path = "https://%s/api/management/v2/devauth/devices/%s/auth/%s" % (
+            get_container_manager().get_mender_gateway(),
+            did,
+            aid,
+        )
 
         headers = {"Content-Type": "application/json"}
         headers.update(self.auth.get_auth_token())
@@ -151,9 +191,11 @@ class DeviceAuthV2():
         return requests_retry().delete(path, headers=headers, verify=False)
 
     def decommission(self, deviceID, expected_http_code=204):
-        decommission_path_url = self.get_auth_v2_base_path() + "devices/" + str(deviceID)
-        r = requests_retry().delete(decommission_path_url,
-                                    verify=False,
-                                    headers=self.auth.get_auth_token())
+        decommission_path_url = (
+            self.get_auth_v2_base_path() + "devices/" + str(deviceID)
+        )
+        r = requests_retry().delete(
+            decommission_path_url, verify=False, headers=self.auth.get_auth_token()
+        )
         assert r.status_code == expected_http_code
         logger.info("device [%s] is decommissioned" % (deviceID))

--- a/tests/MenderAPI/authentication.py
+++ b/tests/MenderAPI/authentication.py
@@ -25,6 +25,7 @@ from .requests_helpers import requests_retry
 
 from testutils.infra.cli import CliUseradm, CliTenantadm
 
+
 class Authentication:
     auth_header = None
 
@@ -76,24 +77,26 @@ class Authentication:
         #             already (if not running xdist)
         r = self._do_login(self.username, self.password)
 
-        logger.info("Getting authentication token for user %s@%s"
-                    % (self.username, self.org_name))
+        logger.info(
+            "Getting authentication token for user %s@%s"
+            % (self.username, self.org_name)
+        )
 
         if create_new_user:
             if r.status_code is not 200:
                 if self.multitenancy and self.org_create:
-                    tenant_id = self._create_org(self.org_name,
-                                                 self.username,
-                                                 self.password)
+                    tenant_id = self._create_org(
+                        self.org_name, self.username, self.password
+                    )
                     tenant_id = tenant_id.strip()
 
                     tenant_data = self._get_tenant_data(tenant_id)
                     tenant_data_json = json.loads(tenant_data)
 
                     self.current_tenant = {
-                        "tenant_id":    tenant_id,
+                        "tenant_id": tenant_id,
                         "tenant_token": tenant_data_json["tenant_token"],
-                        "name":         tenant_data_json["name"]
+                        "name": tenant_data_json["name"],
                     }
                     self.org_create = False
 
@@ -125,10 +128,11 @@ class Authentication:
 
     def _do_login(self, username, password):
         r = requests_retry().post(
-            "https://%s/api/management/%s/useradm/auth/login" %
-            (get_container_manager().get_mender_gateway(), api_version),
+            "https://%s/api/management/%s/useradm/auth/login"
+            % (get_container_manager().get_mender_gateway(), api_version),
             verify=False,
-            auth=HTTPBasicAuth(username, password))
+            auth=HTTPBasicAuth(username, password),
+        )
         assert r.status_code == 200 or r.status_code == 401
 
         if r.status_code == 200:

--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -24,6 +24,7 @@ from . import api_version
 from . import get_container_manager
 from .requests_helpers import requests_retry
 
+
 class Deployments:
     # track the last statistic for a deployment id
     last_statistic = {}
@@ -38,49 +39,75 @@ class Deployments:
         self.last_statistic = Deployments.last_statistic
 
     def get_deployments_base_path(self):
-        return "https://%s/api/management/%s/deployments/" % (get_container_manager().get_mender_gateway(), api_version)
+        return "https://%s/api/management/%s/deployments/" % (
+            get_container_manager().get_mender_gateway(),
+            api_version,
+        )
 
     def upload_image(self, filename, description="abc"):
         image_path_url = self.get_deployments_base_path() + "artifacts"
 
-        r = requests_retry().post(image_path_url,
-                                  verify=False,
-                                  headers=self.auth.get_auth_token(),
-                                  files=(
-                                      ("description", (None, description)),
-                                      ("size", (None, str(os.path.getsize(filename)))),
-                                      ("artifact", (filename, open(filename, 'rb'), "application/octet-stream"))
-                                  ))
+        r = requests_retry().post(
+            image_path_url,
+            verify=False,
+            headers=self.auth.get_auth_token(),
+            files=(
+                ("description", (None, description)),
+                ("size", (None, str(os.path.getsize(filename)))),
+                (
+                    "artifact",
+                    (filename, open(filename, "rb"), "application/octet-stream"),
+                ),
+            ),
+        )
 
-        logger.info("Received image upload status code: " + str(r.status_code) + " with payload: " + str(r.text))
+        logger.info(
+            "Received image upload status code: "
+            + str(r.status_code)
+            + " with payload: "
+            + str(r.text)
+        )
         assert r.status_code == requests.status_codes.codes.created
         return r.headers["location"]
 
     def trigger_deployment(self, name, artifact_name, devices):
         deployments_path_url = self.get_deployments_base_path() + "deployments"
 
-        trigger_data = {"name": name,
-                        "artifact_name": artifact_name,
-                        "devices": devices}
+        trigger_data = {
+            "name": name,
+            "artifact_name": artifact_name,
+            "devices": devices,
+        }
 
-        headers = {'Content-Type': 'application/json'}
+        headers = {"Content-Type": "application/json"}
         headers.update(self.auth.get_auth_token())
 
-        r = requests_retry().post(deployments_path_url, headers=headers,
-                                  data=json.dumps(trigger_data), verify=False)
+        r = requests_retry().post(
+            deployments_path_url,
+            headers=headers,
+            data=json.dumps(trigger_data),
+            verify=False,
+        )
 
         logger.debug("triggering deployment with: " + json.dumps(trigger_data))
         logger.info("deployment returned: " + r.text)
         assert r.status_code == requests.status_codes.codes.created
 
-        deployment_id = str(r.headers['Location'].split("/")[-1])
-        logger.info("deployment [%s] triggered for device [%s]" % (deployment_id, devices))
+        deployment_id = str(r.headers["Location"].split("/")[-1])
+        logger.info(
+            "deployment [%s] triggered for device [%s]" % (deployment_id, devices)
+        )
 
         return deployment_id
 
     def get_logs(self, device, deployment_id, expected_status=200):
-        deployments_logs_url = self.get_deployments_base_path() + "deployments/%s/devices/%s/log" % (deployment_id, device)
-        r = requests_retry().get(deployments_logs_url, headers=self.auth.get_auth_token(), verify=False)
+        deployments_logs_url = self.get_deployments_base_path() + "deployments/%s/devices/%s/log" % (
+            deployment_id,
+            device,
+        )
+        r = requests_retry().get(
+            deployments_logs_url, headers=self.auth.get_auth_token(), verify=False
+        )
         assert r.status_code == expected_status
 
         logger.info("Logs contain " + str(r.text))
@@ -92,14 +119,20 @@ class Deployments:
         if status:
             deployments_status_url += "?status=%s" % (status)
 
-        r = requests_retry().get(deployments_status_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().get(
+            deployments_status_url, headers=self.auth.get_auth_token(), verify=False
+        )
 
         assert r.status_code == requests.status_codes.codes.ok
         return json.loads(r.text)
 
     def get_statistics(self, deployment_id):
-        deployments_statistics_url = self.get_deployments_base_path() + "deployments/%s/statistics" % (deployment_id)
-        r = requests_retry().get(deployments_statistics_url, headers=self.auth.get_auth_token(), verify=False)
+        deployments_statistics_url = self.get_deployments_base_path() + "deployments/%s/statistics" % (
+            deployment_id
+        )
+        r = requests_retry().get(
+            deployments_statistics_url, headers=self.auth.get_auth_token(), verify=False
+        )
         assert r.status_code == requests.status_codes.codes.ok
 
         try:
@@ -107,14 +140,17 @@ class Deployments:
         except Exception as e:
             assert e is None
 
-        if not self.last_statistic.setdefault(deployment_id, []) or \
-                self.last_statistic[deployment_id][-1] != str(r.text):
+        if not self.last_statistic.setdefault(deployment_id, []) or self.last_statistic[
+            deployment_id
+        ][-1] != str(r.text):
             self.last_statistic[deployment_id].append(str(r.text))
             logger.info("Statistics contains new entry: " + str(r.text))
 
         return json.loads(r.text)
 
-    def check_expected_status(self, expected_status, deployment_id, max_wait=60*60, polling_frequency=.2):
+    def check_expected_status(
+        self, expected_status, deployment_id, max_wait=60 * 60, polling_frequency=0.2
+    ):
         timeout = time.time() + max_wait
 
         while time.time() <= timeout:
@@ -122,17 +158,29 @@ class Deployments:
 
             for deployment in data:
                 if deployment["id"] == deployment_id:
-                    logger.info("got expected deployment status (%s) for: %s" % (expected_status, deployment_id))
+                    logger.info(
+                        "got expected deployment status (%s) for: %s"
+                        % (expected_status, deployment_id)
+                    )
                     return
             else:
                 time.sleep(polling_frequency)
                 continue
 
         if time.time() > timeout:
-            pytest.fail("Never found status: %s for %s after %d seconds" % (expected_status, deployment_id, max_wait))
+            pytest.fail(
+                "Never found status: %s for %s after %d seconds"
+                % (expected_status, deployment_id, max_wait)
+            )
 
-
-    def check_expected_statistics(self, deployment_id, expected_status, expected_count, max_wait=60*60, polling_frequency=.2):
+    def check_expected_statistics(
+        self,
+        deployment_id,
+        expected_status,
+        expected_count,
+        max_wait=60 * 60,
+        polling_frequency=0.2,
+    ):
         timeout = time.time() + max_wait
         seen = set()
 
@@ -146,56 +194,94 @@ class Deployments:
                 all_failed_logs = ""
                 for device in self.auth_v2.get_devices():
                     try:
-                        all_failed_logs += self.get_logs(device["id"], deployment_id) + "\n" * 5
+                        all_failed_logs += (
+                            self.get_logs(device["id"], deployment_id) + "\n" * 5
+                        )
                     except Exception as e:
                         logger.warning("failed to get logs.")
 
-                pytest.fail("deployment unexpectedly failed, here are the deployment logs: \n\n %s" % (all_failed_logs))
+                pytest.fail(
+                    "deployment unexpectedly failed, here are the deployment logs: \n\n %s"
+                    % (all_failed_logs)
+                )
 
             if data[expected_status] == expected_count:
                 return
             continue
 
         if time.time() > timeout:
-            pytest.fail("Never found: %s:%s, only seen: %s after %d seconds" % (expected_status, expected_count, str(seen), max_wait))
+            pytest.fail(
+                "Never found: %s:%s, only seen: %s after %d seconds"
+                % (expected_status, expected_count, str(seen), max_wait)
+            )
 
     def get_deployment_overview(self, deployment_id):
-        deployments_overview_url = self.get_deployments_base_path() + "deployments/%s/devices" % (deployment_id)
-        r = requests_retry().get(deployments_overview_url, headers=self.auth.get_auth_token(), verify=False)
+        deployments_overview_url = self.get_deployments_base_path() + "deployments/%s/devices" % (
+            deployment_id
+        )
+        r = requests_retry().get(
+            deployments_overview_url, headers=self.auth.get_auth_token(), verify=False
+        )
         assert r.status_code == requests.status_codes.codes.ok
         return r.json()
 
     def get_deployment(self, deployment_id):
-        deployments_url = self.get_deployments_base_path() + "deployments/%s" % (deployment_id)
-        r = requests_retry().get(deployments_url, headers=self.auth.get_auth_token(), verify=False)
+        deployments_url = self.get_deployments_base_path() + "deployments/%s" % (
+            deployment_id
+        )
+        r = requests_retry().get(
+            deployments_url, headers=self.auth.get_auth_token(), verify=False
+        )
         assert r.status_code == requests.status_codes.codes.ok
         return r.json()
 
     def get_artifact_details(self, artifact_id):
         artifact_url = self.get_deployments_base_path() + "artifacts/%s" % (artifact_id)
-        r = requests_retry().get(artifact_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().get(
+            artifact_url, headers=self.auth.get_auth_token(), verify=False
+        )
         assert r.status_code == requests.status_codes.codes.ok
         return r.json()
 
     def delete_artifact(self, artifact_id):
         artifact_url = self.get_deployments_base_path() + "artifacts/%s" % (artifact_id)
-        r = requests_retry().delete(artifact_url, headers=self.auth.get_auth_token(), verify=False)
+        r = requests_retry().delete(
+            artifact_url, headers=self.auth.get_auth_token(), verify=False
+        )
         assert r.status_code == requests.status_codes.codes.no_content
 
     def get_artifacts(self, auth_create_new_user=True):
         artifact_url = self.get_deployments_base_path() + "artifacts"
-        r = requests_retry().get(artifact_url, headers=self.auth.get_auth_token(auth_create_new_user), verify=False)
+        r = requests_retry().get(
+            artifact_url,
+            headers=self.auth.get_auth_token(auth_create_new_user),
+            verify=False,
+        )
         assert r.status_code == requests.status_codes.codes.ok
         return r.json()
 
     def abort(self, deployment_id):
-        deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (deployment_id)
-        r = requests_retry().put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "aborted"})
+        deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (
+            deployment_id
+        )
+        r = requests_retry().put(
+            deployment_abort_url,
+            verify=False,
+            headers=self.auth.get_auth_token(),
+            json={"status": "aborted"},
+        )
         time.sleep(5)
         assert r.status_code == requests.status_codes.codes.no_content
 
     def abort_finished_deployment(self, deployment_id):
-        deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (deployment_id)
-        r = requests_retry().put(deployment_abort_url, verify=False, headers=self.auth.get_auth_token(), json={"status": "aborted"})
+        deployment_abort_url = self.get_deployments_base_path() + "deployments/%s/status" % (
+            deployment_id
+        )
+        r = requests_retry().put(
+            deployment_abort_url,
+            verify=False,
+            headers=self.auth.get_auth_token(),
+            json={"status": "aborted"},
+        )
         time.sleep(5)
         assert r.status_code == requests.status_codes.codes.unprocessable_entity

--- a/tests/MenderAPI/inventory.py
+++ b/tests/MenderAPI/inventory.py
@@ -19,7 +19,8 @@ from . import api_version
 from . import get_container_manager
 from .requests_helpers import requests_retry
 
-class Inventory():
+
+class Inventory:
     auth = None
 
     def __init__(self, auth):
@@ -31,37 +32,58 @@ class Inventory():
         pass
 
     def get_inv_base_path(self):
-        return "https://%s/api/management/%s/inventory/" % (get_container_manager().get_mender_gateway(), api_version)
+        return "https://%s/api/management/%s/inventory/" % (
+            get_container_manager().get_mender_gateway(),
+            api_version,
+        )
 
     def get_devices(self, has_group=None):
         """get_devices API. has_group can be True/False/None string."""
         params = {}
         if has_group is not None:
-            params = ({"has_group": has_group})
-        ret = requests_retry().get(self.get_inv_base_path() + "devices", params=params, headers=self.auth.get_auth_token(), verify=False)
+            params = {"has_group": has_group}
+        ret = requests_retry().get(
+            self.get_inv_base_path() + "devices",
+            params=params,
+            headers=self.auth.get_auth_token(),
+            verify=False,
+        )
         assert ret.status_code == requests.status_codes.codes.ok
         return ret.json()
 
     def get_device(self, device_id):
         devurl = "%s%s/%s" % (self.get_inv_base_path(), "device", device_id)
-        ret = requests_retry().get(devurl, headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().get(
+            devurl, headers=self.auth.get_auth_token(), verify=False
+        )
         return ret
 
-
     def get_groups(self):
-        ret = requests_retry().get(self.get_inv_base_path() + "groups", headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().get(
+            self.get_inv_base_path() + "groups",
+            headers=self.auth.get_auth_token(),
+            verify=False,
+        )
         assert ret.status_code == requests.status_codes.codes.ok
         return ret.json()
 
     def get_devices_in_group(self, group):
         req = "groups/%s/devices" % group
-        ret = requests_retry().get(self.get_inv_base_path() + req, headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().get(
+            self.get_inv_base_path() + req,
+            headers=self.auth.get_auth_token(),
+            verify=False,
+        )
         assert ret.status_code == requests.status_codes.codes.ok
         return ret.json()
 
     def get_device_group(self, device):
         req = "devices/%s/group" % device
-        ret = requests_retry().get(self.get_inv_base_path() + req, headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().get(
+            self.get_inv_base_path() + req,
+            headers=self.auth.get_auth_token(),
+            verify=False,
+        )
         assert ret.status_code == requests.status_codes.codes.ok
         return ret.json()
 
@@ -70,10 +92,16 @@ class Inventory():
         headers.update(self.auth.get_auth_token())
         body = '{"group":"%s"}' % group
         req = "devices/%s/group" % device
-        ret = requests_retry().put(self.get_inv_base_path() + req, data=body, headers=headers, verify=False)
+        ret = requests_retry().put(
+            self.get_inv_base_path() + req, data=body, headers=headers, verify=False
+        )
         assert ret.status_code == requests.status_codes.codes.no_content
 
     def delete_device_from_group(self, device, group):
         req = "devices/%s/group/%s" % (device, group)
-        ret = requests_retry().delete(self.get_inv_base_path() + req, headers=self.auth.get_auth_token(), verify=False)
+        ret = requests_retry().delete(
+            self.get_inv_base_path() + req,
+            headers=self.auth.get_auth_token(),
+            verify=False,
+        )
         assert ret.status_code == requests.status_codes.codes.no_content

--- a/tests/MenderAPI/requests_helpers.py
+++ b/tests/MenderAPI/requests_helpers.py
@@ -5,9 +5,11 @@ from requests.packages.urllib3.util.retry import Retry
 # Will retry on 500 Server error
 def requests_retry(status_forcelist=[500, 502]):
     s = requests.Session()
-    retries = Retry(total=5,
-                    backoff_factor=1,
-                    status_forcelist=status_forcelist,
-                    method_whitelist=['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'])
-    s.mount('https://', HTTPAdapter(max_retries=retries))
+    retries = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=status_forcelist,
+        method_whitelist=["HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS", "TRACE"],
+    )
+    s.mount("https://", HTTPAdapter(max_retries=retries))
     return s

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -21,7 +21,9 @@ from .helpers import Helpers
 
 from testutils.infra.device import MenderDevice, MenderDeviceGroup
 from testutils.infra.container_manager import factory
+
 container_factory = factory.get_factory()
+
 
 @pytest.fixture(scope="function")
 def standard_setup_one_client(request):
@@ -36,6 +38,7 @@ def standard_setup_one_client(request):
     reset_mender_api(env)
 
     return env
+
 
 @pytest.fixture(scope="function")
 def standard_setup_one_client_bootstrapped(request):
@@ -52,6 +55,7 @@ def standard_setup_one_client_bootstrapped(request):
 
     return env
 
+
 @pytest.fixture(scope="function")
 def standard_setup_one_rofs_client_bootstrapped(request):
     env = container_factory.getRofsClientSetup()
@@ -66,6 +70,7 @@ def standard_setup_one_rofs_client_bootstrapped(request):
     auth_v2.accept_devices(1)
 
     return env
+
 
 @pytest.fixture(scope="function")
 def standard_setup_one_docker_client_bootstrapped(request):
@@ -82,6 +87,7 @@ def standard_setup_one_docker_client_bootstrapped(request):
 
     return env
 
+
 @pytest.fixture(scope="function")
 def standard_setup_two_clients_bootstrapped(request):
     env = container_factory.getStandardSetup(num_clients=2)
@@ -97,6 +103,7 @@ def standard_setup_two_clients_bootstrapped(request):
 
     return env
 
+
 @pytest.fixture(scope="function")
 def standard_setup_without_client(request):
     env = container_factory.getStandardSetup(num_clients=0)
@@ -107,13 +114,15 @@ def standard_setup_without_client(request):
 
     return env
 
+
 @pytest.fixture(scope="function")
 def setup_with_legacy_client(request):
     # The legacy 1.7.0 client was only built for qemux86-64, so skip tests using
     # it when running other platforms.
     if conftest.machine_name != "qemux86-64":
-        pytest.skip("Test only works with qemux86-64, and this is %s"
-                    % conftest.machine_name)
+        pytest.skip(
+            "Test only works with qemux86-64, and this is %s" % conftest.machine_name
+        )
 
     env = container_factory.getLegacyClientSetup()
     request.addfinalizer(env.teardown)
@@ -127,6 +136,7 @@ def setup_with_legacy_client(request):
     auth_v2.accept_devices(1)
 
     return env
+
 
 @pytest.fixture(scope="function")
 def standard_setup_with_signed_artifact_client(request):
@@ -144,6 +154,7 @@ def standard_setup_with_signed_artifact_client(request):
 
     return env
 
+
 @pytest.fixture(scope="function")
 def standard_setup_with_short_lived_token(request):
     env = container_factory.getShortLivedTokenSetup()
@@ -159,6 +170,7 @@ def standard_setup_with_short_lived_token(request):
     auth_v2.accept_devices(1)
 
     return env
+
 
 @pytest.fixture(scope="function")
 def setup_failover(request):
@@ -176,6 +188,7 @@ def setup_failover(request):
 
     return env
 
+
 @pytest.fixture(scope="function")
 def running_custom_production_setup(request):
     conftest.production_setup_lock.acquire()
@@ -192,6 +205,7 @@ def running_custom_production_setup(request):
 
     return env
 
+
 @pytest.fixture(scope="function")
 def enterprise_no_client(request):
     env = container_factory.getEnterpriseSetup(num_clients=0)
@@ -201,6 +215,7 @@ def enterprise_no_client(request):
     reset_mender_api(env)
 
     return env
+
 
 @pytest.fixture(scope="function")
 def enterprise_no_client_smtp(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,8 @@
 #    limitations under the License.
 
 from platform import python_version
-if python_version().startswith('2'):
+
+if python_version().startswith("2"):
     from fabric.api import *
 else:
     # User should re-implement: ???
@@ -52,8 +53,12 @@ def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", help="run slow tests")
     parser.addoption("--runfast", action="store_true", help="run fast tests")
 
-    parser.addoption("--machine-name", action="store", default="qemux86-64",
-                     help="The machine name to test. Most common values are qemux86-64 and vexpress-qemu.")
+    parser.addoption(
+        "--machine-name",
+        action="store",
+        default="qemux86-64",
+        help="The machine name to test. Most common values are qemux86-64 and vexpress-qemu.",
+    )
 
 
 def pytest_configure(config):
@@ -92,6 +97,7 @@ def pytest_configure(config):
 
     MenderTesting.set_test_conditions(config)
 
+
 def unique_test_name(request):
     """Generate unique test names by prepending the class to the method name"""
     if request.node.cls is not None:
@@ -99,15 +105,20 @@ def unique_test_name(request):
     else:
         return request.node.name
 
+
 # If we have xdist installed, the testlogger fixture will include the thread id
 try:
     import xdist
+
     @pytest.fixture(scope="function", autouse=True)
     def testlogger(request, worker_id):
         test_name = unique_test_name(request)
         log.setup_test_logger(test_name, worker_id)
         logger.info("%s is starting.... " % test_name)
+
+
 except ImportError:
+
     @pytest.fixture(scope="function", autouse=True)
     def testlogger(request):
         test_name = unique_test_name(request)
@@ -117,30 +128,42 @@ except ImportError:
 
 def pytest_exception_interact(node, call, report):
     if report.failed:
-        logger.error("Test %s failed with exception:\n%s" % (node.name, call.excinfo.getrepr()))
+        logger.error(
+            "Test %s failed with exception:\n%s" % (node.name, call.excinfo.getrepr())
+        )
         try:
             logger.info("Printing client deployment log, if possible:")
-            output = execute(run, "cat /data/mender/deployment*.log || true", hosts=get_mender_clients())
+            output = execute(
+                run,
+                "cat /data/mender/deployment*.log || true",
+                hosts=get_mender_clients(),
+            )
             logger.info(output)
         except:
             logger.info("Not able to print client deployment log")
 
         try:
             logger.info("Printing client systemd log, if possible:")
-            output = execute(run, "journalctl -u mender-client || true", hosts=get_mender_clients())
+            output = execute(
+                run, "journalctl -u mender-client || true", hosts=get_mender_clients()
+            )
             logger.info(output)
         except:
             logger.info("Not able to print client systemd log")
 
         # Note that this is not very fine grained, but running docker-compose -p XXXX ps seems
         # to ignore the filter
-        output = subprocess.check_output('docker ps --filter "status=exited"', shell=True)
+        output = subprocess.check_output(
+            'docker ps --filter "status=exited"', shell=True
+        )
         logger.info("Containers that exited during the test:")
-        for line in output.split('\n'):
+        for line in output.split("\n"):
             logger.info(line)
+
 
 def get_valid_image():
     return env.valid_image
+
 
 def verify_sane_test_environment():
     # check if required tools are in PATH, add any other checks here
@@ -152,4 +175,6 @@ def verify_sane_test_environment():
 
     ret = subprocess.call("docker ps > /dev/null", shell=True)
     if ret != 0:
-        raise SystemExit("not able to use docker, is your user part of the docker group?")
+        raise SystemExit(
+            "not able to use docker, is your user part of the docker group?"
+        )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,6 +29,7 @@ from MenderAPI import auth_v2
 
 logger = logging.getLogger()
 
+
 class Helpers:
     artifact_info_file = "/etc/mender/artifact_info"
     artifact_prefix = "artifact_name"
@@ -36,7 +37,11 @@ class Helpers:
     @classmethod
     def yocto_id_from_ext4(self, filename):
         try:
-            cmd = "debugfs -R 'cat %s' %s| sed -n 's/^%s=//p'" % (self.artifact_info_file, filename, self.artifact_prefix)
+            cmd = "debugfs -R 'cat %s' %s| sed -n 's/^%s=//p'" % (
+                self.artifact_info_file,
+                filename,
+                self.artifact_prefix,
+            )
             output = subprocess.check_output(cmd, shell=True).strip()
             logger.info("Running: " + cmd + " returned: " + output)
             return output
@@ -45,14 +50,17 @@ class Helpers:
             pytest.fail("Unable to read: %s, is it a broken image?" % (filename))
 
         except Exception as e:
-            pytest.fail("Unexpected error trying to read ext4 image: %s, error: %s" % (filename, str(e)))
+            pytest.fail(
+                "Unexpected error trying to read ext4 image: %s, error: %s"
+                % (filename, str(e))
+            )
 
     @staticmethod
     def identity_script_to_identity_string(output):
         data_dict = {}
-        for line in output.split('\n'):
-            split = line.split('=', 2)
-            assert(len(split) == 2)
+        for line in output.split("\n"):
+            split = line.split("=", 2)
+            assert len(split) == 2
             data_dict[split[0]] = split[1]
 
         return json.dumps(data_dict, separators=(",", ":"))
@@ -75,7 +83,10 @@ class Helpers:
         # Match them.
         ip_to_device_id = {}
         for device in devauth_devices:
-            ip_to_device_id[identity_to_ip[json.dumps(device['identity_data'], separators=(",", ":"))]] = device['id']
+            ip_to_device_id[
+                identity_to_ip[
+                    json.dumps(device["identity_data"], separators=(",", ":"))
+                ]
+            ] = device["id"]
 
         return ip_to_device_id
-

--- a/tests/log.py
+++ b/tests/log.py
@@ -4,7 +4,9 @@ import unicodedata
 import re
 import errno
 
-TEST_LOGS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mender_test_logs")
+TEST_LOGS_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "mender_test_logs"
+)
 
 # Create dir if does not exist
 try:
@@ -15,6 +17,7 @@ except OSError as e:
 
 # Default logger deafult level to DEBUG
 logging.getLogger().setLevel(logging.DEBUG)
+
 
 def setup_test_logger(test_name, worker_id=None):
     """Sets the default test logger
@@ -32,7 +35,9 @@ def setup_test_logger(test_name, worker_id=None):
     # Define format. For console logging, prepend the test name
     base_log_format = "%(asctime)s [%(levelname)s]: >> %(message)s"
     if worker_id is not None:
-        console_log_format = "[{}] {} -- {}".format(worker_id, test_name, base_log_format)
+        console_log_format = "[{}] {} -- {}".format(
+            worker_id, test_name, base_log_format
+        )
     else:
         console_log_format = "{} -- {}".format(test_name, base_log_format)
 
@@ -52,8 +57,9 @@ def setup_test_logger(test_name, worker_id=None):
     logger.addHandler(file_handler)
 
 
-_re_slugify_pass1_sub = re.compile(r'[^\w\s-]').sub
-_re_slugify_pass2_sub = re.compile(r'[-\s]+').sub
+_re_slugify_pass1_sub = re.compile(r"[^\w\s-]").sub
+_re_slugify_pass2_sub = re.compile(r"[-\s]+").sub
+
 
 def slugify(value):
     """
@@ -65,6 +71,8 @@ def slugify(value):
     """
 
     value = unicode(value)
-    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
-    value = _re_slugify_pass1_sub('', value).strip().lower()
-    return _re_slugify_pass2_sub('-', value)
+    value = (
+        unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    )
+    value = _re_slugify_pass1_sub("", value).strip().lower()
+    return _re_slugify_pass2_sub("-", value)

--- a/tests/production_test_env.py
+++ b/tests/production_test_env.py
@@ -5,16 +5,23 @@ import sys
 import subprocess
 import argparse
 
-parser = argparse.ArgumentParser(description='Helper script to bring up production env and provision for upgrade testing')
+parser = argparse.ArgumentParser(
+    description="Helper script to bring up production env and provision for upgrade testing"
+)
 
-parser.add_argument('--start', dest='start', action='store_true',
-                    help='start production environment')
+parser.add_argument(
+    "--start", dest="start", action="store_true", help="start production environment"
+)
 
-parser.add_argument('--kill', dest='kill', action='store_true',
-                    help='destroy production environment')
+parser.add_argument(
+    "--kill", dest="kill", action="store_true", help="destroy production environment"
+)
 
-parser.add_argument('--docker-compose-instance', required=True,
-                    help='The docker-compose instance to use (project name)')
+parser.add_argument(
+    "--docker-compose-instance",
+    required=True,
+    help="The docker-compose instance to use (project name)",
+)
 
 if len(sys.argv) == 1:
     parser.print_help()
@@ -24,29 +31,59 @@ args = parser.parse_args()
 
 docker_compose_project = args.docker_compose_instance
 
+
 def fill_production_template():
 
     # copy production environment yml file
-    subprocess.check_output(["cp", "production/config/prod.yml.template", "production-testing-env.yml"], cwd="../")
-    subprocess.check_output("sed -i 's,/production/,/,g' ../production-testing-env.yml", shell=True)
-    subprocess.check_output("sed -i 's/ALLOWED_HOSTS: my-gateway-dns-name/ALLOWED_HOSTS: ~./' ../production-testing-env.yml", shell=True)
-    subprocess.check_output("sed -i '0,/set-my-alias-here.com/s/set-my-alias-here.com/localhost/' ../production-testing-env.yml", shell=True)
-    subprocess.check_output("sed -i 's|DEPLOYMENTS_AWS_URI:.*|DEPLOYMENTS_AWS_URI: https://localhost:9000|' ../production-testing-env.yml", shell=True)
-    subprocess.check_output("sed -i 's/MINIO_ACCESS_KEY:.*/MINIO_ACCESS_KEY: Q3AM3UQ867SPQQA43P2F/' ../production-testing-env.yml", shell=True)
-    subprocess.check_output("sed -i 's/MINIO_SECRET_KEY:.*/MINIO_SECRET_KEY: abcssadasdssado798dsfjhkksd/' ../production-testing-env.yml", shell=True)
-    subprocess.check_output("sed -i 's/DEPLOYMENTS_AWS_AUTH_KEY:.*/DEPLOYMENTS_AWS_AUTH_KEY: Q3AM3UQ867SPQQA43P2F/' ../production-testing-env.yml", shell=True)
-    subprocess.check_output("sed -i 's/DEPLOYMENTS_AWS_AUTH_SECRET:.*/DEPLOYMENTS_AWS_AUTH_SECRET: abcssadasdssado798dsfjhkksd/' ../production-testing-env.yml", shell=True)
+    subprocess.check_output(
+        ["cp", "production/config/prod.yml.template", "production-testing-env.yml"],
+        cwd="../",
+    )
+    subprocess.check_output(
+        "sed -i 's,/production/,/,g' ../production-testing-env.yml", shell=True
+    )
+    subprocess.check_output(
+        "sed -i 's/ALLOWED_HOSTS: my-gateway-dns-name/ALLOWED_HOSTS: ~./' ../production-testing-env.yml",
+        shell=True,
+    )
+    subprocess.check_output(
+        "sed -i '0,/set-my-alias-here.com/s/set-my-alias-here.com/localhost/' ../production-testing-env.yml",
+        shell=True,
+    )
+    subprocess.check_output(
+        "sed -i 's|DEPLOYMENTS_AWS_URI:.*|DEPLOYMENTS_AWS_URI: https://localhost:9000|' ../production-testing-env.yml",
+        shell=True,
+    )
+    subprocess.check_output(
+        "sed -i 's/MINIO_ACCESS_KEY:.*/MINIO_ACCESS_KEY: Q3AM3UQ867SPQQA43P2F/' ../production-testing-env.yml",
+        shell=True,
+    )
+    subprocess.check_output(
+        "sed -i 's/MINIO_SECRET_KEY:.*/MINIO_SECRET_KEY: abcssadasdssado798dsfjhkksd/' ../production-testing-env.yml",
+        shell=True,
+    )
+    subprocess.check_output(
+        "sed -i 's/DEPLOYMENTS_AWS_AUTH_KEY:.*/DEPLOYMENTS_AWS_AUTH_KEY: Q3AM3UQ867SPQQA43P2F/' ../production-testing-env.yml",
+        shell=True,
+    )
+    subprocess.check_output(
+        "sed -i 's/DEPLOYMENTS_AWS_AUTH_SECRET:.*/DEPLOYMENTS_AWS_AUTH_SECRET: abcssadasdssado798dsfjhkksd/' ../production-testing-env.yml",
+        shell=True,
+    )
 
 
 def setup_docker_volumes():
-    docker_volumes = ["mender-artifacts",
-                      "mender-redis-db",
-                      "mender-elasticsearch-db",
-                      "mender-db"]
+    docker_volumes = [
+        "mender-artifacts",
+        "mender-redis-db",
+        "mender-elasticsearch-db",
+        "mender-db",
+    ]
 
     for volume in docker_volumes:
         ret = subprocess.call(["docker", "volume", "create", "--name=%s" % volume])
         assert ret == 0, "failed to create docker volumes"
+
 
 if args.start:
     # create volumes required for production environment
@@ -54,22 +91,42 @@ if args.start:
 
     # add keys for production environment
     if not os.path.exists("../keys-generated"):
-        ret = subprocess.call(["./keygen"], env={"CERT_API_CN": "localhost",
-                                                 "CERT_STORAGE_CN": "localhost"},
-                              cwd="../")
+        ret = subprocess.call(
+            ["./keygen"],
+            env={"CERT_API_CN": "localhost", "CERT_STORAGE_CN": "localhost"},
+            cwd="../",
+        )
         assert ret == 0, "failed to generate keys"
     fill_production_template()
 
     # start docker-compose
-    ret = subprocess.call(["docker-compose",
-                           "-p", docker_compose_project,
-                           "-f", "docker-compose.yml",
-                           "-f", "docker-compose.storage.minio.yml",
-                           "-f", "./production-testing-env.yml",
-                           "up", "-d"],
-                          cwd="../")
+    ret = subprocess.call(
+        [
+            "docker-compose",
+            "-p",
+            docker_compose_project,
+            "-f",
+            "docker-compose.yml",
+            "-f",
+            "docker-compose.storage.minio.yml",
+            "-f",
+            "./production-testing-env.yml",
+            "up",
+            "-d",
+        ],
+        cwd="../",
+    )
 
     assert ret == 0, "failed to start docker-compose"
 
 if args.kill:
-    subprocess.call(["docker-compose", "-p", docker_compose_project, "down", "-v", "--remove-orphans"])
+    subprocess.call(
+        [
+            "docker-compose",
+            "-p",
+            docker_compose_project,
+            "down",
+            "-v",
+            "--remove-orphans",
+        ]
+    )

--- a/tests/tests/mendertesting.py
+++ b/tests/tests/mendertesting.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 class MenderTesting(object):
     slow_cond = False
     fast_cond = False
@@ -24,5 +25,9 @@ class MenderTesting(object):
             MenderTesting.slow_cond = True
             MenderTesting.fast_cond = True
 
-        MenderTesting.slow = pytest.mark.skipif(not MenderTesting.slow_cond, reason="need --runslow option to run")
-        MenderTesting.fast = pytest.mark.skipif(not MenderTesting.fast_cond, reason="need --runfast option to run")
+        MenderTesting.slow = pytest.mark.skipif(
+            not MenderTesting.slow_cond, reason="need --runslow option to run"
+        )
+        MenderTesting.fast = pytest.mark.skipif(
+            not MenderTesting.fast_cond, reason="need --runfast option to run"
+        )

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -20,19 +20,25 @@ import time
 import pytest
 
 from .. import conftest
-from ..common_setup import standard_setup_one_rofs_client_bootstrapped, \
-                           standard_setup_with_short_lived_token, setup_failover, \
-                           standard_setup_one_client_bootstrapped
+from ..common_setup import (
+    standard_setup_one_rofs_client_bootstrapped,
+    standard_setup_with_short_lived_token,
+    setup_failover,
+    standard_setup_one_client_bootstrapped,
+)
 from .common_update import update_image, update_image_failed
 from ..MenderAPI import image, inv, logger
 from .mendertesting import MenderTesting
 
+
 class TestBasicIntegration(MenderTesting):
-
-
     @MenderTesting.fast
-    @pytest.mark.skipif(not os.path.exists("mender-image-full-cmdline-rofs-%s.ext4" % conftest.machine_name),
-                        reason="Thud branch and older from Yocto does not have R/O rootfs support")
+    @pytest.mark.skipif(
+        not os.path.exists(
+            "mender-image-full-cmdline-rofs-%s.ext4" % conftest.machine_name
+        ),
+        reason="Thud branch and older from Yocto does not have R/O rootfs support",
+    )
     def test_double_update_rofs(self, standard_setup_one_rofs_client_bootstrapped):
         """Upgrade a device with two consecutive R/O images using different compression algorithms"""
 
@@ -41,7 +47,9 @@ class TestBasicIntegration(MenderTesting):
         # Verify that partition is read-only as expected
         mender_device.run("mount | fgrep 'on / ' | fgrep '(ro,'")
 
-        host_ip = standard_setup_one_rofs_client_bootstrapped.get_virtual_network_host_ip()
+        host_ip = (
+            standard_setup_one_rofs_client_bootstrapped.get_virtual_network_host_ip()
+        )
         update_image(
             mender_device,
             host_ip,
@@ -93,8 +101,10 @@ class TestBasicIntegration(MenderTesting):
             if conf == None:
                 raise SystemExit("Could not retrieve mender.conf")
 
-            conf["Servers"] = [{"ServerURL": "https://docker.mender-failover.io"}, \
-                               {"ServerURL": conf["ServerURL"]}]
+            conf["Servers"] = [
+                {"ServerURL": "https://docker.mender-failover.io"},
+                {"ServerURL": conf["ServerURL"]},
+            ]
             conf.pop("ServerURL")
             image.replace_mender_conf(tmp_image, conf)
 
@@ -104,7 +114,9 @@ class TestBasicIntegration(MenderTesting):
             os.remove(tmp_image)
 
     @MenderTesting.fast
-    def test_failed_updated_and_valid_update(self, standard_setup_one_client_bootstrapped):
+    def test_failed_updated_and_valid_update(
+        self, standard_setup_one_client_bootstrapped
+    ):
         """Upload a device with a broken image, followed by a valid image"""
 
         mender_device = standard_setup_one_client_bootstrapped.device
@@ -123,13 +135,18 @@ class TestBasicIntegration(MenderTesting):
             compression_type="none",
         )
 
-    def test_forced_update_check_from_client(self, standard_setup_one_client_bootstrapped):
+    def test_forced_update_check_from_client(
+        self, standard_setup_one_client_bootstrapped
+    ):
         """Upload a device with a broken image, followed by a valid image"""
 
         mender_device = standard_setup_one_client_bootstrapped.device
 
         # Give the image a really large wait interval.
-        sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % ("\(.*PollInter.*:\)\( *[0-9]*\)", "\\1 1800")
+        sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % (
+            "\(.*PollInter.*:\)\( *[0-9]*\)",
+            "\\1 1800",
+        )
         out = mender_device.run(sedcmd)
         if out.return_code != 0:
             logger.error(out)
@@ -173,13 +190,18 @@ class TestBasicIntegration(MenderTesting):
         )
 
     @pytest.mark.timeout(1000)
-    def test_forced_inventory_update_from_client(self, standard_setup_one_client_bootstrapped):
+    def test_forced_inventory_update_from_client(
+        self, standard_setup_one_client_bootstrapped
+    ):
         """Forces an inventory update from an idling client."""
 
         mender_device = standard_setup_one_client_bootstrapped.device
 
         # Give the image a really large wait interval.
-        sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % ("\(.*PollInter.*:\)\( *[0-9]*\)", "\\1 1800")
+        sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % (
+            "\(.*PollInter.*:\)\( *[0-9]*\)",
+            "\\1 1800",
+        )
         mender_device.run(sedcmd)
         mender_device.run("systemctl restart mender-client")
 
@@ -204,7 +226,9 @@ class TestBasicIntegration(MenderTesting):
             wait_count = 0
 
         # Create some new inventory data from an inventory script.
-        mender_device.run("cd /usr/share/mender/inventory && echo '#!/bin/sh\necho host=foobar' > mender-inventory-test && chmod +x mender-inventory-test")
+        mender_device.run(
+            "cd /usr/share/mender/inventory && echo '#!/bin/sh\necho host=foobar' > mender-inventory-test && chmod +x mender-inventory-test"
+        )
 
         # Now that the client has settled into the wait-state, run the command, and check if it does indeed exit the wait state,
         # and send inventory.

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -18,7 +18,10 @@ import time
 import pytest
 
 from .. import conftest
-from ..common_setup import standard_setup_one_client, standard_setup_one_client_bootstrapped
+from ..common_setup import (
+    standard_setup_one_client,
+    standard_setup_one_client_bootstrapped,
+)
 from .common_update import common_update_procedure
 from ..MenderAPI import auth_v2, logger
 from .mendertesting import MenderTesting
@@ -37,7 +40,9 @@ class TestBootstrapping(MenderTesting):
 
         # iterate over devices and accept them
         for d in auth_v2.get_devices():
-            auth_v2.set_device_auth_set_status(d["id"], d["auth_sets"][0]["id"], "accepted")
+            auth_v2.set_device_auth_set_status(
+                d["id"], d["auth_sets"][0]["id"], "accepted"
+            )
             logger.info("Accepting DeviceID: %s" % d["id"])
 
         # make sure all devices are accepted
@@ -71,7 +76,9 @@ class TestBootstrapping(MenderTesting):
 
         # iterate over devices and reject them
         for device in auth_v2.get_devices():
-            auth_v2.set_device_auth_set_status(device["id"], device["auth_sets"][0]["id"], "rejected")
+            auth_v2.set_device_auth_set_status(
+                device["id"], device["auth_sets"][0]["id"], "rejected"
+            )
             logger.info("Rejecting DeviceID: %s" % device["id"])
 
         auth_v2.check_expected_status("rejected", 1)

--- a/tests/tests/test_db_migration.py
+++ b/tests/tests/test_db_migration.py
@@ -25,15 +25,16 @@ from .common_update import update_image, common_update_procedure
 from ..MenderAPI import deploy, logger
 from .mendertesting import MenderTesting
 
-class TestDBMigration(MenderTesting):
 
+class TestDBMigration(MenderTesting):
     def ensure_persistent_conf_script(self, dir):
         # Because older versions of Yocto branches did not split mender.conf
         # into /etc/mender/mender.conf and /data/mender/mender.conf, we need to
         # provide the content of the second file ourselves.
         name = os.path.join(dir, "ArtifactInstall_Enter_00_ensure_persistent_conf")
         with open(name, "w") as fd:
-            fd.write("""#!/bin/sh
+            fd.write(
+                """#!/bin/sh
 
 set -e
 
@@ -45,11 +46,14 @@ if ! [ -f /data/mender/mender.conf ]; then
     ) > /data/mender/mender.conf
 fi
 exit 0
-""")
+"""
+            )
         return name
 
     @pytest.mark.usefixtures("setup_with_legacy_client")
-    def test_migrate_from_legacy_mender_v1_failure(self, setup_with_legacy_client, install_image=conftest.get_valid_image()):
+    def test_migrate_from_legacy_mender_v1_failure(
+        self, setup_with_legacy_client, install_image=conftest.get_valid_image()
+    ):
         """
             Start a legacy client (1.7.0) first and update it to the new one.
 
@@ -63,7 +67,7 @@ exit 0
         mender_device = setup_with_legacy_client.device
 
         dirpath = tempfile.mkdtemp()
-        script_content = '#!/bin/sh\nexit 1\n'
+        script_content = "#!/bin/sh\nexit 1\n"
         with open(os.path.join(dirpath, "ArtifactCommit_Enter_01"), "w") as fd:
             fd.write(script_content)
 
@@ -74,10 +78,14 @@ exit 0
         # first start with the failed update
         host_ip = setup_with_legacy_client.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot:
-            deployment_id, _ = common_update_procedure(install_image,
-                                                       scripts=[ensure_persistent_conf,
-                                                                os.path.join(dirpath, "ArtifactCommit_Enter_01")],
-                                                       version=2)
+            deployment_id, _ = common_update_procedure(
+                install_image,
+                scripts=[
+                    ensure_persistent_conf,
+                    os.path.join(dirpath, "ArtifactCommit_Enter_01"),
+                ],
+                version=2,
+            )
 
             logger.info("waiting for system to reboot twice")
             reboot.verify_reboot_performed(number_of_reboots=2)
@@ -95,7 +103,9 @@ exit 0
         )
 
     @pytest.mark.usefixtures("setup_with_legacy_client")
-    def test_migrate_from_legacy_mender_v1_success(self, setup_with_legacy_client, install_image=conftest.get_valid_image()):
+    def test_migrate_from_legacy_mender_v1_success(
+        self, setup_with_legacy_client, install_image=conftest.get_valid_image()
+    ):
         """
             Start a legacy client (1.7.0) first and update it to the new one.
 
@@ -119,7 +129,7 @@ exit 0
                 script_path = os.path.join(tmpdir, script)
                 scripts_paths += [script_path]
                 with open(script_path, "w") as fd:
-                    fd.write('#!/bin/sh\necho $(basename $0) >> %s\n' % test_log)
+                    fd.write("#!/bin/sh\necho $(basename $0) >> %s\n" % test_log)
 
             # do the succesfull update twice
             host_ip = setup_with_legacy_client.get_virtual_network_host_ip()

--- a/tests/tests/test_demo_artifact.py
+++ b/tests/tests/test_demo_artifact.py
@@ -31,12 +31,15 @@ class TestDemoArtifact(MenderTesting):
     # NOTE - The password is set on a per test-basis,
     # as it is generated on the fly by the demo script.
     auth = authentication.Authentication(
-        name='mender-demo', username='mender-demo@example.com')
+        name="mender-demo", username="mender-demo@example.com"
+    )
     authv2 = DeviceAuthV2(auth)
     deploy = deployments.Deployments(auth, authv2)
 
     @pytest.fixture(scope="function")
-    def run_demo_script(self, running_custom_production_setup, exit_cond="Login password:"):
+    def run_demo_script(
+        self, running_custom_production_setup, exit_cond="Login password:"
+    ):
         """Simple fixture which returns a function which runs 'demo up'.
 
         :param exit_cond
@@ -51,25 +54,30 @@ class TestDemoArtifact(MenderTesting):
         def run_demo_script_up(exit_cond=exit_cond):
             test_env = os.environ.copy()
             test_env[
-                'DOCKER_COMPOSE_PROJECT_NAME'] = running_custom_production_setup.name
+                "DOCKER_COMPOSE_PROJECT_NAME"
+            ] = running_custom_production_setup.name
             proc = subprocess.Popen(
                 [
-                    './demo', '--client', '-p',
-                    running_custom_production_setup.name, 'up'
+                    "./demo",
+                    "--client",
+                    "-p",
+                    running_custom_production_setup.name,
+                    "up",
                 ],
                 cwd="..",
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                env=test_env)
-            logger.info('Started the demo script')
+                env=test_env,
+            )
+            logger.info("Started the demo script")
             password = ""
             time.sleep(60)
-            for line in iter(proc.stdout.readline, ''):
+            for line in iter(proc.stdout.readline, ""):
                 logger.info(line)
                 if exit_cond in line.strip():
                     if exit_cond == "Login password:":
-                        password = line.split(':')[-1].strip()
-                        logger.info('The login password:')
+                        password = line.split(":")[-1].strip()
+                        logger.info("The login password:")
                         logger.info(password)
                         self.auth.password = password
                         assert len(password) == 12
@@ -116,7 +124,7 @@ class TestDemoArtifact(MenderTesting):
         except:
             logger.error(str(arts))
             raise
-        assert "mender-demo-artifact" in arts[0]['name']
+        assert "mender-demo-artifact" in arts[0]["name"]
         # Bring down the demo script
         proc.send_signal(signal.SIGTERM)
         proc.wait()
@@ -125,9 +133,11 @@ class TestDemoArtifact(MenderTesting):
     def demo_artifact_installation(self, run_demo_script):
         """Tests that the demo-artifact is successfully deployed to a client device."""
         run_demo_script()
-        artifacts = self.deploy.get_artifacts(auth_create_new_user=False) # User should be created by the demo script.
+        artifacts = self.deploy.get_artifacts(
+            auth_create_new_user=False
+        )  # User should be created by the demo script.
         assert len(artifacts) == 1
-        artifact_name = artifacts[0]['name']
+        artifact_name = artifacts[0]["name"]
 
         # Trigger the deployment
         devices = self.authv2.get_devices()
@@ -136,17 +146,16 @@ class TestDemoArtifact(MenderTesting):
         # Accept the device to be updated
         self.authv2.accept_devices(1)
         devices = list(
-            set([
-                device["id"]
-                for device in self.authv2.get_devices_status("accepted")
-            ]))
+            set([device["id"] for device in self.authv2.get_devices_status("accepted")])
+        )
         assert len(devices) == 1
 
         # Run the deployment.
         deployment_id = self.deploy.trigger_deployment(
             name="Demo artifact deployment",
             artifact_name=artifact_name,
-            devices=devices)
+            devices=devices,
+        )
 
         # Verify the deployment
         self.deploy.check_expected_status("finished", deployment_id)
@@ -160,4 +169,4 @@ class TestDemoArtifact(MenderTesting):
         # Verify that the demo user is still present, when bringing
         # the environment up a second time
         self.demo_artifact_upload(run_demo_script, exit_cond="The user already exists")
-        logger.info('Finished')
+        logger.info("Finished")

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -23,9 +23,11 @@ from .common_update import common_update_procedure
 from ..MenderAPI import auth_v2, deploy
 from .mendertesting import MenderTesting
 
-class TestDeploymentAborting(MenderTesting):
 
-    def abort_deployment(self, container_manager, abort_step=None, mender_performs_reboot=False):
+class TestDeploymentAborting(MenderTesting):
+    def abort_deployment(
+        self, container_manager, abort_step=None, mender_performs_reboot=False
+    ):
         """
             Trigger a deployment, and cancel it within 15 seconds, make sure no deployment is performed.
 
@@ -37,12 +39,14 @@ class TestDeploymentAborting(MenderTesting):
 
         mender_device = container_manager.device
 
-        install_image=conftest.get_valid_image()
+        install_image = conftest.get_valid_image()
         expected_partition = mender_device.get_active_partition()
         expected_image_id = mender_device.yocto_id_installed_on_machine()
         host_ip = container_manager.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot:
-            deployment_id, _ = common_update_procedure(install_image, verify_status=False)
+            deployment_id, _ = common_update_procedure(
+                install_image, verify_status=False
+            )
 
             if abort_step is not None:
                 deploy.check_expected_statistics(deployment_id, abort_step, 1)
@@ -69,22 +73,29 @@ class TestDeploymentAborting(MenderTesting):
         deploy.check_expected_status("finished", deployment_id)
 
     @MenderTesting.fast
-    def test_deployment_abortion_instantly(self, standard_setup_one_client_bootstrapped):
+    def test_deployment_abortion_instantly(
+        self, standard_setup_one_client_bootstrapped
+    ):
         self.abort_deployment(standard_setup_one_client_bootstrapped)
 
     # Because the install step is over almost instantly, this test is very
     # fragile, it breaks at the slightest timing issue: MEN-1364
     @pytest.mark.skip
     @MenderTesting.fast
-    def test_deployment_abortion_downloading(self, standard_setup_one_client_bootstrapped):
-        self.abort_deployment(standard_setup_one_client_bootstrapped,
-                              "downloading")
+    def test_deployment_abortion_downloading(
+        self, standard_setup_one_client_bootstrapped
+    ):
+        self.abort_deployment(standard_setup_one_client_bootstrapped, "downloading")
 
     @MenderTesting.fast
-    def test_deployment_abortion_rebooting(self, standard_setup_one_client_bootstrapped):
-        self.abort_deployment(standard_setup_one_client_bootstrapped,
-                              "rebooting",
-                              mender_performs_reboot=True)
+    def test_deployment_abortion_rebooting(
+        self, standard_setup_one_client_bootstrapped
+    ):
+        self.abort_deployment(
+            standard_setup_one_client_bootstrapped,
+            "rebooting",
+            mender_performs_reboot=True,
+        )
 
     @MenderTesting.slow
     def test_deployment_abortion_success(self, standard_setup_one_client_bootstrapped):

--- a/tests/tests/test_grouping.py
+++ b/tests/tests/test_grouping.py
@@ -20,6 +20,7 @@ from ..MenderAPI import inv, deploy, logger
 from .mendertesting import MenderTesting
 from ..helpers import Helpers
 
+
 @MenderTesting.fast
 class TestGrouping(MenderTesting):
     def validate_group_responses(self, device_map):
@@ -44,21 +45,27 @@ class TestGrouping(MenderTesting):
             else:
                 groups_map[group] = [device]
 
-        assert(sorted(inv.get_groups()) == sorted(groups))
-        assert(sorted([device['id'] for device in inv.get_devices(has_group=True)]) == sorted(devices_with_group))
-        assert(sorted([device['id'] for device in inv.get_devices(has_group=False)]) == sorted(devices_without_group))
-        assert(sorted([device['id'] for device in inv.get_devices()]) == sorted(device_map.keys()))
+        assert sorted(inv.get_groups()) == sorted(groups)
+        assert sorted(
+            [device["id"] for device in inv.get_devices(has_group=True)]
+        ) == sorted(devices_with_group)
+        assert sorted(
+            [device["id"] for device in inv.get_devices(has_group=False)]
+        ) == sorted(devices_without_group)
+        assert sorted([device["id"] for device in inv.get_devices()]) == sorted(
+            device_map.keys()
+        )
 
         for group in groups:
-            assert(sorted(inv.get_devices_in_group(group)) == sorted(groups_map[group]))
+            assert sorted(inv.get_devices_in_group(group)) == sorted(groups_map[group])
         for device in device_map:
-            assert(inv.get_device_group(device)['group'] == device_map[device])
+            assert inv.get_device_group(device)["group"] == device_map[device]
 
     def test_basic_groups(self, standard_setup_two_clients_bootstrapped):
         """Tests various group operations."""
 
-        devices = [device['id'] for device in inv.get_devices()]
-        assert(len(devices) == 2)
+        devices = [device["id"] for device in inv.get_devices()]
+        assert len(devices) == 2
 
         # Purely for easier reading: Assign labels to each device.
         alpha = devices[0]
@@ -85,7 +92,6 @@ class TestGrouping(MenderTesting):
         inv.delete_device_from_group(bravo, "Red")
         self.validate_group_responses({alpha: None, bravo: None})
 
-
     def test_update_device_group(self, standard_setup_two_clients_bootstrapped):
         """
             Perform a successful upgrade on one group of devices, and assert that:
@@ -102,7 +108,7 @@ class TestGrouping(MenderTesting):
         # to update the group alpha, not beta.
 
         mender_device_group = standard_setup_two_clients_bootstrapped.device_group
-        assert(len(mender_device_group) == 2)
+        assert len(mender_device_group) == 2
         alpha = mender_device_group[0]
         bravo = mender_device_group[1]
 
@@ -118,7 +124,7 @@ class TestGrouping(MenderTesting):
 
         inv.put_device_in_group(id_alpha, "Update")
 
-        reboot = { alpha: None, bravo: None }
+        reboot = {alpha: None, bravo: None}
         host_ip = standard_setup_two_clients_bootstrapped.get_virtual_network_host_ip()
         with alpha.get_reboot_detector(host_ip) as reboot[
             alpha
@@ -138,7 +144,9 @@ class TestGrouping(MenderTesting):
         assert alpha.get_active_partition() == pass_part_alpha
         assert bravo.get_active_partition() != pass_part_bravo
 
-        deploy.check_expected_statistics(deployment_id, expected_status="success", expected_count=1)
+        deploy.check_expected_statistics(
+            deployment_id, expected_status="success", expected_count=1
+        )
 
         # No logs for either host: alpha because it was successful, bravo
         # because it should never have attempted an update in the first place.

--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -21,21 +21,29 @@ from .common_update import common_update_procedure
 from ..MenderAPI import auth_v2, deploy
 from .mendertesting import MenderTesting
 
+
 @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
 class TestFailures(MenderTesting):
-
     @MenderTesting.slow
-    def test_update_image_id_already_installed(self, standard_setup_one_client_bootstrapped, install_image=conftest.get_valid_image()):
+    def test_update_image_id_already_installed(
+        self,
+        standard_setup_one_client_bootstrapped,
+        install_image=conftest.get_valid_image(),
+    ):
         """Uploading an image with an incorrect name set results in failure and rollback."""
 
         mender_device = standard_setup_one_client_bootstrapped.device
 
         host_ip = standard_setup_one_client_bootstrapped.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot:
-            deployment_id, expected_image_id = common_update_procedure(install_image, True)
+            deployment_id, expected_image_id = common_update_procedure(
+                install_image, True
+            )
             reboot.verify_reboot_performed()
 
-        devices_accepted_id = [device["id"] for device in auth_v2.get_devices_status("accepted")]
+        devices_accepted_id = [
+            device["id"] for device in auth_v2.get_devices_status("accepted")
+        ]
         deployment_id = deploy.trigger_deployment(
             name="New valid update",
             artifact_name=expected_image_id,

--- a/tests/tests/test_inventory.py
+++ b/tests/tests/test_inventory.py
@@ -23,9 +23,9 @@ from ..common_setup import standard_setup_one_client_bootstrapped
 from ..MenderAPI import auth_v2, inv, logger
 from .mendertesting import MenderTesting
 
+
 @pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
 class TestInventory(MenderTesting):
-
     @MenderTesting.fast
     def test_inventory(self):
         """Test that device reports inventory after having bootstrapped."""
@@ -38,48 +38,85 @@ class TestInventory(MenderTesting):
                 inv_json = inv.get_devices()
                 auth_json = auth_v2.get_devices()
 
-                auth_ids = [device['id'] for device in auth_json]
+                auth_ids = [device["id"] for device in auth_json]
 
-                assert(len(inv_json) > 0)
+                assert len(inv_json) > 0
 
                 for device in inv_json:
                     try:
                         # Check that authentication and inventory agree.
-                        assert(device['id'] in auth_ids)
+                        assert device["id"] in auth_ids
 
-                        attrs = device['attributes']
+                        attrs = device["attributes"]
 
                         # Extract name and value only, to make tests more resilient
-                        attrs = [{"name": x.get('name'), "value": x.get('value')} for x in attrs]
+                        attrs = [
+                            {"name": x.get("name"), "value": x.get("value")}
+                            for x in attrs
+                        ]
 
                         # Check individual attributes.
-                        network_interfaces = [elem for elem in attrs if elem['name'] == "network_interfaces"]
+                        network_interfaces = [
+                            elem
+                            for elem in attrs
+                            if elem["name"] == "network_interfaces"
+                        ]
                         assert len(network_interfaces) == 1
                         network_interfaces = network_interfaces[0]
-                        if type(network_interfaces['value']) is str:
-                            assert any(network_interfaces['value'] == iface for iface in ["eth0", "enp0s3"])
+                        if type(network_interfaces["value"]) is str:
+                            assert any(
+                                network_interfaces["value"] == iface
+                                for iface in ["eth0", "enp0s3"]
+                            )
                         else:
-                            assert any(iface in network_interfaces['value'] for iface in ["eth0", "enp0s3"])
-                        assert(json.loads('{"name": "hostname", "value": "%s"}' % conftest.machine_name) in attrs)
-                        assert(json.loads('{"name": "device_type", "value": "%s"}' % conftest.machine_name) in attrs)
+                            assert any(
+                                iface in network_interfaces["value"]
+                                for iface in ["eth0", "enp0s3"]
+                            )
+                        assert (
+                            json.loads(
+                                '{"name": "hostname", "value": "%s"}'
+                                % conftest.machine_name
+                            )
+                            in attrs
+                        )
+                        assert (
+                            json.loads(
+                                '{"name": "device_type", "value": "%s"}'
+                                % conftest.machine_name
+                            )
+                            in attrs
+                        )
 
                         if conftest.machine_name == "qemux86-64":
                             bootloader_integration = "uefi_grub"
                         elif conftest.machine_name == "vexpress-qemu":
                             bootloader_integration = "uboot"
                         else:
-                            pytest.fail("Unknown machine_name. Please add an expected bootloader_integration for this machine_name")
-                        assert(json.loads('{"name": "mender_bootloader_integration", "value": "%s"}' % bootloader_integration) in attrs)
+                            pytest.fail(
+                                "Unknown machine_name. Please add an expected bootloader_integration for this machine_name"
+                            )
+                        assert (
+                            json.loads(
+                                '{"name": "mender_bootloader_integration", "value": "%s"}'
+                                % bootloader_integration
+                            )
+                            in attrs
+                        )
 
                         # Check that all known keys are present.
-                        keys = [str(attr['name']) for attr in attrs]
+                        keys = [str(attr["name"]) for attr in attrs]
                         expected_keys = [
                             "hostname",
                             "network_interfaces",
                             "cpu_model",
                             "mem_total_kB",
                             "device_type",
-                            ["ipv4_enp0s3", "ipv6_enp0s3", "ipv4_eth0"], # Multiple possibilities
+                            [
+                                "ipv4_enp0s3",
+                                "ipv6_enp0s3",
+                                "ipv4_eth0",
+                            ],  # Multiple possibilities
                             ["mac_enp0s3", "mac_eth0"],
                             "mender_client_version",
                             "artifact_name",

--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -38,7 +38,7 @@ class TestPreauthBase(MenderTesting):
         # preauthorize a new device
         preauth_iddata = {"mac": "mac-preauth"}
         # serialize manually to avoid an extra space (id data helper doesn't insert one)
-        preauth_iddata_str = "{\"mac\":\"mac-preauth\"}"
+        preauth_iddata_str = '{"mac":"mac-preauth"}'
 
         r = auth_v2.preauth(json.loads(preauth_iddata_str), preauth_key)
         assert r.status_code == 201
@@ -46,13 +46,13 @@ class TestPreauthBase(MenderTesting):
         # verify the device appears correctly in api results
         devs = auth_v2.get_devices(2)
 
-        dev_preauth = [d for d in devs if d['status'] == 'preauthorized']
+        dev_preauth = [d for d in devs if d["status"] == "preauthorized"]
         assert len(dev_preauth) == 1
         dev_preauth = dev_preauth[0]
         logger.info("dev_prauth_map: " + str(dev_preauth))
-        assert dev_preauth['identity_data'] == preauth_iddata
-        assert len(dev_preauth['auth_sets']) == 1
-        assert dev_preauth['auth_sets'][0]['pubkey'] == preauth_key
+        assert dev_preauth["identity_data"] == preauth_iddata
+        assert len(dev_preauth["auth_sets"]) == 1
+        assert dev_preauth["auth_sets"][0]["pubkey"] == preauth_key
 
         # make one of the existing devices the preauthorized device
         # by substituting id data and restarting
@@ -62,13 +62,14 @@ class TestPreauthBase(MenderTesting):
         # verify api results - after some time the device should be 'accepted'
         for _ in range(120):
             time.sleep(15)
-            dev_accepted = auth_v2.get_devices_status(status="accepted", expected_devices=2)
-            if len([d for d in dev_accepted if d['status'] == 'accepted']) == 1:
+            dev_accepted = auth_v2.get_devices_status(
+                status="accepted", expected_devices=2
+            )
+            if len([d for d in dev_accepted if d["status"] == "accepted"]) == 1:
                 break
 
-
         logger.info("devices: " + str(dev_accepted))
-        dev_accepted = [d for d in dev_accepted if d['status'] == 'accepted']
+        dev_accepted = [d for d in dev_accepted if d["status"] == "accepted"]
         logger.info("accepted devices: " + str(dev_accepted))
 
         Client.get_logs(mender_device)
@@ -77,9 +78,9 @@ class TestPreauthBase(MenderTesting):
         dev_accepted = dev_accepted[0]
         logger.info("accepted device: " + str(dev_accepted))
 
-        assert dev_accepted['identity_data'] == preauth_iddata
-        assert len(dev_preauth['auth_sets']) == 1
-        assert dev_accepted['auth_sets'][0]['pubkey'] == preauth_key
+        assert dev_accepted["identity_data"] == preauth_iddata
+        assert len(dev_preauth["auth_sets"]) == 1
+        assert dev_accepted["auth_sets"][0]["pubkey"] == preauth_key
 
         # verify device was issued a token
         Client.have_authtoken(mender_device)
@@ -89,8 +90,8 @@ class TestPreauthBase(MenderTesting):
             Test the removal of a preauthorized auth set, verify it's gone from all API results.
         """
         # preauthorize
-        preauth_iddata = json.loads("{\"mac\":\"preauth-mac\"}")
-        preauth_key = '''-----BEGIN PUBLIC KEY-----
+        preauth_iddata = json.loads('{"mac":"preauth-mac"}')
+        preauth_key = """-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzogVU7RGDilbsoUt/DdH
 VJvcepl0A5+xzGQ50cq1VE/Dyyy8Zp0jzRXCnnu9nu395mAFSZGotZVr+sWEpO3c
 yC3VmXdBZmXmQdZqbdD/GuixJOYfqta2ytbIUPRXFN7/I7sgzxnXWBYXYmObYvdP
@@ -99,32 +100,34 @@ okP0mQanY+WKxp7Q16pt1RoqoAd0kmV39g13rFl35muSHbSBoAW3GBF3gO+mF5Ty
 iyYyh1852rti3Afw4mDxuVSD7sd9ggvYMc0QHIpQNkD4YWOhNiE1AB0zH57VbUYG
 UwIDAQAB
 -----END PUBLIC KEY-----
-'''
+"""
 
         r = auth_v2.preauth(preauth_iddata, preauth_key)
         assert r.status_code == 201
 
         devs = auth_v2.get_devices(2)
 
-        dev_preauth = [d for d in devs if d['identity_data'] == preauth_iddata]
+        dev_preauth = [d for d in devs if d["identity_data"] == preauth_iddata]
         assert len(dev_preauth) == 1
         dev_preauth = dev_preauth[0]
 
         # remove from deviceauth
-        r = auth_v2.delete_auth_set(dev_preauth['id'], dev_preauth["auth_sets"][0]["id"])
+        r = auth_v2.delete_auth_set(
+            dev_preauth["id"], dev_preauth["auth_sets"][0]["id"]
+        )
         assert r.status_code == 204
 
         # verify removed from deviceauth
         devs = auth_v2.get_devices(1)
-        dev_removed = [d for d in devs if d['identity_data'] == preauth_iddata]
+        dev_removed = [d for d in devs if d["identity_data"] == preauth_iddata]
         assert len(dev_removed) == 0
 
         # verify removed from deviceauth
-        r = auth_v2.get_device(dev_preauth['id'])
+        r = auth_v2.get_device(dev_preauth["id"])
         assert r.status_code == 404
 
         # verify removed from inventory
-        r = inv.get_device(dev_preauth['id'])
+        r = inv.get_device(dev_preauth["id"])
         assert r.status_code == 404
 
     def do_test_fail_preauth_existing(self):
@@ -136,7 +139,7 @@ UwIDAQAB
         dev = devs[0]
 
         # try to preauthorize the same id data, new key
-        preauth_key = '''-----BEGIN PUBLIC KEY-----
+        preauth_key = """-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzogVU7RGDilbsoUt/DdH
 VJvcepl0A5+xzGQ50cq1VE/Dyyy8Zp0jzRXCnnu9nu395mAFSZGotZVr+sWEpO3c
 yC3VmXdBZmXmQdZqbdD/GuixJOYfqta2ytbIUPRXFN7/I7sgzxnXWBYXYmObYvdP
@@ -145,8 +148,8 @@ okP0mQanY+WKxp7Q16pt1RoqoAd0kmV39g13rFl35muSHbSBoAW3GBF3gO+mF5Ty
 iyYyh1852rti3Afw4mDxuVSD7sd9ggvYMc0QHIpQNkD4YWOhNiE1AB0zH57VbUYG
 UwIDAQAB
 -----END PUBLIC KEY-----
-'''
-        r = auth_v2.preauth(dev['identity_data'], preauth_key)
+"""
+        r = auth_v2.preauth(dev["identity_data"], preauth_key)
         assert r.status_code == 409
 
 
@@ -183,17 +186,17 @@ class TestPreauthEnterprise(TestPreauthBase):
         mender_device.ssh_is_opened()
         container_manager.device = mender_device
 
+
 class Client:
     """Wraps various actions on the client, performed via SSH (inside fabric.execute())."""
 
-    ID_HELPER = '/usr/share/mender/identity/mender-device-identity'
-    PRIV_KEY = '/data/mender/mender-agent.pem'
-    MENDER_STORE = '/data/mender/mender-store'
+    ID_HELPER = "/usr/share/mender/identity/mender-device-identity"
+    PRIV_KEY = "/data/mender/mender-agent.pem"
+    MENDER_STORE = "/data/mender/mender-store"
 
     KEYGEN_TIMEOUT = 300
     DEVICE_ACCEPTED_TIMEOUT = 600
     MENDER_STORE_TIMEOUT = 600
-
 
     @staticmethod
     def get_logs(device):
@@ -205,25 +208,24 @@ class Client:
         """Extract the device's public key from its private key."""
 
         Client.__wait_for_keygen(device)
-        keystr = device.run('cat {}'.format(Client.PRIV_KEY))
+        keystr = device.run("cat {}".format(Client.PRIV_KEY))
         private_key = serialization.load_pem_private_key(
             data=keystr.encode() if isinstance(keystr, str) else keystr,
             password=None,
-            backend=default_backend()
+            backend=default_backend(),
         )
         public_key = private_key.public_key()
         return public_key.public_bytes(
-            serialization.Encoding.PEM,
-            serialization.PublicFormat.SubjectPublicKeyInfo
+            serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
         )
 
     @staticmethod
     def substitute_id_data(device, id_data_dict):
         """Change the device's identity by substituting it's id data helper script."""
 
-        id_data = '#!/bin/sh\n'
-        for k,v in id_data_dict.items():
-            id_data += 'echo {}={}\n'.format(k,v)
+        id_data = "#!/bin/sh\n"
+        for k, v in id_data_dict.items():
+            id_data += "echo {}={}\n".format(k, v)
 
         cmd = 'echo "{}" > {}'.format(id_data, Client.ID_HELPER)
         device.run(cmd)
@@ -243,16 +245,20 @@ class Client:
                 out = device.run(
                     "strings {} | grep authtoken".format(Client.MENDER_STORE)
                 )
-                return out != ''
+                return out != ""
             except:
                 output_from_journalctl = device.run("journalctl -u mender-client -l")
                 logger.info("Logs from client: " + output_from_journalctl)
 
                 time.sleep(10)
                 sleepsec += 10
-                logger.info("waiting for mender-store file, sleepsec: {}".format(sleepsec))
+                logger.info(
+                    "waiting for mender-store file, sleepsec: {}".format(sleepsec)
+                )
 
-        assert sleepsec <= Client.MENDER_STORE_TIMEOUT, "timeout for mender-store file exceeded"
+        assert (
+            sleepsec <= Client.MENDER_STORE_TIMEOUT
+        ), "timeout for mender-store file exceeded"
 
     @staticmethod
     def __wait_for_keygen(device):
@@ -269,4 +275,3 @@ class Client:
                 break
 
         assert sleepsec <= Client.KEYGEN_TIMEOUT, "timeout for key generation exceeded"
-

--- a/tests/tests/test_security.py
+++ b/tests/tests/test_security.py
@@ -22,33 +22,46 @@ import time
 import pytest
 
 from .. import conftest
-from ..common_setup import running_custom_production_setup, standard_setup_with_short_lived_token
+from ..common_setup import (
+    running_custom_production_setup,
+    standard_setup_with_short_lived_token,
+)
 from .common_update import common_update_procedure
 from .mendertesting import MenderTesting
 from ..MenderAPI import logger
 
-class TestSecurity(MenderTesting):
 
+class TestSecurity(MenderTesting):
     def test_ssl_only(self, running_custom_production_setup):
         """ make sure we are not exposing any non-ssl connections in production environment """
         done = False
         sleep_time = 2
         # start production environment
-        subprocess.call(["./production_test_env.py", "--start",
-                         "--docker-compose-instance", running_custom_production_setup.name])
+        subprocess.call(
+            [
+                "./production_test_env.py",
+                "--start",
+                "--docker-compose-instance",
+                running_custom_production_setup.name,
+            ]
+        )
 
         try:
 
             # get all exposed ports from docker
 
             for _ in range(3):
-                exposed_hosts = subprocess.check_output("docker ps | grep %s | grep -o -E '0.0.0.0:[0-9]*' | cat"
-                                                        % running_custom_production_setup.name,
-                                                        shell=True)
+                exposed_hosts = subprocess.check_output(
+                    "docker ps | grep %s | grep -o -E '0.0.0.0:[0-9]*' | cat"
+                    % running_custom_production_setup.name,
+                    shell=True,
+                )
 
                 try:
                     for host in exposed_hosts.split():
-                        with contextlib.closing(ssl.wrap_socket(socket.socket())) as sock:
+                        with contextlib.closing(
+                            ssl.wrap_socket(socket.socket())
+                        ) as sock:
                             logger.info("%s: connect to host with TLS" % host)
                             host, port = host.split(":")
                             sock.connect((host, int(port)))
@@ -66,9 +79,14 @@ class TestSecurity(MenderTesting):
 
         finally:
             # tear down production env
-            subprocess.call(["./production_test_env.py", "--kill",
-                             "--docker-compose-instance", running_custom_production_setup.name])
-
+            subprocess.call(
+                [
+                    "./production_test_env.py",
+                    "--kill",
+                    "--docker-compose-instance",
+                    running_custom_production_setup.name,
+                ]
+            )
 
     def test_token_token_expiration(self, standard_setup_with_short_lived_token):
         """ verify that an expired token is handled correctly (client gets a new, valid one)

--- a/tests/tests/test_signed_image_update.py
+++ b/tests/tests/test_signed_image_update.py
@@ -21,6 +21,7 @@ from .common_update import update_image, common_update_procedure
 from ..MenderAPI import auth_v2, deploy
 from .mendertesting import MenderTesting
 
+
 @MenderTesting.fast
 class TestSignedUpdates(MenderTesting):
     """
@@ -37,18 +38,26 @@ class TestSignedUpdates(MenderTesting):
             signed=True,
         )
 
-    @pytest.mark.parametrize("standard_setup_with_signed_artifact_client", ["force_new"], indirect=True)
-    def test_unsigned_artifact_fails_deployment(self, standard_setup_with_signed_artifact_client):
+    @pytest.mark.parametrize(
+        "standard_setup_with_signed_artifact_client", ["force_new"], indirect=True
+    )
+    def test_unsigned_artifact_fails_deployment(
+        self, standard_setup_with_signed_artifact_client
+    ):
         """
             Make sure that an unsigned image fails, and is handled by the backend.
             Notice that this test needs a fresh new version of the backend, since
             we installed a signed image earlier without a verification key in mender.conf
         """
 
-        deployment_id, _ = common_update_procedure(install_image=conftest.get_valid_image())
+        deployment_id, _ = common_update_procedure(
+            install_image=conftest.get_valid_image()
+        )
         deploy.check_expected_status("finished", deployment_id)
         deploy.check_expected_statistics(deployment_id, "failure", 1)
 
         for d in auth_v2.get_devices():
-            assert "expecting signed artifact, but no signature file found" in \
-                deploy.get_logs(d["id"], deployment_id)
+            assert (
+                "expecting signed artifact, but no signature file found"
+                in deploy.get_logs(d["id"], deployment_id)
+            )

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -70,7 +70,7 @@ TEST_SETS = [
             "ExpectedStatus": "success",
             "ScriptOrder": [
                 "Idle_Enter_08_testing",
-                "Idle_Enter_09", # Error in this script should not have any effect.
+                "Idle_Enter_09",  # Error in this script should not have any effect.
                 "Idle_Leave_09",
                 "Idle_Leave_10",
                 "Sync_Enter_02",
@@ -105,7 +105,7 @@ TEST_SETS = [
             "ScriptOrder": [
                 "Idle_Enter_08_testing",
                 "Idle_Enter_09",
-                "Idle_Leave_09", # Error in this script should not have any effect.
+                "Idle_Leave_09",  # Error in this script should not have any effect.
                 "Idle_Leave_10",
                 "Sync_Enter_02",
                 "Sync_Enter_03",
@@ -314,7 +314,7 @@ TEST_SETS = [
                 "ArtifactReboot_Leave_99",
                 "ArtifactCommit_Enter_01",
                 "ArtifactCommit_Enter_05",
-                "ArtifactCommit_Leave_01_extra_string", # Error in this script should not have any effect.
+                "ArtifactCommit_Leave_01_extra_string",  # Error in this script should not have any effect.
                 "ArtifactCommit_Error_91",
             ],
         },
@@ -402,9 +402,7 @@ REBOOT_TEST_SET = [
     (
         "simulate_powerloss_artifact_install_enter",
         {
-            "RebootScripts": [
-                "ArtifactInstall_Enter_01",
-            ],
+            "RebootScripts": ["ArtifactInstall_Enter_01",],
             "ExpectedFinalPartition": ["OriginalPartition"],
             "ScriptOrder": [
                 "ArtifactInstall_Enter_01",
@@ -417,7 +415,7 @@ REBOOT_TEST_SET = [
             "ExpectedScriptFlow": [
                 "ArtifactInstall_Enter_01",  # kill!
                 "ArtifactFailure_Enter_01",  # run failure scripts
-                "ArtifactFailure_Leave_89"
+                "ArtifactFailure_Leave_89",
             ],
         },
     ),
@@ -481,12 +479,11 @@ REBOOT_TEST_SET = [
 ]
 
 
-
 class TestStateScripts(MenderTesting):
     scripts = [
         "Idle_Enter_08_testing",
         "Idle_Enter_09",
-        "Idle_Enter_100", # Invalid script, should never be run.
+        "Idle_Enter_100",  # Invalid script, should never be run.
         "Idle_Leave_09",
         "Idle_Leave_10",
         "Idle_Error_00",
@@ -524,39 +521,44 @@ class TestStateScripts(MenderTesting):
         "ArtifactRollback_Enter_01",
         "ArtifactRollback_Leave_00",
         "ArtifactRollback_Leave_01",
-        "ArtifactRollback_Error_15", # Error for this state doesn't exist, should never run.
+        "ArtifactRollback_Error_15",  # Error for this state doesn't exist, should never run.
         "ArtifactRollbackReboot_Enter_00",
         "ArtifactRollbackReboot_Enter_99",
         "ArtifactRollbackReboot_Leave_01",
         "ArtifactRollbackReboot_Leave_99",
-        "ArtifactRollbackReboot_Error_88", # Error for this state doesn't exist, should never run.
-        "ArtifactRollbackReboot_Error_99", # Error for this state doesn't exist, should never run.
+        "ArtifactRollbackReboot_Error_88",  # Error for this state doesn't exist, should never run.
+        "ArtifactRollbackReboot_Error_99",  # Error for this state doesn't exist, should never run.
         "ArtifactFailure_Enter_22",
         "ArtifactFailure_Enter_33",
         "ArtifactFailure_Leave_44",
         "ArtifactFailure_Leave_55",
-        "ArtifactFailure_Error_55", # Error for this state doesn't exist, should never run.
+        "ArtifactFailure_Error_55",  # Error for this state doesn't exist, should never run.
     ]
 
     @pytest.mark.parametrize("description,test_set", REBOOT_TEST_SET)
-    def test_reboot_recovery(self, standard_setup_one_client_bootstrapped, description, test_set):
+    def test_reboot_recovery(
+        self, standard_setup_one_client_bootstrapped, description, test_set
+    ):
 
         mender_device = standard_setup_one_client_bootstrapped.device
         work_dir = "test_state_scripts.%s" % mender_device.host_string
 
-        script_content = '#!/bin/sh\n\necho "$(basename $0)" >> /data/test_state_scripts.log\n'
+        script_content = (
+            '#!/bin/sh\n\necho "$(basename $0)" >> /data/test_state_scripts.log\n'
+        )
 
-        script_failure_content = script_content + 'sync\necho b > /proc/sysrq-trigger\n' # flush to disk before killing
+        script_failure_content = (
+            script_content + "sync\necho b > /proc/sysrq-trigger\n"
+        )  # flush to disk before killing
 
         # This is only needed in the case: die commit-leave,
         # otherwise the device will get stuck in a boot-reboot loop
-        script_reboot_once =(
-        '''#!/bin/sh
+        script_reboot_once = """#!/bin/sh
         if [ $(grep -c $(basename $0) /data/test_state_scripts.log) -eq 0 ]; then
             echo "$(basename $0)" >> /data/test_state_scripts.log && sync && echo b > /proc/sysrq-trigger
         fi
         echo "$(basename $0)" >> /data/test_state_scripts.log
-        exit 0''')
+        exit 0"""
 
         # Put artifact-scripts in the artifact.
         artifact_script_dir = os.path.join(work_dir, "artifact-scripts")
@@ -570,8 +572,7 @@ class TestStateScripts(MenderTesting):
         new_rootfs = os.path.join(work_dir, "rootfs.ext4")
         shutil.copy(conftest.get_valid_image(), new_rootfs)
 
-        ps = subprocess.Popen(
-            ["debugfs", "-w", new_rootfs], stdin=subprocess.PIPE)
+        ps = subprocess.Popen(["debugfs", "-w", new_rootfs], stdin=subprocess.PIPE)
         ps.stdin.write("cd /etc/mender\n" "mkdir scripts\n" "cd scripts\n")
         ps.stdin.close()
         ps.wait()
@@ -590,8 +591,8 @@ class TestStateScripts(MenderTesting):
 
         # Now create the artifact, and make the deployment.
         device_id = Helpers.ip_to_device_id_map(
-                MenderDeviceGroup([mender_device.host_string])
-            )[mender_device.host_string]
+            MenderDeviceGroup([mender_device.host_string])
+        )[mender_device.host_string]
 
         host_ip = standard_setup_one_client_bootstrapped.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot_detector:
@@ -600,7 +601,8 @@ class TestStateScripts(MenderTesting):
                 install_image=new_rootfs,
                 verify_status=True,
                 devices=[device_id],
-                scripts=[artifact_script_dir])[0]
+                scripts=[artifact_script_dir],
+            )[0]
 
             try:
 
@@ -619,7 +621,7 @@ class TestStateScripts(MenderTesting):
                 # wait until the last script has been run
                 logger.debug("waint until the last script has been run")
                 script_logs = ""
-                timeout = time.time() + 60*60
+                timeout = time.time() + 60 * 60
                 while timeout >= time.time():
                     time.sleep(3)
                     script_logs = mender_device.run("cat /data/test_state_scripts.log")
@@ -652,7 +654,9 @@ class TestStateScripts(MenderTesting):
 
     @MenderTesting.slow
     @pytest.mark.parametrize("description,test_set", TEST_SETS)
-    def test_state_scripts(self, standard_setup_one_client_bootstrapped, description, test_set):
+    def test_state_scripts(
+        self, standard_setup_one_client_bootstrapped, description, test_set
+    ):
         """Test that state scripts are executed in right order, and that errors
         are treated like they should."""
 
@@ -674,28 +678,30 @@ class TestStateScripts(MenderTesting):
             new_rootfs = os.path.join(work_dir, "rootfs.ext4")
             shutil.copy(conftest.get_valid_image(), new_rootfs)
             ps = subprocess.Popen(["debugfs", "-w", new_rootfs], stdin=subprocess.PIPE)
-            ps.stdin.write("cd /etc/mender\n"
-                           "mkdir scripts\n"
-                           "cd scripts\n")
+            ps.stdin.write("cd /etc/mender\n" "mkdir scripts\n" "cd scripts\n")
 
             with open(os.path.join(rootfs_script_dir, "version"), "w") as fd:
-                if test_set.get('CorruptEtcScriptVersionInUpdate'):
+                if test_set.get("CorruptEtcScriptVersionInUpdate"):
                     fd.write("1000")
                 else:
                     fd.write("2")
             ps.stdin.write("rm version\n")
-            ps.stdin.write("write %s version\n" % os.path.join(rootfs_script_dir, "version"))
+            ps.stdin.write(
+                "write %s version\n" % os.path.join(rootfs_script_dir, "version")
+            )
             for script in self.scripts:
                 if script.startswith("Artifact"):
                     # This is a script for the artifact, skip this one.
                     continue
                 with open(os.path.join(rootfs_script_dir, script), "w") as fd:
-                    if script in test_set['FailureScript']:
+                    if script in test_set["FailureScript"]:
                         fd.write(script_failure_content)
                     else:
                         fd.write(script_content)
                     os.fchmod(fd.fileno(), 0755)
-                ps.stdin.write("write %s %s\n" % (os.path.join(rootfs_script_dir, script), script))
+                ps.stdin.write(
+                    "write %s %s\n" % (os.path.join(rootfs_script_dir, script), script)
+                )
 
             ps.stdin.close()
             ps.wait()
@@ -707,7 +713,9 @@ class TestStateScripts(MenderTesting):
             # Then copy them to QEMU host.
             # Zip them all up to avoid having to copy each and every file, which is
             # quite slow.
-            subprocess.check_call(["tar", "czf", "../rootfs-scripts.tar.gz", "."], cwd=rootfs_script_dir)
+            subprocess.check_call(
+                ["tar", "czf", "../rootfs-scripts.tar.gz", "."], cwd=rootfs_script_dir
+            )
             # Stop client first to avoid race conditions.
             mender_device.run("systemctl stop mender-client")
             try:
@@ -731,7 +739,7 @@ class TestStateScripts(MenderTesting):
                     # Not an artifact script, skip this one.
                     continue
                 with open(os.path.join(artifact_script_dir, script), "w") as fd:
-                    if script in test_set['FailureScript']:
+                    if script in test_set["FailureScript"]:
                         fd.write(script_failure_content)
                     else:
                         fd.write(script_content)
@@ -742,11 +750,13 @@ class TestStateScripts(MenderTesting):
             device_id = Helpers.ip_to_device_id_map(
                 MenderDeviceGroup([mender_device.host_string])
             )[mender_device.host_string]
-            deployment_id = common_update_procedure(install_image=new_rootfs,
-                                                    verify_status=False,
-                                                    devices=[device_id],
-                                                    scripts=[artifact_script_dir])[0]
-            if test_set['ExpectedStatus'] is None:
+            deployment_id = common_update_procedure(
+                install_image=new_rootfs,
+                verify_status=False,
+                devices=[device_id],
+                scripts=[artifact_script_dir],
+            )[0]
+            if test_set["ExpectedStatus"] is None:
                 # In this case we don't expect the deployment to even be
                 # attempted, presumably due to failing Idle/Sync/Download
                 # scripts on the client. So no deployment checking. Just wait
@@ -760,6 +770,7 @@ class TestStateScripts(MenderTesting):
                         logger.error("%s:\n%s" % (cmd, output))
                         all_output += "%s\n" % output
                     return all_output
+
                 info_query = [
                     "cat /data/test_state_scripts.log 1>&2",
                     "journalctl -u mender-client",
@@ -768,7 +779,7 @@ class TestStateScripts(MenderTesting):
                     "for fd in /proc/`pgrep mender`/fdinfo/*; do echo $fd:; cat $fd; done",
                 ]
                 starttime = time.time()
-                while starttime + 60*60 >= time.time():
+                while starttime + 60 * 60 >= time.time():
                     result = mender_device.run(
                         "grep Error /data/test_state_scripts.log", warn_only=True
                     )
@@ -781,27 +792,35 @@ class TestStateScripts(MenderTesting):
                         continue
                 else:
                     info = fetch_info(info_query)
-                    pytest.fail('Waited too long for "Error" to appear in log:\n%s' % info)
+                    pytest.fail(
+                        'Waited too long for "Error" to appear in log:\n%s' % info
+                    )
             else:
-                deploy.check_expected_statistics(deployment_id, test_set['ExpectedStatus'], 1)
+                deploy.check_expected_statistics(
+                    deployment_id, test_set["ExpectedStatus"], 1
+                )
 
             # Always give the client a little bit of time to settle in the base
             # state after an update.
             time.sleep(10)
 
             output = mender_device.run("cat /data/test_state_scripts.log")
-            self.verify_script_log_correct(test_set, output.split('\n'))
+            self.verify_script_log_correct(test_set, output.split("\n"))
 
             new_active = mender_device.get_active_partition()
-            should_switch_partition = (test_set['ExpectedStatus'] == "success")
+            should_switch_partition = test_set["ExpectedStatus"] == "success"
 
-            if test_set.get('SwapPartitionExpectation'):
+            if test_set.get("SwapPartitionExpectation"):
                 should_switch_partition = not should_switch_partition
 
             if should_switch_partition:
-                assert old_active != new_active, "Device did not switch partition as expected!"
+                assert (
+                    old_active != new_active
+                ), "Device did not switch partition as expected!"
             else:
-                assert old_active == new_active, "Device switched partition which was not expected!"
+                assert (
+                    old_active == new_active
+                ), "Device switched partition which was not expected!"
 
         except:
             output = mender_device.run(
@@ -826,7 +845,7 @@ class TestStateScripts(MenderTesting):
             )
 
     def verify_script_log_correct(self, test_set, log_orig):
-        expected_order = test_set['ScriptOrder']
+        expected_order = test_set["ScriptOrder"]
 
         # First remove timestamps from the log
         log = [l.split(" ")[-1] for l in log_orig]
@@ -856,10 +875,12 @@ class TestStateScripts(MenderTesting):
                     num_iterations = num_iterations + 1
                     expected_pos = 0
 
-                if (log_pos < len(log)
+                if (
+                    log_pos < len(log)
                     and log[log_pos - 1].startswith("Sync_")
                     and log[log_pos].startswith("Idle_")
-                    and not expected_order[expected_pos].startswith("Idle_")):
+                    and not expected_order[expected_pos].startswith("Idle_")
+                ):
                     # The Idle/Sync sequence is allowed to "wrap around" and start
                     # over, because it may take a few rounds of checking before the
                     # deployment is ready for the client.
@@ -869,14 +890,15 @@ class TestStateScripts(MenderTesting):
             # Test cases with None expectation will loop through the error sequence in a loop, but still
             # we want to make sure that it is reasonable (i.e. looping with the correct time intervals).
             # For these cases we set a max. of 50 iterations to accomodate for slow running of the framework
-            if test_set['ExpectedStatus'] is not None:
+            if test_set["ExpectedStatus"] is not None:
                 assert num_iterations == 1
             else:
                 assert num_iterations < 50
 
         except:
-            logger.error("Exception in verify_script_log_correct: log of scripts = '%s'"
-                  % "\n".join(log_orig))
-            logger.error("scripts we expected = '%s'"
-                  % "\n".join(expected_order))
+            logger.error(
+                "Exception in verify_script_log_correct: log of scripts = '%s'"
+                % "\n".join(log_orig)
+            )
+            logger.error("scripts we expected = '%s'" % "\n".join(expected_order))
             raise

--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -19,11 +19,14 @@ import tempfile
 import shutil
 
 from .. import conftest
-from ..common_setup import standard_setup_one_docker_client_bootstrapped, \
-                           standard_setup_one_client_bootstrapped
+from ..common_setup import (
+    standard_setup_one_docker_client_bootstrapped,
+    standard_setup_one_client_bootstrapped,
+)
 from .common_update import common_update_procedure, update_image
 from ..MenderAPI import deploy, logger
 from .mendertesting import MenderTesting
+
 
 class TestUpdateModules(MenderTesting):
     @MenderTesting.fast
@@ -42,8 +45,10 @@ class TestUpdateModules(MenderTesting):
                     fd.write(file_and_content)
 
             def make_artifact(artifact_file, artifact_id):
-                cmd = ("directory-artifact-gen -o %s -n %s -t docker-client -d /tmp/test_file_update_module %s"
-                       % (artifact_file, artifact_id, file_tree))
+                cmd = (
+                    "directory-artifact-gen -o %s -n %s -t docker-client -d /tmp/test_file_update_module %s"
+                    % (artifact_file, artifact_id, file_tree)
+                )
                 logger.info("Executing: " + cmd)
                 subprocess.check_call(cmd, shell=True)
                 return artifact_file
@@ -55,8 +60,9 @@ class TestUpdateModules(MenderTesting):
             # quick that it sometimes races past the 'inprogress' status without
             # the test framework having time to register it. That's not really
             # the part we're interested in though, so just skip it.
-            deployment_id, expected_image_id = common_update_procedure(make_artifact=make_artifact,
-                                                                       verify_status=False)
+            deployment_id, expected_image_id = common_update_procedure(
+                make_artifact=make_artifact, verify_status=False
+            )
             deploy.check_expected_statistics(deployment_id, "failure", 1)
             deploy.check_expected_status("finished", deployment_id)
 
@@ -66,8 +72,9 @@ class TestUpdateModules(MenderTesting):
             # Remove path block.
             mender_device.run("rm -f /tmp/test_file_update_module")
 
-            deployment_id, expected_image_id = common_update_procedure(make_artifact=make_artifact,
-                                                                       verify_status=False)
+            deployment_id, expected_image_id = common_update_procedure(
+                make_artifact=make_artifact, verify_status=False
+            )
             deploy.check_expected_statistics(deployment_id, "success", 1)
             deploy.check_expected_status("finished", deployment_id)
 
@@ -97,8 +104,10 @@ class TestUpdateModules(MenderTesting):
                 fd.write("dummy")
 
             def make_artifact(artifact_file, artifact_id):
-                cmd = ("mender-artifact write rootfs-image -o %s -n %s -t docker-client -f %s"
-                       % (artifact_file, artifact_id, file1))
+                cmd = (
+                    "mender-artifact write rootfs-image -o %s -n %s -t docker-client -f %s"
+                    % (artifact_file, artifact_id, file1)
+                )
                 logger.info("Executing: " + cmd)
                 subprocess.check_call(cmd, shell=True)
                 return artifact_file
@@ -110,8 +119,13 @@ class TestUpdateModules(MenderTesting):
             output = mender_device.run("mender -show-artifact").strip()
             assert output == "original"
 
-            output = standard_setup_one_docker_client_bootstrapped.get_logs_of_service("mender-client")
-            assert "Artifact Payload type 'rootfs-image' is not supported by this Mender Client" in output
+            output = standard_setup_one_docker_client_bootstrapped.get_logs_of_service(
+                "mender-client"
+            )
+            assert (
+                "Artifact Payload type 'rootfs-image' is not supported by this Mender Client"
+                in output
+            )
 
         finally:
             shutil.rmtree(file_tree)
@@ -122,9 +136,16 @@ class TestUpdateModules(MenderTesting):
         built-in rootfs-image type."""
 
         def make_artifact(artifact_file, artifact_id):
-            cmd = ("mender-artifact write module-image "
-                   + "-o %s -n %s -t %s -T rootfs-image-v2 -f %s"
-                   % (artifact_file, artifact_id, conftest.machine_name, conftest.get_valid_image()))
+            cmd = (
+                "mender-artifact write module-image "
+                + "-o %s -n %s -t %s -T rootfs-image-v2 -f %s"
+                % (
+                    artifact_file,
+                    artifact_id,
+                    conftest.machine_name,
+                    conftest.get_valid_image(),
+                )
+            )
             logger.info("Executing: " + cmd)
             subprocess.check_call(cmd, shell=True)
             return artifact_file

--- a/testutils/api/client.py
+++ b/testutils/api/client.py
@@ -15,35 +15,58 @@ import os.path
 
 import requests
 
-GATEWAY_URL='https://mender-api-gateway'
+GATEWAY_URL = "https://mender-api-gateway"
+
 
 class ApiClient:
     def __init__(self, base_url=GATEWAY_URL):
         self.base_url = base_url
 
         # default content type should be ok for 99% of requests
-        self.headers = {'Content-Type': 'application/json'}
+        self.headers = {"Content-Type": "application/json"}
 
     def with_auth(self, token):
-        return self.with_header('Authorization', 'Bearer ' + token)
+        return self.with_header("Authorization", "Bearer " + token)
 
     def with_header(self, hdr, val):
-        self.headers[hdr]=val
+        self.headers[hdr] = val
         return self
 
-    def call(self, method, url, body=None, data=None, path_params={}, qs_params={}, headers={}, auth=None, files=None):
+    def call(
+        self,
+        method,
+        url,
+        body=None,
+        data=None,
+        path_params={},
+        qs_params={},
+        headers={},
+        auth=None,
+        files=None,
+    ):
         url = self.__make_url(url)
         url = self.__subst_path_params(url, path_params)
-        return requests.request(method, url, json=body, data=data, params=qs_params, headers=self.__make_headers(headers), auth=auth, verify=False, files=files)
+        return requests.request(
+            method,
+            url,
+            json=body,
+            data=data,
+            params=qs_params,
+            headers=self.__make_headers(headers),
+            auth=auth,
+            verify=False,
+            files=files,
+        )
 
     def post(self, url, path_params={}, body=None, data=None):
         url = self.__make_url(url)
         url = self.__subst_path_params(url, path_params)
-        return requests.request('POST', url, json=body, data=data)
+        return requests.request("POST", url, json=body, data=data)
 
     def __make_url(self, path):
-        return os.path.join(self.base_url,
-                            path if not path.startswith("/") else path[1:])
+        return os.path.join(
+            self.base_url, path if not path.startswith("/") else path[1:]
+        )
 
     def __subst_path_params(self, url, path_params):
         return url.format(**path_params)

--- a/testutils/api/deployments.py
+++ b/testutils/api/deployments.py
@@ -13,15 +13,15 @@
 #    limitations under the License.
 import testutils.api.client
 
-URL_MGMT = testutils.api.client.GATEWAY_URL + '/api/management/v1/deployments'
-URL_DEVICES = testutils.api.client.GATEWAY_URL + '/api/devices/v1/deployments'
+URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v1/deployments"
+URL_DEVICES = testutils.api.client.GATEWAY_URL + "/api/devices/v1/deployments"
 
-URL_NEXT   = '/device/deployments/next'
-URL_LOG    = '/device/deployments/{id}/log'
-URL_STATUS = '/device/deployments/{id}/status'
-URL_DEPLOYMENTS           = '/deployments'
-URL_DEPLOYMENTS_ID        = '/deployments/{id}'
-URL_DEPLOYMENTS_DEVICES   = '/deployments/{id}/devices'
-URL_DEPLOYMENTS_ARTIFACTS = '/artifacts'
-URL_DEPLOYMENTS_ARTIFACTS_GET = '/artifacts/{id}'
-URL_DEPLOYMENTS_ARTIFACTS_GENERATE = '/artifacts/generate'
+URL_NEXT = "/device/deployments/next"
+URL_LOG = "/device/deployments/{id}/log"
+URL_STATUS = "/device/deployments/{id}/status"
+URL_DEPLOYMENTS = "/deployments"
+URL_DEPLOYMENTS_ID = "/deployments/{id}"
+URL_DEPLOYMENTS_DEVICES = "/deployments/{id}/devices"
+URL_DEPLOYMENTS_ARTIFACTS = "/artifacts"
+URL_DEPLOYMENTS_ARTIFACTS_GET = "/artifacts/{id}"
+URL_DEPLOYMENTS_ARTIFACTS_GENERATE = "/artifacts/generate"

--- a/testutils/api/deviceauth.py
+++ b/testutils/api/deviceauth.py
@@ -16,17 +16,18 @@ import json
 import testutils.api.client
 import testutils.util.crypto
 
-URL_DEVICES = testutils.api.client.GATEWAY_URL + '/api/devices/v1/authentication'
-URL_INTERNAL = 'http://mender-device-auth:8080/api/internal/v1/devauth'
+URL_DEVICES = testutils.api.client.GATEWAY_URL + "/api/devices/v1/authentication"
+URL_INTERNAL = "http://mender-device-auth:8080/api/internal/v1/devauth"
 
-URL_AUTH_REQS = '/auth_requests'
-URL_LIMITS_MAX_DEVICES = '/tenant/{tid}/limits/max_devices'
+URL_AUTH_REQS = "/auth_requests"
+URL_LIMITS_MAX_DEVICES = "/tenant/{tid}/limits/max_devices"
 
-def auth_req(id_data, pubkey, privkey, tenant_token=''):
+
+def auth_req(id_data, pubkey, privkey, tenant_token=""):
     payload = {
         "id_data": json.dumps(id_data),
         "tenant_token": tenant_token,
         "pubkey": pubkey,
     }
     signature = testutils.util.crypto.rsa_sign_data(json.dumps(payload), privkey)
-    return payload, {'X-MEN-Signature': signature}
+    return payload, {"X-MEN-Signature": signature}

--- a/testutils/api/deviceauth_v2.py
+++ b/testutils/api/deviceauth_v2.py
@@ -13,22 +13,21 @@
 #    limitations under the License.
 import testutils.api.client
 
-URL_MGMT = testutils.api.client.GATEWAY_URL + '/api/management/v2/devauth'
+URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v2/devauth"
 
-URL_AUTHSET_STATUS = '/devices/{did}/auth/{aid}/status'
-URL_AUTHSET = '/devices/{did}/auth/{aid}'
+URL_AUTHSET_STATUS = "/devices/{did}/auth/{aid}/status"
+URL_AUTHSET = "/devices/{did}/auth/{aid}"
 
-URL_DEVICES = '/devices'
-URL_DEVICE = '/devices/{id}'
-URL_AUTHSET_STATUS  = '/devices/{did}/auth/{aid}/status'
-URL_DEVICES_COUNT = '/devices/count'
-URL_LIMITS_MAX_DEVICES = '/limits/max_devices'
+URL_DEVICES = "/devices"
+URL_DEVICE = "/devices/{id}"
+URL_AUTHSET_STATUS = "/devices/{did}/auth/{aid}/status"
+URL_DEVICES_COUNT = "/devices/count"
+URL_LIMITS_MAX_DEVICES = "/limits/max_devices"
+
 
 def preauth_req(id_data, pubkey):
-    return {
-        "identity_data": id_data,
-        "pubkey": pubkey
-    }
+    return {"identity_data": id_data, "pubkey": pubkey}
+
 
 def req_status(status):
-    return {'status': status}
+    return {"status": status}

--- a/testutils/api/inventory.py
+++ b/testutils/api/inventory.py
@@ -13,10 +13,10 @@
 #    limitations under the License.
 import testutils.api.client
 
-URL_MGMT = testutils.api.client.GATEWAY_URL + '/api/management/v1/inventory'
-URL_DEV = testutils.api.client.GATEWAY_URL + '/api/devices/v1/inventory'
+URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v1/inventory"
+URL_DEV = testutils.api.client.GATEWAY_URL + "/api/devices/v1/inventory"
 
-URL_DEVICE = '/devices/{id}'
-URL_DEVICES = '/devices'
+URL_DEVICE = "/devices/{id}"
+URL_DEVICES = "/devices"
 
-URL_DEVICE_ATTRIBUTES = '/device/attributes'
+URL_DEVICE_ATTRIBUTES = "/device/attributes"

--- a/testutils/api/tenantadm.py
+++ b/testutils/api/tenantadm.py
@@ -12,14 +12,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-URL = 'http://mender-tenantadm:8080/api'
-URL_INTERNAL = URL + '/internal/v1/tenantadm'
-URL_MGMT = URL + '/management/v1/tenantadm'
+URL = "http://mender-tenantadm:8080/api"
+URL_INTERNAL = URL + "/internal/v1/tenantadm"
+URL_MGMT = URL + "/management/v1/tenantadm"
 
-URL_INTERNAL_SUSPEND = '/tenants/{tid}/status'
-URL_INTERNAL_TENANTS = '/tenants'
-URL_MGMT_TENANTS = '/tenants'
-URL_MGMT_THIS_TENANT = '/user/tenant'
+URL_INTERNAL_SUSPEND = "/tenants/{tid}/status"
+URL_INTERNAL_TENANTS = "/tenants"
+URL_MGMT_TENANTS = "/tenants"
+URL_MGMT_THIS_TENANT = "/user/tenant"
+
 
 def req_status(status):
-    return {'status': status}
+    return {"status": status}

--- a/testutils/api/tenantadm_v2.py
+++ b/testutils/api/tenantadm_v2.py
@@ -12,9 +12,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-URL = 'http://mender-tenantadm:8080/api'
-URL_MGMT = URL + '/management/v2/tenantadm'
+URL = "http://mender-tenantadm:8080/api"
+URL_MGMT = URL + "/management/v2/tenantadm"
 
-URL_CREATE_ORG_TENANT = '/tenants'
-URL_TENANT_STATUS = '/tenants/{id}/status'
-URL_TENANT_SECRET = '/secret'
+URL_CREATE_ORG_TENANT = "/tenants"
+URL_TENANT_STATUS = "/tenants/{id}/status"
+URL_TENANT_SECRET = "/secret"

--- a/testutils/api/useradm.py
+++ b/testutils/api/useradm.py
@@ -14,11 +14,11 @@
 
 import testutils.api.client
 
-URL_MGMT = testutils.api.client.GATEWAY_URL + '/api/management/v1/useradm'
+URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v1/useradm"
 
-URL_LOGIN = '/auth/login'
-URL_SETTINGS = '/settings'
-URL_2FAQR = '/2faqr'
-URL_2FAVERIFY = '/2faverify'
-URL_USERS = '/users'
-URL_USERS_ID = '/users/{id}'
+URL_LOGIN = "/auth/login"
+URL_SETTINGS = "/settings"
+URL_2FAQR = "/2faqr"
+URL_2FAVERIFY = "/2faverify"
+URL_USERS = "/users"
+URL_USERS_ID = "/users/{id}"

--- a/testutils/infra/container_manager/base.py
+++ b/testutils/infra/container_manager/base.py
@@ -15,6 +15,7 @@
 
 import random
 
+
 class BaseContainerManagerNamespace:
     """Base class to define a containers namespace
     """

--- a/testutils/infra/container_manager/docker_manager.py
+++ b/testutils/infra/container_manager/docker_manager.py
@@ -15,8 +15,8 @@ import subprocess
 
 from .base import BaseContainerManagerNamespace
 
-class DockerNamespace(BaseContainerManagerNamespace):
 
+class DockerNamespace(BaseContainerManagerNamespace):
     def __init__(self, name):
         BaseContainerManagerNamespace.__init__(self, name)
 
@@ -27,23 +27,25 @@ class DockerNamespace(BaseContainerManagerNamespace):
         pass
 
     def execute(self, container_id, cmd):
-        cmd = ['docker', 'exec', '{}'.format(container_id)] + cmd
-        ret = subprocess.check_output(cmd).decode('utf-8').strip()
+        cmd = ["docker", "exec", "{}".format(container_id)] + cmd
+        ret = subprocess.check_output(cmd).decode("utf-8").strip()
         return ret
 
     def cmd(self, container_id, docker_cmd, cmd=[]):
-        cmd = ['docker', docker_cmd] + [str(container_id)] + cmd
-        ret = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        return ret.stdout.decode('utf-8').strip()
+        cmd = ["docker", docker_cmd] + [str(container_id)] + cmd
+        ret = subprocess.run(
+            cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        return ret.stdout.decode("utf-8").strip()
 
     def getid(self, filters):
         filters.append(self.name)
         filters = ["grep {}".format(f) for f in filters]
-        cmd = "docker ps | " + " | ".join(filters)  + " | awk '{print $1}'"
+        cmd = "docker ps | " + " | ".join(filters) + " | awk '{print $1}'"
 
-        ret = subprocess.check_output(cmd, shell=True).decode('utf-8').strip()
+        ret = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
 
-        if ret == '':
-            raise RuntimeError('container id for {} not found'.format(str(filters)))
+        if ret == "":
+            raise RuntimeError("container id for {} not found".format(str(filters)))
 
         return ret

--- a/testutils/infra/container_manager/factory.py
+++ b/testutils/infra/container_manager/factory.py
@@ -24,6 +24,7 @@ from .docker_compose_manager import DockerComposeEnterpriseSetup
 from .docker_compose_manager import DockerComposeEnterpriseSMTPSetup
 from .docker_compose_manager import DockerComposeCustomSetup
 
+
 class ContainerManagerFactory:
     def getStandardSetup(self, name=None, num_clients=1):
         """Standard setup consisting on all core backend services and optionally clients
@@ -76,27 +77,38 @@ class ContainerManagerFactory:
         """
         pass
 
+
 class DockerComposeManagerFactory(ContainerManagerFactory):
     def getStandardSetup(self, name=None, num_clients=1):
         return DockerComposeStandardSetup(name, num_clients)
+
     def getDockerClientSetup(self, name=None):
         return DockerComposeDockerClientSetup(name)
+
     def getRofsClientSetup(self, name=None):
         return DockerComposeRofsClientSetup(name)
+
     def getLegacyClientSetup(self, name=None):
         return DockerComposeLegacyClientSetup(name)
+
     def getSignedArtifactClientSetup(self, name=None):
         return DockerComposeSignedArtifactClientSetup(name)
+
     def getShortLivedTokenSetup(self, name=None):
         return DockerComposeShortLivedTokenSetup(name)
+
     def getFailoverServerSetup(self, name=None):
         return DockerComposeFailoverServerSetup(name)
+
     def getEnterpriseSetup(self, name=None, num_clients=0):
         return DockerComposeEnterpriseSetup(name, num_clients)
+
     def getEnterpriseSMTPSetup(self, name=None):
         return DockerComposeEnterpriseSMTPSetup(name)
+
     def getCustomSetup(self, name=None):
         return DockerComposeCustomSetup(name)
+
 
 def get_factory(manager_id="docker-compose"):
     if manager_id == "docker-compose":

--- a/testutils/infra/mongo.py
+++ b/testutils/infra/mongo.py
@@ -14,12 +14,13 @@
 
 from pymongo import MongoClient as PyMongoClient
 
+
 class MongoClient:
     def __init__(self, addr="mender-mongo:27017"):
         self.client = PyMongoClient(addr)
 
     def cleanup(self):
         dbs = self.client.list_database_names()
-        dbs = [d for d in dbs if d not in ['local', 'admin', 'config', 'workflows']]
+        dbs = [d for d in dbs if d not in ["local", "admin", "config", "workflows"]]
         for d in dbs:
             self.client.drop_database(d)

--- a/testutils/infra/smtpd_mock.py
+++ b/testutils/infra/smtpd_mock.py
@@ -15,16 +15,16 @@
 
 import smtpd
 
-class Message():
 
+class Message:
     def __init__(self, peer, mailfrom, rcpttos, data):
         self.peer = peer
         self.mailfrom = mailfrom
         self.rcpttos = rcpttos
         self.data = data
 
-class SMTPServerMock(smtpd.SMTPServer):
 
+class SMTPServerMock(smtpd.SMTPServer):
     def __init__(self, *args, **kwargs):
         self.messages = []
         smtpd.SMTPServer.__init__(self, *args, **kwargs)

--- a/testutils/util/crypto.py
+++ b/testutils/util/crypto.py
@@ -13,13 +13,14 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 from base64 import b64encode
-from cryptography.hazmat.backends   import default_backend
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric import padding
 
-def rsa_compare_keys(a,b):
+
+def rsa_compare_keys(a, b):
     """
     Compares the base64 encoded DER structure of the keys
     """
@@ -29,17 +30,16 @@ def rsa_compare_keys(a,b):
     b_b64 = "".join(list(filter(None, b.splitlines()))[1:-1])
     return a_b64 == b_b64
 
+
 def rsa_get_keypair():
     private_key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=1024,
-        backend=default_backend()
+        public_exponent=65537, key_size=1024, backend=default_backend()
     )
     public_key = private_key.public_key()
     private_pem = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption()
+        encryption_algorithm=serialization.NoEncryption(),
     )
     public_pem = public_key.public_bytes(
         encoding=serialization.Encoding.PEM,
@@ -47,15 +47,16 @@ def rsa_get_keypair():
     )
     return private_pem.decode(), public_pem.decode()
 
+
 def rsa_sign_data(data, private_key):
     _private_key = serialization.load_pem_private_key(
         private_key if isinstance(private_key, bytes) else private_key.encode(),
         password=None,
-        backend=default_backend()
+        backend=default_backend(),
     )
     signature = _private_key.sign(
         data if isinstance(data, bytes) else data.encode(),
         padding.PKCS1v15(),
-        hashes.SHA256()
+        hashes.SHA256(),
     )
     return b64encode(signature).decode()


### PR DESCRIPTION
Format all integration and testutils Python code with black formatter and start enforcing it in the CI Pipeline.

Even though it is still running with Python 2, it should be okey to
use Python 3 style.