### PR TITLE
Update versions for all backend images to mender-master

### DIFF
--- a/docker-compose.client.rofs.yml
+++ b/docker-compose.client.rofs.yml
@@ -5,4 +5,4 @@ services:
     # mender-client
     #
     mender-client:
-        image: mendersoftware/mender-client-qemu-rofs:master
+        image: mendersoftware/mender-client-qemu-rofs:mender-master

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -5,7 +5,7 @@ services:
     # mender-client
     #
     mender-client:
-        image: mendersoftware/mender-client-qemu:master
+        image: mendersoftware/mender-client-qemu:mender-master
         networks:
             - mender
         stdin_open: true

--- a/docker-compose.docker-client.yml
+++ b/docker-compose.docker-client.yml
@@ -3,6 +3,6 @@ services:
 
     mender-client:
         # Needs to be built in mender client's test directory.
-        image: mendersoftware/mender-client-docker:master
+        image: mendersoftware/mender-client-docker:mender-master
         networks:
             - mender

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -3,20 +3,20 @@ services:
 
     # subsitute services with 'enterprise' versions
     mender-deployments:
-        image: registry.mender.io/mendersoftware/deployments-enterprise:master
+        image: registry.mender.io/mendersoftware/deployments-enterprise:mender-master
 
     mender-inventory:
-        image: registry.mender.io/mendersoftware/inventory-enterprise:master
+        image: registry.mender.io/mendersoftware/inventory-enterprise:mender-master
 
     mender-workflows-server:
-        image: registry.mender.io/mendersoftware/workflows-enterprise:master
+        image: registry.mender.io/mendersoftware/workflows-enterprise:mender-master
 
     mender-workflows-worker:
-        image: registry.mender.io/mendersoftware/workflows-enterprise-worker:master
+        image: registry.mender.io/mendersoftware/workflows-enterprise-worker:mender-master
 
     # add services
     mender-tenantadm:
-        image: registry.mender.io/mendersoftware/tenantadm:master
+        image: registry.mender.io/mendersoftware/tenantadm:mender-master
         environment:
             TENANTADM_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
         extends:
@@ -33,7 +33,7 @@ services:
             DEVICEAUTH_TENANTADM_ADDR: 'http://mender-tenantadm:8080'
 
     mender-useradm:
-        image: registry.mender.io/mendersoftware/useradm-enterprise:master
+        image: registry.mender.io/mendersoftware/useradm-enterprise:mender-master
         environment:
             USERADM_TENANTADM_ADDR: 'http://mender-tenantadm:8080'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # mender-deployments
     #
     mender-deployments:
-        image: mendersoftware/deployments:master
+        image: mendersoftware/deployments:mender-master
         extends:
             file: common.yml
             service: mender-base
@@ -18,7 +18,7 @@ services:
     # mender-gui
     #
     mender-gui:
-        image: mendersoftware/gui:master
+        image: mendersoftware/gui:mender-master
         extends:
             file: common.yml
             service: mender-base
@@ -35,7 +35,7 @@ services:
     # mender-api-gateway
     #
     mender-api-gateway:
-        image: mendersoftware/api-gateway:master
+        image: mendersoftware/api-gateway:mender-master
         extends:
             file: common.yml
             service: mender-base
@@ -54,7 +54,7 @@ services:
     # mender-device-auth
     #
     mender-device-auth:
-        image: mendersoftware/deviceauth:master
+        image: mendersoftware/deviceauth:mender-master
         environment:
             DEVICEAUTH_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
         extends:
@@ -70,7 +70,7 @@ services:
     # mender-inventory
     #
     mender-inventory:
-        image: mendersoftware/inventory:master
+        image: mendersoftware/inventory:mender-master
         extends:
             file: common.yml
             service: mender-base
@@ -83,7 +83,7 @@ services:
     # mender-useradm
     #
     mender-useradm:
-        image: mendersoftware/useradm:master
+        image: mendersoftware/useradm:mender-master
         extends:
             file: common.yml
             service: mender-base
@@ -96,7 +96,7 @@ services:
     # mender-workflows-server
     #
     mender-workflows-server:
-        image: mendersoftware/workflows:master
+        image: mendersoftware/workflows:mender-master
         environment:
             WORKFLOWS_MONGO_URL: mongodb://mender-mongo:27017
         extends:
@@ -111,7 +111,7 @@ services:
     # mender-workflows-worker
     #
     mender-workflows-worker:
-        image: mendersoftware/workflows-worker:master
+        image: mendersoftware/workflows-worker:mender-master
         command: worker --excluded-workflows generate_artifact
         environment:
             WORKFLOWS_MONGO_URL: mongodb://mender-mongo:27017
@@ -127,7 +127,7 @@ services:
     # mender-create-artifact-worker
     #
     mender-create-artifact-worker:
-        image: mendersoftware/create-artifact-worker:master
+        image: mendersoftware/create-artifact-worker:mender-master
         environment:
             WORKFLOWS_MONGO_URL: mongodb://mender-mongo:27017
         extends:

--- a/other-components.yml
+++ b/other-components.yml
@@ -5,7 +5,7 @@
 # 'services' tag.
 services:
     mender-artifact:
-        image: mendersoftware/mender-artifact:master
+        image: mendersoftware/mender-artifact:mender-master
 
     mender-cli:
-        image: mendersoftware/mender-cli:master
+        image: mendersoftware/mender-cli:mender-master


### PR DESCRIPTION
MEN-3466: Update backend images to use version mender-master

Introducing a new versioning schema, from this release on the Docker
images for the backend repositories will be published in their
corresponding registries following the Mender product version.

This means tags `<service>:mender-<mender-version>` instead of the old
tags `<service>:<service-version>`, which will eventually be deprecated.

Changelog: Commit