### PR TITLE
[integration tests] Cleanup update_image and related tests

### DIFF
--- a/tests/tests/test_00_multi_tenancy.py
+++ b/tests/tests/test_00_multi_tenancy.py
@@ -17,7 +17,7 @@ import time
 
 from .. import conftest
 from ..common_setup import enterprise_no_client
-from .common_update import update_image, update_image_failed, common_update_procedure
+from .common_update import update_image, common_update_procedure
 from ..MenderAPI import auth, auth_v2, deploy, image, logger, inv
 from .mendertesting import MenderTesting
 from . import artifact_lock
@@ -174,14 +174,12 @@ class TestMultiTenancyEnterprise(MenderTesting):
                 "password": "hunter2hunter2",
                 "username": "foo2",
                 "container": "mender-client-deployment-1",
-                "fail": False,
             },
             {
                 "email": "bar2@bar2.com",
                 "password": "hunter2hunter2",
                 "username": "bar2",
                 "container": "mender-client-deployment-2",
-                "fail": True,
             },
         ]
 
@@ -202,15 +200,9 @@ class TestMultiTenancyEnterprise(MenderTesting):
                 )
             )
             host_ip = enterprise_no_client.get_virtual_network_host_ip()
-            if user["fail"]:
-                update_image_failed(mender_device, host_ip)
-            else:
-                update_image(
-                    mender_device,
-                    host_ip,
-                    install_image=valid_image,
-                    skip_reboot_verification=True,
-                )
+            update_image(
+                mender_device, host_ip, install_image=valid_image,
+            )
 
     def test_multi_tenancy_deployment_aborting(self, enterprise_no_client, valid_image):
         """ Simply make sure we are able to run the multi tenancy setup and

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -258,10 +258,6 @@ class TestFaultTolerance(MenderTesting):
 
         tmpdir = tempfile.mkdtemp()
         try:
-            orig_image = valid_image
-            image_name = os.path.join(tmpdir, os.path.basename(orig_image))
-            shutil.copyfile(orig_image, image_name)
-
             # With the persistent mender.conf in /data, and the transient
             # mender.conf in /etc, we can simply delete the former (rootfs
             # config) to break the config, and add it back into the transient
@@ -292,8 +288,8 @@ class TestFaultTolerance(MenderTesting):
             update_image_failed(
                 mender_device,
                 host_ip,
-                install_image=image_name,
                 expected_log_message="Unable to roll back with a stub module, but will try to reboot to restore state",
+                install_image=valid_image,
             )
 
         finally:


### PR DESCRIPTION
The main change is removing the wrongly used and misleading parameter
"skip_reboot_verification", which was only skipping a second check for
the device not reboot (?). The original intention of this is unknown.

Reorganized the parameters in update_image/update_image_fail to show
which ones are used by these and which are just passed downstream to
other helpers.

Simplified TestMultiTenancyEnterprise and optimize TestFaultTolerance.