### PR TITLE
backend-tests: provides/depends selection only available in "Enterprise"

### DIFF
--- a/backend-tests/docker/Dockerfile
+++ b/backend-tests/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y -qq update && apt-get -qq -y install \
 COPY requirements-py3.txt .
 
 RUN pip3 install -r requirements-py3.txt
-COPY mender-artifact /usr/local/bin/mender-artifact
+COPY ./downloaded-tools/mender-artifact /usr/local/bin/mender-artifact
 RUN chmod 755 /usr/local/bin/mender-artifact
 
 ENTRYPOINT ["bash", "/tests/run.sh"]

--- a/backend-tests/run
+++ b/backend-tests/run
@@ -30,6 +30,8 @@ PYTEST_REPORT_ENTERPRISE="--self-contained-html \
         --html=report_backend_integration_enterprise.html"
 PYTEST_REPORT=""
 
+TOOLS="$INTEGRATION_PATH/backend-tests/downloaded-tools"
+
 usage() {
     echo "runner script for backend-specific integration tests"
     echo ""
@@ -90,7 +92,22 @@ parse_args(){
 }
 
 build_backend_tests_runner() {
+    mkdir -p "$TOOLS"
+
+    get_runner_requirements
+
     docker build -t mender-backend-tests-runner -f $INTEGRATION_PATH/backend-tests/docker/Dockerfile $INTEGRATION_PATH/backend-tests
+}
+
+get_runner_requirements() {
+    MENDER_ARTIFACT_BRANCH=$($INTEGRATION_PATH/extra/release_tool.py --version-of mender-artifact)
+    echo "downloading mender-artifact/$MENDER_ARTIFACT_BRANCH"
+
+    curl --fail "https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/${MENDER_ARTIFACT_BRANCH}/linux/mender-artifact" \
+         -o "$TOOLS/mender-artifact" \
+         -z "$TOOLS/mender-artifact"
+
+    chmod +x "$TOOLS/mender-artifact"
 }
 
 run_tests() {

--- a/tests/MenderAPI/authentication.py
+++ b/tests/MenderAPI/authentication.py
@@ -56,16 +56,17 @@ class Authentication:
         self.multitenancy = Authentication.multitenancy
         self.current_tenant = Authentication.current_tenant
 
-    def set_tenant(self, org_name, username, password):
-        self.new_tenant(org_name, username, password)
+    def set_tenant(self, org_name, username, password, plan="os"):
+        self.new_tenant(org_name, username, password, plan)
 
-    def new_tenant(self, org_name, username, password):
+    def new_tenant(self, org_name, username, password, plan="os"):
         self.multitenancy = True
         self.reset_auth_token()
         self.org_name = org_name
         self.org_create = True
         self.username = username
         self.password = password
+        self.plan = plan
         self.get_auth_token()
 
     def get_auth_token(self, create_new_user=True):
@@ -85,7 +86,7 @@ class Authentication:
             if r.status_code is not 200:
                 if self.multitenancy and self.org_create:
                     tenant_id = self._create_org(
-                        self.org_name, self.username, self.password
+                        self.org_name, self.username, self.password, self.plan
                     )
                     tenant_id = tenant_id.strip()
 
@@ -138,10 +139,10 @@ class Authentication:
             self.auth_header = {"Authorization": "Bearer " + str(r.text)}
         return r
 
-    def _create_org(self, name, username, password):
+    def _create_org(self, name, username, password, plan="os"):
         namespace = get_container_manager().name
         cli = CliTenantadm(containers_namespace=namespace)
-        tenant_id = cli.create_org(name, username, password)
+        tenant_id = cli.create_org(name, username, password, plan)
         return tenant_id
 
     def _get_tenant_data(self, tenant_id):

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -98,6 +98,22 @@ function get_requirements() {
         exit 1
     fi
 
+    curl --fail "https://raw.githubusercontent.com/mendersoftware/mender/${MENDER_BRANCH}/support/modules-artifact-gen/directory-artifact-gen" \
+         -o downloaded-tools/directory-artifact-gen \
+         -z downloaded-tools/directory-artifact-gen
+    
+    if [ $? -ne 0 ]; then
+        echo "failed to download directory-artifact-gen"
+        exit 1
+    fi
+
+    chmod +x downloaded-tools/directory-artifact-gen
+
+    if [ $? -ne 0 ]; then
+        echo "failed to download directory-artifact-gen"
+        exit 1
+    fi
+
     export PATH=$PWD/downloaded-tools:$PATH
 
     inject_pre_generated_ssh_keys

--- a/tests/tests/test_provides_depends.py
+++ b/tests/tests/test_provides_depends.py
@@ -34,7 +34,7 @@ class TestProvidesDependsEnterprise(MenderTesting):
 
         # Create tenant user
         auth.reset_auth_token()
-        auth.new_tenant("admin", "bob@builder.org", "secret-service")
+        auth.new_tenant("admin", "bob@builder.org", "secret-service", "enterprise")
         token = auth.current_tenant["tenant_token"]
 
         # Create client setup with tenant token


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-3312

extending an existing case to prove "os" and "professional" plans will not get the provides/depends selection.

actually, the first 2 commits are bugfixes (missing tools - only provided by mender-qa).

https://gitlab.com/Northern.tech/Mender/mender-qa/pipelines/133235225

(adding @lluiscampos for a look over the first 2 commits)