### PR TITLE
Misc follow ups on integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,14 +131,15 @@ def pytest_exception_interact(node, call, report):
         else:
             try:
                 logger.info("Printing client deployment log, if possible:")
-                output = device.run("cat /data/mender/deployment*.log || true")
+                output = device.run("cat /data/mender/deployment*.log || true", wait=60)
                 logger.info(output)
             except:
                 logger.info("Not able to print client deployment log")
             try:
                 logger.info("Printing client systemd log, if possible:")
                 output = device.run(
-                    "journalctl -u %s || true" % device.get_client_service_name()
+                    "journalctl -u %s || true" % device.get_client_service_name(),
+                    wait=60,
                 )
                 logger.info(output)
             except:

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -9,3 +9,6 @@ addopts = --capture=no
 # known location to speed up test collection and to avoid picking up undesired
 # tests by accident.
 testpaths = tests
+#
+# Use v1 of xunit format (default will change in pytest 6.0)
+junit_family=xunit1

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -145,7 +145,7 @@ class TestBasicIntegration(MenderTesting):
 
         # Give the image a really large wait interval.
         sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % (
-            "\(.*PollInter.*:\)\( *[0-9]*\)",
+            r"\(.*PollInter.*:\)\( *[0-9]*\)",
             "\\1 1800",
         )
         mender_device.run(sedcmd)
@@ -195,7 +195,7 @@ class TestBasicIntegration(MenderTesting):
 
         # Give the image a really large wait interval.
         sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % (
-            "\(.*PollInter.*:\)\( *[0-9]*\)",
+            r"\(.*PollInter.*:\)\( *[0-9]*\)",
             "\\1 1800",
         )
         mender_device.run(sedcmd)

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -79,9 +79,6 @@ class TestDeploymentAborting(MenderTesting):
             standard_setup_one_client_bootstrapped, valid_image
         )
 
-    # Because the install step is over almost instantly, this test is very
-    # fragile, it breaks at the slightest timing issue: MEN-1364
-    @pytest.mark.skip
     @MenderTesting.fast
     def test_deployment_abortion_downloading(
         self, standard_setup_one_client_bootstrapped, valid_image

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -97,24 +97,3 @@ class TestDeploymentAborting(MenderTesting):
             "rebooting",
             mender_performs_reboot=True,
         )
-
-    @MenderTesting.slow
-    def test_deployment_abortion_success(
-        self, standard_setup_one_client_bootstrapped, valid_image
-    ):
-        # maybe an acceptance test is enough for this check?
-
-        mender_device = standard_setup_one_client_bootstrapped.device
-
-        host_ip = standard_setup_one_client_bootstrapped.get_virtual_network_host_ip()
-        with mender_device.get_reboot_detector(host_ip) as reboot:
-            deployment_id, _ = common_update_procedure(valid_image)
-
-            reboot.verify_reboot_performed()
-
-        deploy.check_expected_statistics(deployment_id, "success", 1)
-        time.sleep(5)
-
-        deploy.abort_finished_deployment(deployment_id)
-        deploy.check_expected_statistics(deployment_id, "success", 1)
-        deploy.check_expected_status("finished", deployment_id)

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -44,7 +44,7 @@ class TestFaultTolerance(MenderTesting):
         try:
             for h in hosts:
                 gateway_ip = device.run(
-                    "nslookup %s | grep -A1 'Name:' | egrep '^Address( 1)?:'  | grep -oE '((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])'"
+                    r"nslookup %s | grep -A1 'Name:' | egrep '^Address( 1)?:'  | grep -oE '((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])'"
                     % (h),
                     hide=True,
                 ).strip()

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -66,7 +66,7 @@ class TestFaultTolerance(MenderTesting):
                         "iptables -I OUTPUT 1 -s %s -j DROP" % gateway_ip, hide=True
                     )
         except Exception as e:
-            logger.info("Exception while messing with network connectivity: " + e)
+            logger.info("Exception while messing with network connectivity: %s", str(e))
 
     @staticmethod
     def wait_for_download_retry_attempts(device, search_string):

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -109,14 +109,9 @@ class DockerComposeNamespace(DockerNamespace):
         for count in range(1, 6):
             with docker_lock:
                 try:
-                    output = subprocess.check_output(
+                    return subprocess.check_output(
                         cmd, stderr=subprocess.STDOUT, shell=True, env=penv
-                    )
-
-                    # Return as string (Python 2/3 compatible)
-                    if isinstance(output, bytes):
-                        return output.decode("utf-8")
-                    return output
+                    ).decode("utf-8")
 
                 except subprocess.CalledProcessError as e:
                     logger.info(
@@ -128,10 +123,7 @@ class DockerComposeNamespace(DockerNamespace):
                 logger.info("sleeping %d seconds and retrying" % (count * 30))
                 time.sleep(count * 30)
 
-        raise Exception(
-            "failed to start docker-compose (called: %s): exit code: %d, output: %s"
-            % (e.cmd, e.returncode, e.output)
-        )
+        raise Exception("failed to start docker-compose (called: %s)" % cmd)
 
     def _wait_for_containers(self, expected_containers):
         files_args = "".join([" -f %s" % file for file in self.docker_compose_files])
@@ -231,10 +223,7 @@ class DockerComposeNamespace(DockerNamespace):
             shell=True,
         )
 
