### PR TITLE
Move dependency between deployments and storage-proxy to demo yaml

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -58,6 +58,8 @@ services:
             DEPLOYMENTS_AWS_AUTH_KEY: minio
             DEPLOYMENTS_AWS_AUTH_SECRET: minio123
             DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io:9000
+        depends_on:
+            - storage-proxy
 
     minio:
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
             - mender
         depends_on:
             - mender-mongo
-            - storage-proxy
 
     #
     # mender-gui


### PR DESCRIPTION
The docker-compose service mender-deployments depends on storage-proxy,
which is defined in docker-compose.demo.yml. This causes docker-compose
commands, as well as the logging command executed when the user presses
ENTER after running ./demo up, to fail with the following message:

ERROR: Service 'mender-deployments' depends on service 'storage-proxy'
which is undefined.

This commit moves the dependency on storage-proxy to the file where it
really belong to: docker-compose.demo.yml

Changelog: None

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>