### PR TITLE
Fix robustness of test_large_update_image

### DIFF
--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -61,7 +61,12 @@ class TestFailures(MenderTesting):
 
         host_ip = standard_setup_one_client_bootstrapped.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot:
-            deployment_id, _ = common_update_procedure(install_image="large_image.dat")
+            deployment_id, _ = common_update_procedure(
+                install_image="large_image.dat",
+                # We use verify_status=False because the device is very quick in reporting
+                # failure and the test framework might miss the 'inprogress' status transition.
+                verify_status=False,
+            )
             deploy.check_expected_statistics(deployment_id, "failure", 1)
             reboot.verify_reboot_not_performed()
             deploy.check_expected_status("finished", deployment_id)


### PR DESCRIPTION
This test has now failed 3 times in the last 7 nightly builds due to the
framework missing this short transition into "inprogress".

Why the device is now faster that it used to be is unknown. But the
change improves robustness of the test regardless.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>