### PR TITLE
[compose files] Temporary set mender-api-gateway-docker to old "master"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     # mender-api-gateway
     #
     mender-api-gateway:
-        image: mendersoftware/api-gateway:mender-master
+        image: mendersoftware/api-gateway:master
         extends:
             file: common.yml
             service: mender-base


### PR DESCRIPTION
There is a bug in release_tool affecting the versioning of this
component. Let's set it to old master not to block development while we
find a proper fix.