### PR TITLE
MEN-4366: New versioning scheme for backend Docker tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ include:
 stages:
   - test
 
-test:extra-tools:
+test:extra-tools:changelog-generator:
   image: "python:3"
   stage: test
 
@@ -25,3 +25,14 @@ test:extra-tools:
   script:
     # Check changelog-generator test.
     - ( cd extra/changelog-generator && ./test-changelog-generator )
+
+test:extra-tools:release-tool:
+  image: "python:3"
+  stage: test
+
+  before_script:
+    - pip install pytest pyyaml
+
+  script:
+    # Run release-tool unit tests.
+    - python3 -m pytest extra/test_release_tool.py

--- a/component-maps.yml
+++ b/component-maps.yml
@@ -41,6 +41,7 @@ git:
     docker_image: []
     docker_container: []
     release_component: true
+    independent_component: true
 
   inventory:
     docker_image:
@@ -64,6 +65,7 @@ git:
     docker_container:
     - mender-client
     release_component: true
+    independent_component: true
 
   mender-api-gateway-docker:
     docker_image:
@@ -76,11 +78,13 @@ git:
     docker_image: []
     docker_container: []
     release_component: true
+    independent_component: true
 
   mender-cli:
     docker_image: []
     docker_container: []
     release_component: true
+    independent_component: true
 
   mender-conductor:
     docker_image:

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -1768,16 +1768,19 @@ def set_docker_compose_version_to(dir, repo, tag, git_tag=None):
 
         if git_tag is not None:
             # Replace Git tag with a new one.
