### PR TITLE
integration tests: adjust tests after introducing new deployment creation flow

### DIFF
--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -49,8 +49,13 @@ class TestDeploymentAborting(MenderTesting):
 
             if abort_step is not None:
                 deploy.check_expected_statistics(deployment_id, abort_step, 1)
+
             deploy.abort(deployment_id)
-            deploy.check_expected_statistics(deployment_id, "aborted", 1)
+
+            # there will be abored deployment only if the deployment
+            # for the device has already started
+            if abort_step is not None:
+                deploy.check_expected_statistics(deployment_id, "aborted", 1)
 
             # no deployment logs are sent by the client, is this expected?
             for d in auth_v2.get_devices():


### PR DESCRIPTION
We should not expect deployment statistics for devices that didn't ask for the deployment.
With the new flow for creating deployments, device deployments are being created on the fly, so if the deployment was aborted before the device asked for the deployment it will never get it.

Related to https://github.com/mendersoftware/deployments/pull/426