### PR TITLE
tests: Take into account multiple mender.service names.

### DIFF
--- a/tests/tests/test_00_multi_tenancy.py
+++ b/tests/tests/test_00_multi_tenancy.py
@@ -42,8 +42,10 @@ class TestMultiTenancyEnterprise(MenderTesting):
         mender_device = MenderDevice(enterprise_no_client.get_mender_clients()[0])
 
         mender_device.ssh_is_opened()
+        client_service_name = mender_device.get_client_service_name()
         mender_device.run(
-            'journalctl -u mender-client | grep "authentication request rejected server error message: Unauthorized"',
+            'journalctl -u %s | grep "authentication request rejected server error message: Unauthorized"'
+            % client_service_name,
             wait=70,
         )
 
@@ -55,7 +57,7 @@ class TestMultiTenancyEnterprise(MenderTesting):
         mender_device.run(
             "sed -i 's/%s/%s/g' /etc/mender/mender.conf" % (wrong_token, token)
         )
-        mender_device.run("systemctl restart mender-client")
+        mender_device.run("systemctl restart %s" % client_service_name)
 
         auth_v2.get_devices(expected_devices=1)
 
@@ -242,6 +244,7 @@ class TestMultiTenancyEnterprise(MenderTesting):
                 )
             )
             mender_device.run(
-                'journalctl -u mender-client | grep "deployment aborted at the backend"',
+                'journalctl -u %s | grep "deployment aborted at the backend"'
+                % mender_device.get_client_service_name(),
                 wait=600,
             )

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -149,13 +149,14 @@ class TestBasicIntegration(MenderTesting):
             "\\1 1800",
         )
         mender_device.run(sedcmd)
-        mender_device.run("systemctl restart mender-client")
+        client_service_name = mender_device.get_client_service_name()
+        mender_device.run("systemctl restart %s" % client_service_name)
 
         def deployment_callback():
             logger.info("Running pre deployment callback function")
             wait_count = 0
             # Match the log template six times to make sure the client is truly sleeping.
-            catcmd = "journalctl -u mender-client --output=cat"
+            catcmd = "journalctl -u %s --output=cat" % client_service_name
             template = mender_device.run(catcmd)
             while True:
                 logger.info("sleeping...")
@@ -198,12 +199,13 @@ class TestBasicIntegration(MenderTesting):
             "\\1 1800",
         )
         mender_device.run(sedcmd)
-        mender_device.run("systemctl restart mender-client")
+        client_service_name = mender_device.get_client_service_name()
+        mender_device.run("systemctl restart %s" % client_service_name)
 
         logger.info("Running pre deployment callback function")
         wait_count = 0
         # Match the log template six times to make sure the client is truly sleeping.
-        catcmd = "journalctl -u mender-client --output=cat"
+        catcmd = "journalctl -u %s --output=cat" % client_service_name
         template = mender_device.run(catcmd)
         while True:
             logger.info("sleeping...")

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -99,7 +99,8 @@ class TestBootstrapping(MenderTesting):
 
         # Check from client side
         mender_device.run(
-            "journalctl -u mender-client -l -n 3 | grep -q 'authentication request rejected'"
+            "journalctl -u %s -l -n 3 | grep -q 'authentication request rejected'"
+            % mender_device.get_client_service_name()
         )
 
         # Check that we can accept again the device from the server

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -75,8 +75,8 @@ class TestFaultTolerance(MenderTesting):
 
         while int(time.time()) < timeout_time:
             output = device.run(
-                "journalctl -u mender-client -l --no-pager | grep 'msg=\".*%s' | wc -l"
-                % re.escape(search_string),
+                "journalctl -u %s -l --no-pager | grep 'msg=\".*%s' | wc -l"
+                % (device.get_client_service_name(), re.escape(search_string)),
                 hide=True,
             )
             time.sleep(2)

--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -199,7 +199,9 @@ class Client:
 
     @staticmethod
     def get_logs(device):
-        output_from_journalctl = device.run("journalctl -u mender-client -l")
+        output_from_journalctl = device.run(
+            "journalctl -u %s -l" % device.get_client_service_name()
+        )
         logger.info(output_from_journalctl)
 
     @staticmethod
@@ -233,7 +235,7 @@ class Client:
     def restart(device):
         """Restart the mender service."""
 
-        device.run("systemctl restart mender-client.service")
+        device.run("systemctl restart %s.service" % device.get_client_service_name())
 
     @staticmethod
     def have_authtoken(device):
@@ -246,7 +248,9 @@ class Client:
                 )
                 return out != ""
             except:
-                output_from_journalctl = device.run("journalctl -u mender-client -l")
+                output_from_journalctl = device.run(
+                    "journalctl -u %s -l" % device.get_client_service_name()
+                )
                 logger.info("Logs from client: " + output_from_journalctl)
 
                 time.sleep(10)

--- a/tests/tests/test_security.py
+++ b/tests/tests/test_security.py
@@ -96,7 +96,8 @@ class TestSecurity(MenderTesting):
 
         mender_device = standard_setup_with_short_lived_token.device
         mender_device.run(
-            'journalctl -u mender-client -l --no-pager | grep "received new authorization data"',
+            'journalctl -u %s -l --no-pager | grep "received new authorization data"'
+            % mender_device.get_client_service_name(),
             wait=60,
         )
 

--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -119,7 +119,7 @@ class TestUpdateModules(MenderTesting):
             assert output == "original"
 
             output = standard_setup_one_docker_client_bootstrapped.get_logs_of_service(
-                "mender-client"
+                mender_device.get_client_service_name()
             )
             assert (
                 "Artifact Payload type 'rootfs-image' is not supported by this Mender Client"

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -126,6 +126,8 @@ class MenderDevice:
     def get_reboot_detector(self, host_ip):
         return RebootDetector(self, host_ip)
 
+    def get_client_service_name(self):
+        return self.run("if test -e /lib/systemd/system/mender.service; then echo mender; else echo mender-client; fi").strip()
 
 class RebootDetector:
     # This global one is used to increment each port used.
@@ -271,6 +273,12 @@ class MenderDeviceGroup:
         """
         for dev in self._devices:
             dev.ssh_is_opened(wait)
+
+    def get_client_service_name(self):
+        # We assume that the service name is always the same across all devices,
+        # so it's enough to return the first one.
+        assert len(self._devices) > 0
+        return self._devices[0].get_client_service_name()
 
 
 def _ssh_prep_args(device):


### PR DESCRIPTION
Due to integration needing to be tested with meta-mender branches
warrior and older, we need to be prepared for the client being named
both "mender.service" (the old name), and "mender-client.service" (the
new name).

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>