-            with open(filename) as fd:
-                full_content = "".join(fd.readlines())
-            with open(filename, "w") as fd:
-                fd.write(
-                    re.sub(
-                        r"(\s*%s:[\n\s]+git-version:\s+)(.*)" % re.escape(repo.git()),
-                        r"\g<1>%s" % git_tag,
-                        full_content,
+            assosiated_repos = repo.associated_components_of_type("git")
+            for assosiated_repo in assosiated_repos:
+                with open(filename) as fd:
+                    full_content = "".join(fd.readlines())
+                with open(filename, "w") as fd:
+                    fd.write(
+                        re.sub(
+                            r"(\s*%s:[\n\s]+git-version:\s+)(.*)"
+                            % re.escape(assosiated_repo.git()),
+                            r"\g<1>%s" % git_tag,
+                            full_content,
+                        )
                     )
-                )
 
 
 def purge_build_tags(state, tag_avail):
@@ -2477,7 +2480,9 @@ def do_set_version_to(args):
         sys.exit(1)
 
     repo = Component.get_component_of_any_type(args.set_version_of)
-    set_docker_compose_version_to(integration_dir(), repo, args.version)
+    set_docker_compose_version_to(
+        integration_dir(), repo, args.version, git_tag=args.version
+    )
 
 
 def is_marked_as_releaseable_in_integration_version(

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -154,16 +154,54 @@ def test_set_version_of(capsys):
         capsys, ["--version-of", "inventory", "--version-type", "git"], "master"
     )
 
-    # Once set to something, only the Docker version changes
+    # Using --set-version-of modifies both versions, regardless of using the repo name
     run_main_assert_result(
         capsys, ["--set-version-of", "inventory", "--version", "1.2.3-test"]
     )
-    run_main_assert_result(capsys, ["--version-of", "inventory"], "master")
+    run_main_assert_result(capsys, ["--version-of", "inventory"], "1.2.3-test")
     run_main_assert_result(
         capsys, ["--version-of", "inventory", "--version-type", "docker"], "1.2.3-test"
     )
     run_main_assert_result(
-        capsys, ["--version-of", "inventory", "--version-type", "git"], "master"
+        capsys, ["--version-of", "inventory", "--version-type", "git"], "1.2.3-test"
+    )
+
+    # or the container name. However, setting from the container name sets all repos (os + ent)
+    run_main_assert_result(
+        capsys, ["--set-version-of", "mender-deployments", "--version", "4.5.6-test"]
+    )
+    run_main_assert_result(capsys, ["--version-of", "mender-deployments"], "4.5.6-test")
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "mender-deployments", "--version-type", "docker"],
+        "4.5.6-test",
+    )
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "mender-deployments", "--version-type", "git"],
+        "4.5.6-test",
+    )
+    run_main_assert_result(capsys, ["--version-of", "deployments"], "4.5.6-test")
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "deployments", "--version-type", "docker"],
+        "4.5.6-test",
+    )
+    run_main_assert_result(
+        capsys, ["--version-of", "deployments", "--version-type", "git"], "4.5.6-test"
+    )
+    run_main_assert_result(
+        capsys, ["--version-of", "deployments-enterprise"], "4.5.6-test"
+    )
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "deployments-enterprise", "--version-type", "docker"],
+        "4.5.6-test",
+    )
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "deployments-enterprise", "--version-type", "git"],
+        "4.5.6-test",
     )
 
     # For old releases, --version-type shall be ignored

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -1,0 +1,198 @@
+# Copyright 2020 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import os
+import sys
+import shutil
+import re
+from unittest.mock import patch
+
+import pytest
+
+from release_tool import main
+from release_tool import docker_compose_files_list
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+RELEASE_TOOL = os.path.join(THIS_DIR, "release_tool.py")
+INTEGRATION_DIR = os.path.normpath(os.path.join(THIS_DIR, ".."))
+
+
+@pytest.fixture(scope="function", autouse=True)
+def master_yml_files(request):
+    """Edit all yml files setting them to 'master' versions
+
+    So that the tests can be run from any branch or with any
+    local changes in the yml files. The files are restored after
+    the test run.
+    """
+
+    for filename in docker_compose_files_list(INTEGRATION_DIR):
+        shutil.copyfile(filename, filename + ".bkp")
+
+        with open(filename) as fd:
+            full_content = "".join(fd.readlines())
+        with open(filename, "w") as fd:
+            fd.write(
+                re.sub(
+                    r"image:\s+(mendersoftware|.*mender\.io)/(.+):.*",
+                    r"image: \g<1>/\g<2>:master",
+                    full_content,
+                )
+            )
+        with open(filename) as fd:
+            full_content = "".join(fd.readlines())
+        with open(filename, "w") as fd:
+            fd.write(
+                re.sub(
+                    r"git-version:\s+.*",
+                    r"git-version: master",
+                    full_content,
+                    flags=re.MULTILINE,
+                )
+            )
+
+    def restore():
+        for filename in docker_compose_files_list(INTEGRATION_DIR):
+            os.rename(filename + ".bkp", filename)
+
+    request.addfinalizer(restore)
+
+
+def run_main_assert_result(capsys, args, expect=""):
+    testargs = [RELEASE_TOOL] + args
+    with patch.object(sys, "argv", testargs):
+        main()
+
+    captured = capsys.readouterr().out.strip()
+    assert captured == expect
+
+
+def test_version_of(capsys):
+    # On a clean checkout, both will be master
+    run_main_assert_result(capsys, ["--version-of", "inventory"], "master")
+    run_main_assert_result(
+        capsys, ["--version-of", "inventory", "--version-type", "docker"], "master"
+    )
+    run_main_assert_result(
+        capsys, ["--version-of", "inventory", "--version-type", "git"], "master"
+    )
+
+    # For an independent component, it should still accept docker/git type of the query
+    run_main_assert_result(capsys, ["--version-of", "mender"], "master")
+    run_main_assert_result(
+        capsys, ["--version-of", "mender", "--version-type", "docker"], "master"
+    )
+    run_main_assert_result(
+        capsys, ["--version-of", "mender", "--version-type", "git"], "master"
+    )
+    run_main_assert_result(capsys, ["--version-of", "mender-client-qemu"], "master")
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "mender-client-qemu", "--version-type", "docker"],
+        "master",
+    )
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "mender-client-qemu", "--version-type", "git"],
+        "master",
+    )
+
+    # Manually modifying the Git version:
+    filename = os.path.join(INTEGRATION_DIR, "git-versions.yml")
+    with open(filename, "w") as fd:
+        fd.write(
+            """services:
+    inventory:
+        git-version: 1.2.3-git
+"""
+        )
+    run_main_assert_result(capsys, ["--version-of", "inventory"], "1.2.3-git")
+    run_main_assert_result(
+        capsys, ["--version-of", "inventory", "--version-type", "docker"], "master"
+    )
+    run_main_assert_result(
+        capsys, ["--version-of", "inventory", "--version-type", "git"], "1.2.3-git"
+    )
+
+    # Manually modifying the Docker version:
+    filename = os.path.join(INTEGRATION_DIR, "docker-compose.yml")
+    with open(filename, "w") as fd:
+        fd.write(
+            """services:
+    mender-inventory:
+        image: mendersoftware/inventory:4.5.6-docker
+"""
+        )
+    run_main_assert_result(capsys, ["--version-of", "inventory"], "1.2.3-git")
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "inventory", "--version-type", "docker"],
+        "4.5.6-docker",
+    )
+    run_main_assert_result(
+        capsys, ["--version-of", "inventory", "--version-type", "git"], "1.2.3-git"
+    )
+
+
+def test_set_version_of(capsys):
+
+    run_main_assert_result(
+        capsys, ["--version-of", "inventory", "--version-type", "docker"], "master"
+    )
+    run_main_assert_result(
+        capsys, ["--version-of", "inventory", "--version-type", "git"], "master"
+    )
+
+    # Once set to something, only the Docker version changes
+    run_main_assert_result(
+        capsys, ["--set-version-of", "inventory", "--version", "1.2.3-test"]
+    )
+    run_main_assert_result(capsys, ["--version-of", "inventory"], "master")
+    run_main_assert_result(
+        capsys, ["--version-of", "inventory", "--version-type", "docker"], "1.2.3-test"
+    )
+    run_main_assert_result(
+        capsys, ["--version-of", "inventory", "--version-type", "git"], "master"
+    )
+
+    # For old releases, --version-type shall be ignored
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "inventory", "--in-integration-version", "2.3.0"],
+        "1.7.0",
+    )
+    run_main_assert_result(
+        capsys,
+        [
+            "--version-of",
+            "inventory",
+            "--version-type",
+            "git",
+            "--in-integration-version",
+            "2.3.0",
+        ],
+        "1.7.0",
+    )
+    run_main_assert_result(
+        capsys,
+        [
+            "--version-of",
+            "inventory",
+            "--version-type",
+            "docker",
+            "--in-integration-version",
+            "2.3.0",
+        ],
+        "1.7.0",
+    )

