### PR TITLE
[release tool] Support branch integrations using tags for -g option

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -428,7 +428,12 @@ def version_of(integration_dir, yml_component, in_integration_version=None):
             # If the repository didn't exist in that version, just return all
             # commits in that case, IOW no lower end point range.
             if data.get(yml_component.yml()) is not None:
-                repo_range.append(remote + data[yml_component.yml()]['version'])
+                version = data[yml_component.yml()]['version']
+                # If it is a tag, do not prepend remote name
+                if re.search(r"^[0-9]+\.[0-9]+\.[0-9]+$", version):
+                    repo_range.append(version)
+                else:
+                    repo_range.append(remote + version)
         return range_type.join(repo_range)
     else:
         data = get_docker_compose_data(integration_dir)


### PR DESCRIPTION
Some integration branch (i.e. staging) will be using tags for some of
its components (in staging branch, mender or mender-artifact).

Before this change --version-of would be prepending the remote if the
input had a remote; now it will avoid prepending the remote to a tag,
which was resulting in invalid git syntax for a revision.