### PR TITLE
Update migration scripts (dump/migrate/restore)

### DIFF
--- a/migration/dump-db
+++ b/migration/dump-db
@@ -8,6 +8,9 @@ SERVICES="\
   mender-useradm \
   mender-device-auth \
   mender-deployments \
+  mender-create-artifact-worker \
+  mender-workflows-server \
+  mender-workflows-worker \
 "
 DB_SERVICES="\
   mender-mongo

--- a/migration/migrate-db
+++ b/migration/migrate-db
@@ -8,6 +8,9 @@ SERVICES="\
   mender-useradm \
   mender-device-auth \
   mender-deployments \
+  mender-create-artifact-worker \
+  mender-workflows-server \
+  mender-workflows-worker \
 "
 
 DB_SERVICES="\
@@ -15,6 +18,9 @@ DB_SERVICES="\
   mender-mongo-inventory \
   mender-mongo-device-auth \
   mender-mongo-deployments \
+  mender-create-artifact-worker \
+  mender-workflows-server \
+  mender-workflows-worker \
 "
 
 OLD_DB_VOLUMES="\
@@ -22,6 +28,9 @@ OLD_DB_VOLUMES="\
   mender-inventory-db \
   mender-deviceauth-db \
   mender-deployments-db \
+  mender-create-artifact-worker-db \
+  mender-workflows-server-db \
+  mender-workflows-worker-db \
 "
 
 

--- a/migration/migration-helper.yml
+++ b/migration/migration-helper.yml
@@ -5,7 +5,7 @@ services:
     # mongo migration helper service
     #
     mongo-helper:
-        image: mongo:3.4
+        image: mongo:3.6
         networks:
             - mender
         volumes:

--- a/migration/restore-db
+++ b/migration/restore-db
@@ -8,6 +8,9 @@ SERVICES="\
   mender-useradm \
   mender-device-auth \
   mender-deployments \
+  mender-create-artifact-worker \
+  mender-workflows-server \
+  mender-workflows-worker \
 "
 
 DB_SERVICES="\


### PR DESCRIPTION
The dump-db, migrate-db and restore-db in migration/ needs to be updated to reflect the new back-end components. Additionally, use mongodb 3.6 utilities to dump/restore mongo database.
