### PR TITLE
[release_tool] Fix --version-of --in-integration-version combination

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,8 +32,13 @@ test:extra-tools:release-tool:
 
   before_script:
     - pip install pytest pyyaml
+    # Add github remote for tests using --integration-versions-including
     - git remote add github https://github.com/mendersoftware/integration.git
     - git fetch github
+    # Fetch master branch for tests using --in-integration-version
+    - if [ $CI_COMMIT_REF_NAME != "master" ]; then
+    -  git fetch origin master:master
+    - fi
 
   script:
     # Run release-tool unit tests.

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -553,7 +553,14 @@ def version_of(
             # If the repository didn't exist in that version, just return all
             # commits in that case, IOW no lower end point range.
             if data.get(yml_component.yml()) is not None:
-                version = data[yml_component.yml()]["version"]
+                # Old release branches will not have git_version (i.e. version matches git_version)
+                if (
+                    git_version
+                    and data[yml_component.yml()].get("git_version") is not None
+                ):
+                    version = data[yml_component.yml()]["git_version"]
+                else:
+                    version = data[yml_component.yml()]["version"]
                 # If it is a tag, do not prepend remote name
                 if re.search(r"^[0-9]+\.[0-9]+\.[0-9]+$", version):
                     repo_range.append(version)

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -45,7 +45,17 @@ def master_yml_files(request):
         with open(filename, "w") as fd:
             fd.write(
                 re.sub(
-                    r"image:\s+(mendersoftware|.*mender\.io)/(.+):.*",
+                    r"image:\s+(mendersoftware|.*mender\.io)/((?!mender\-client\-.+|mender-artifact|mender-cli).+):.*",
+                    r"image: \g<1>/\g<2>:mender-master",
+                    full_content,
+                )
+            )
+        with open(filename) as fd:
+            full_content = "".join(fd.readlines())
+        with open(filename, "w") as fd:
+            fd.write(
+                re.sub(
+                    r"image:\s+(mendersoftware|.*mender\.io)/(mender\-client\-.+|mender-artifact|mender-cli):.*",
                     r"image: \g<1>/\g<2>:master",
                     full_content,
                 )
@@ -84,7 +94,9 @@ def test_version_of(capsys):
     # On a clean checkout, both will be master
     run_main_assert_result(capsys, ["--version-of", "inventory"], "master")
     run_main_assert_result(
-        capsys, ["--version-of", "inventory", "--version-type", "docker"], "master"
+        capsys,
+        ["--version-of", "inventory", "--version-type", "docker"],
+        "mender-master",
     )
     run_main_assert_result(
         capsys, ["--version-of", "inventory", "--version-type", "git"], "master"
@@ -121,7 +133,9 @@ def test_version_of(capsys):
         )
     run_main_assert_result(capsys, ["--version-of", "inventory"], "1.2.3-git")
     run_main_assert_result(
-        capsys, ["--version-of", "inventory", "--version-type", "docker"], "master"
+        capsys,
+        ["--version-of", "inventory", "--version-type", "docker"],
+        "mender-master",
     )
     run_main_assert_result(
         capsys, ["--version-of", "inventory", "--version-type", "git"], "1.2.3-git"

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -161,6 +161,70 @@ def test_version_of(capsys):
     )
 
 
+def test_version_of_with_in_integration_version(capsys):
+    # In remote master, shall be master
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "inventory", "--in-integration-version", "master"],
+        "master",
+    )
+    run_main_assert_result(
+        capsys,
+        [
+            "--version-of",
+            "inventory",
+            "--version-type",
+            "docker",
+            "--in-integration-version",
+            "master",
+        ],
+        "mender-master",
+    )
+    run_main_assert_result(
+        capsys,
+        [
+            "--version-of",
+            "inventory",
+            "--version-type",
+            "git",
+            "--in-integration-version",
+            "master",
+        ],
+        "master",
+    )
+
+    # For old releases, --version-type shall be ignored
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "inventory", "--in-integration-version", "2.3.0"],
+        "1.7.0",
+    )
+    run_main_assert_result(
+        capsys,
+        [
+            "--version-of",
+            "inventory",
+            "--version-type",
+            "git",
+            "--in-integration-version",
+            "2.3.0",
+        ],
+        "1.7.0",
+    )
+    run_main_assert_result(
+        capsys,
+        [
+            "--version-of",
+            "inventory",
+            "--version-type",
+            "docker",
+            "--in-integration-version",
+            "2.3.0",
+        ],
+        "1.7.0",
+    )
+
+
 def test_set_version_of(capsys):
     # Using --set-version-of modifies both versions, regardless of using the repo name
     run_main_assert_result(
@@ -210,37 +274,6 @@ def test_set_version_of(capsys):
         capsys,
         ["--version-of", "deployments-enterprise", "--version-type", "git"],
         "4.5.6-test",
-    )
-
-    # For old releases, --version-type shall be ignored
-    run_main_assert_result(
-        capsys,
-        ["--version-of", "inventory", "--in-integration-version", "2.3.0"],
-        "1.7.0",
-    )
-    run_main_assert_result(
-        capsys,
-        [
-            "--version-of",
-            "inventory",
-            "--version-type",
-            "git",
-            "--in-integration-version",
-            "2.3.0",
-        ],
-        "1.7.0",
-    )
-    run_main_assert_result(
-        capsys,
-        [
-            "--version-of",
-            "inventory",
-            "--version-type",
-            "docker",
-            "--in-integration-version",
-            "2.3.0",
-        ],
-        "1.7.0",
     )
 
 


### PR DESCRIPTION
* [test_release_tool] Modify fixture to better represent real files
I.e. only backend services should present the "mender-master" kind of
tag, while client and other tools should use plain "master".

* [release_tool] Fix --version-of --in-integration-version combination
When using --in-integration-version, a piece of code was missing to
prefer Git versions over Docker ones.
Added a unit test for it also.