--- a/git-versions.yml
+++ b/git-versions.yml
@@ -1,0 +1,39 @@
+# This file lists all software components that are part of a Mender
+# release with their internal versions. The keys represent images
+# rather than "services", but we keep it for the sake of parsing it
+# the same way as other-components and docker-compose files.
+services:
+
+    #
+    # backend open source services
+    #
+    deployments:
+        git-version: master
+    gui:
+        git-version: master
+    mender-api-gateway-docker:
+        git-version: master
+    deviceauth:
+        git-version: master
+    inventory:
+        git-version: master
+    useradm:
+        git-version: master
+    workflows:
+        git-version: master
+    create-artifact-worker:
+        git-version: master
+
+    #
+    # backend enterprise services
+    #
+    deployments-enterprise:
+        git-version: master
+    inventory-enterprise:
+        git-version: master
+    useradm-enterprise:
+        git-version: master
+    workflows-enterprise:
+        git-version: master
+    tenantadm:
+        git-version: master

--- a/production/run
+++ b/production/run
@@ -3,10 +3,14 @@ set -e
 
 ../verify-docker-versions
 
+# Pass this value on to the GUI container as an env variable
 export INTEGRATION_VERSION=$(git describe --tags --abbrev=0)
-export MENDER_ARTIFACT_VERSION=$(../extra/release_tool.py -g mender-artifact)
-export MENDER_VERSION=$(../extra/release_tool.py -g mender)
+# Parse the Mender-Artifact version used from the other-components.yml file's image tag
+export MENDER_ARTIFACT_VERSION=$(awk -F':' '/mendersoftware\/mender-artifact/ {print $3}' other-components.yml)
+# Parse the mender version from docker-compose.yml mender image's tag
+export MENDER_VERSION=$(awk -F':' '/mendersoftware\/mender-client/ {print $3}' docker-compose.client.yml)
 export MENDER_DEB_PACKAGE_VERSION=$MENDER_VERSION
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
     export GATEWAY_IP=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -1)
 else

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -103,7 +103,7 @@ function get_requirements() {
     curl --fail "https://raw.githubusercontent.com/mendersoftware/mender/${MENDER_BRANCH}/support/modules-artifact-gen/directory-artifact-gen" \
          -o downloaded-tools/directory-artifact-gen \
          -z downloaded-tools/directory-artifact-gen
-    
+
     if [ $? -ne 0 ]; then
         echo "failed to download directory-artifact-gen"
         exit 1
@@ -147,11 +147,11 @@ fi
 mkdir -p output
 ret=0
 docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
-       mendersoftware/mender-client-qemu:$(../extra/release_tool.py --version-of mender-client-qemu) || ret=$?
+       mendersoftware/mender-client-qemu:$(../extra/release_tool.py --version-of mender-client-qemu --version-type docker) || ret=$?
 if [ $ret -eq 0 ]; then
     # There is `extract_fs` support. Get the R/O image too.
     docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
-           mendersoftware/mender-client-qemu-rofs:$(../extra/release_tool.py --version-of mender-client-qemu-rofs)
+           mendersoftware/mender-client-qemu-rofs:$(../extra/release_tool.py --version-of mender-client-qemu-rofs --version-type docker)
     mv output/* .
 else
     # Old style ext4 fetching.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -147,11 +147,11 @@ fi
 mkdir -p output
 ret=0
 docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
-       mendersoftware/mender-client-qemu:$(../extra/release_tool.py -g mender-client-qemu) || ret=$?
+       mendersoftware/mender-client-qemu:$(../extra/release_tool.py --version-of mender-client-qemu) || ret=$?
 if [ $ret -eq 0 ]; then
     # There is `extract_fs` support. Get the R/O image too.
     docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
-           mendersoftware/mender-client-qemu-rofs:$(../extra/release_tool.py -g mender-client-qemu-rofs)
+           mendersoftware/mender-client-qemu-rofs:$(../extra/release_tool.py --version-of mender-client-qemu-rofs)
     mv output/* .
 else
     # Old style ext4 fetching.


### PR DESCRIPTION
So here goes all my work around release_tool. Best reviewed commit by commit, I think.

From the interface point of view, it touches two parts of the tool.
- CLI options `--version-of` and `--set-version-of`: they use a new file `internal-vesions.yml` to figure out where to get/set the Git or Docker version.
- Release process: new flag in `components-maps,yml` informs the tool about which repos follow Mender product version and which Git tags when publishing Docker images.