### PR TITLE
Move the deployments' dependency on storage-proxy to the right file

### DIFF
--- a/demo
+++ b/demo
@@ -303,4 +303,10 @@ echo "Press Enter to show the logs."
 echo "Press Ctrl-C to stop the backend and quit."
 read -se
 
-docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME} logs --follow
+docker-compose \
+    -f docker-compose.yml \
+    -f docker-compose.storage.minio.yml \
+    -f docker-compose.demo.yml \
+    -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+    $CLIENT \
+    logs --follow

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -58,8 +58,6 @@ services:
             DEPLOYMENTS_AWS_AUTH_KEY: minio
             DEPLOYMENTS_AWS_AUTH_SECRET: minio123
             DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io:9000
-        depends_on:
-            - storage-proxy
 
     minio:
         networks:

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -27,3 +27,10 @@ services:
         depends_on:
             minio:
                 condition: service_healthy
+
+    #
+    # mender-deployments depends on storage-proxy if minio is in use
+    #
+    mender-deployments:
+        depends_on:
+            - storage-proxy


### PR DESCRIPTION
The deployments service depends on storage-proxy if minio is in use, thus it makes sense to move the dependency from the `docker-compose.demo.yml` to the `docker-compose.storage.minio.yml` file.

Additionally, improve demo script to include logs of all the components: include the docker-compose yaml files when running the logs command. Without them, the logs from minio, storage-proxy and client are missing.
