### PR TITLE
Misc test fixes and optimization.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,9 @@ def pytest_exception_interact(node, call, report):
                 logger.info("Not able to print client deployment log")
             try:
                 logger.info("Printing client systemd log, if possible:")
-                output = device.run("journalctl -u mender-client || true")
+                output = device.run(
+                    "journalctl -u %s || true" % device.get_client_service_name()
+                )
                 logger.info(output)
             except:
                 logger.info("Not able to print client systemd log")

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -28,7 +28,8 @@ from ..MenderAPI import deploy, logger
 from .mendertesting import MenderTesting
 
 DOWNLOAD_RETRY_TIMEOUT_TEST_SETS = [
-    {"blockAfterStart": False, "logMessageToLookFor": "Update fetch failed:",},
+    # We use "pdate" to be able to match "Update" (2.4.x) and "update" (2.3.x and earlier)
+    {"blockAfterStart": False, "logMessageToLookFor": "pdate fetch failed:",},
     {"blockAfterStart": True, "logMessageToLookFor": "Download connection broken:",},
 ]
 
@@ -227,8 +228,9 @@ class TestFaultTolerance(MenderTesting):
         with mender_device.get_reboot_detector(host_ip) as reboot:
             deployment_id, new_yocto_id = common_update_procedure(valid_image)
 
+            # We use "pdate" to be able to match "Update" (2.4.x) and "update" (2.3.x and earlier)
             TestFaultTolerance.wait_for_download_retry_attempts(
-                mender_device, "Update fetch failed"
+                mender_device, "pdate fetch failed",
             )
             mender_device.run("sed -i.bak '/1.1.1.1/d' /etc/hosts")
 

--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -119,7 +119,7 @@ class TestUpdateModules(MenderTesting):
             assert output == "original"
 
             output = standard_setup_one_docker_client_bootstrapped.get_logs_of_service(
-                mender_device.get_client_service_name()
+                "mender-client"
             )
             assert (
                 "Artifact Payload type 'rootfs-image' is not supported by this Mender Client"

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -60,6 +60,7 @@ class MenderDevice:
             connect_kwargs={"password": "", "banner_timeout": 60, "auth_timeout": 60},
         )
         self._conn.client.set_missing_host_key_policy(IgnorePolicy())
+        self._service_name = None
 
     @property
     def host_string(self):
@@ -127,9 +128,11 @@ class MenderDevice:
         return RebootDetector(self, host_ip)
 
     def get_client_service_name(self):
-        return self.run(
-            "if test -e /lib/systemd/system/mender.service; then echo mender; else echo mender-client; fi"
-        ).strip()
+        if self._service_name is None:
+            self._service_name = self.run(
+                "if test -e /lib/systemd/system/mender.service; then echo mender; else echo mender-client; fi"
+            ).strip()
+        return self._service_name
 
 
 class RebootDetector:


### PR DESCRIPTION
See individual commits.

With regards to 3d4cc2a, we usually don't do this as we branch out `integration` repo to follow the release branches.

@kacf @oleorhagen You can argue that is not really necessary and we can live with these two tests failing. Generally speaking: is is a good idea to have known tests failing in staging or should be do these kind of fixes when we find problems?