-        # Return as list of strings (Python 2/3 compatible)
-        if isinstance(output, bytes):
-            return output.decode().split()
-        return output.split()
+        return output.decode().split()
 
     def get_logs_of_service(self, service):
         """Return logs of service"""
@@ -250,10 +239,7 @@ class DockerComposeNamespace(DockerNamespace):
             "docker inspect --format='{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}'",
             shell=True,
         )
-        # Return as string (Python 2/3 compatible)
-        if isinstance(output, bytes):
-            return output.decode().split()[0]
-        return output.split()[0]
+        return output.decode().split()[0]
 
     def get_mender_clients(self):
         """Returns IP address(es) of mender-client cotainer(s)"""
@@ -266,10 +252,7 @@ class DockerComposeNamespace(DockerNamespace):
             % (self.name, image_name)
         )
         output = subprocess.check_output(cmd, shell=True)
-        # Return as string (Python 2/3 compatible)
-        if isinstance(output, bytes):
-            return output.decode().strip() + ":8822"
-        return output.strip() + ":8822"
+        return output.decode().strip() + ":8822"
 
     def get_mender_gateway(self):
         """Returns IP address of mender-api-gateway service"""

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -351,11 +351,11 @@ def _run(conn, cmd, **kw):
             result = conn.run(cmd, **kw)
             break
         except NoValidConnectionsError as e:
-            logger.info("Could not connect to host %s: %s", conn.host, e)
+            logger.info("Could not connect to host %s: %s", conn.host, str(e))
             continue
         except SSHException as e:
             logger.info(
-                "Got SSH exception while connecting to host %s: %s", conn.host, e
+                "Got SSH exception while connecting to host %s: %s", conn.host, str(e)
             )
             if not (
                 "Connection reset by peer" in str(e)
@@ -367,7 +367,9 @@ def _run(conn, cmd, **kw):
         except OSError as e:
             # The OSError is happening while there is no QEMU instance initialized
             logger.info(
-                "Got OSError exception while connecting to host %s: %s", conn.host, e
+                "Got OSError exception while connecting to host %s: %s",
+                conn.host,
+                str(e),
             )
             if not "Cannot assign requested address" in str(e):
                 raise e
@@ -378,17 +380,13 @@ def _run(conn, cmd, **kw):
             logger.info(
                 "Got UnexpectedExit while executing command in host %s: %s",
                 conn.host,
-                e,
+                str(e),
             )
             continue
         except Exception as e:
-            logger.error(
-                "Generic exception happened while connecting to host %s: %s",
-                conn.host,
-                e,
+            logger.exception(
+                "Generic exception happened while connecting to host %s", conn.host,
             )
-            logger.error(type(e))
-            logger.error(e.args)
             raise e
     else:
         raise RuntimeError(

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -326,12 +326,17 @@ def _put(device, file, local_path=".", remote_path="."):
     )
 
 
+# Roughly the execution time of the slowest test (*) times 3
+# (*) As per 2020-03-24 test_image_download_retry_hosts_broken takes 515.13 seconds
+_DEFAULT_WAIT_TIME = 25 * 60
+
+
 def _run(conn, cmd, **kw):
     if kw.get("wait") is not None:
         wait = kw["wait"]
         del kw["wait"]
     else:
-        wait = 60 * 60
+        wait = _DEFAULT_WAIT_TIME
 
     result = None
     start_time = time.time()


### PR DESCRIPTION
* Clear DeprecationWarning(s)
From pytest warning about the xunit family version and from Python on
suspicious non-escaped characters.

* Re-enable test_deployment_abortion_downloading
The comment doesn't seem to match the actual code (the deployment is
aborted in "download" and not in "install", and the JIRA ticket also
seems to refer to another test (using "install").
Furthermore, the test seems to pass with no issues locally.

* Remove test_deployment_abortion_success
This test has nothing to do with "aborting" the deployment, it just
performs a regular update.
The simple regular updates are tested extensively in many other tests
(which on top of that test something else) so removing this one just to
save exec time.

* Set default SSH wait time to 25 minutes
The previous wait time of 1h comes from non optimal performance running
on DO in the past. Adjusting it to 3 times the slowest test as per
today.

* Limit the device wait in pytest failure hook to 1 minute
After a test that has failed due to an unresponsive device, we don't
want to keep waiting here twice the default time for possible debug
data.
