### PR TITLE
[release_tool] Fixes for --integration-versions-including

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,8 @@ test:extra-tools:release-tool:
 
   before_script:
     - pip install pytest pyyaml
+    - git remote add github https://github.com/mendersoftware/integration.git
+    - git fetch github
 
   script:
     # Run release-tool unit tests.

--- a/docker-compose.client.rofs.yml
+++ b/docker-compose.client.rofs.yml
@@ -5,4 +5,4 @@ services:
     # mender-client
     #
     mender-client:
-        image: mendersoftware/mender-client-qemu-rofs:mender-master
+        image: mendersoftware/mender-client-qemu-rofs:master

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -5,7 +5,7 @@ services:
     # mender-client
     #
     mender-client:
-        image: mendersoftware/mender-client-qemu:mender-master
+        image: mendersoftware/mender-client-qemu:master
         networks:
             - mender
         stdin_open: true

--- a/docker-compose.docker-client.yml
+++ b/docker-compose.docker-client.yml
@@ -3,6 +3,6 @@ services:
 
     mender-client:
         # Needs to be built in mender client's test directory.
-        image: mendersoftware/mender-client-docker:mender-master
+        image: mendersoftware/mender-client-docker:master
         networks:
             - mender

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -475,8 +475,12 @@ def get_docker_compose_data_for_rev(git_dir, rev):
         .split("\n")
     )
     for filename in files:
-        if filename != "other-components.yml" and not (
-            filename.startswith("docker-compose") and filename.endswith(".yml")
+        if (
+            filename != "git-versions.yml"
+            and filename != "other-components.yml"
+            and not (
+                filename.startswith("docker-compose") and filename.endswith(".yml")
+            )
         ):
             continue
 
@@ -2576,7 +2580,11 @@ def do_integration_versions_including(args):
             print("Unrecognized repository: %s" % args.integration_versions_including)
             sys.exit(1)
         try:
-            version = data[repo.yml_components()[0].yml()]["version"]
+            # Prefer Git versions
+            if data[repo.yml_components()[0].yml()].get("git_version") is not None:
+                version = data[repo.yml_components()[0].yml()]["git_version"]
+            else:
+                version = data[repo.yml_components()[0].yml()]["version"]
         except KeyError:
             # If key doesn't exist it's because the version is from before
             # that component existed. So definitely not a match.

--- a/other-components.yml
+++ b/other-components.yml
@@ -5,7 +5,7 @@
 # 'services' tag.
 services:
     mender-artifact:
-        image: mendersoftware/mender-artifact:mender-master
+        image: mendersoftware/mender-artifact:master
 
     mender-cli:
-        image: mendersoftware/mender-cli:mender-master
+        image: mendersoftware/mender-cli:master


### PR DESCRIPTION
* Compose files fix: Only backend shall use version mender-master
Fixes commit 56140bf; where following its own commit message only the
backend components should have been updated to "mender-master" version.

* [release_tool] Fix -f option to prefer git versions over docker
The use case is for the user (or bot) to pass a git version in -v
parameter. So compare against internal git version when present.
Added a unit tests for it.
