### PR TITLE
[release-tool/compose files]: Fix for mender-api-gateway-docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,9 +36,7 @@ test:extra-tools:release-tool:
     - git remote add github https://github.com/mendersoftware/integration.git
     - git fetch github
     # Fetch master branch for tests using --in-integration-version
-    - if [ $CI_COMMIT_REF_NAME != "master" ]; then
-    -  git fetch origin master:master
-    - fi
+    - git fetch origin master:master
 
   script:
     # Run release-tool unit tests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     # mender-api-gateway
     #
     mender-api-gateway:
-        image: mendersoftware/api-gateway:master
+        image: mendersoftware/api-gateway:mender-master
         extends:
             file: common.yml
             service: mender-base

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -401,7 +401,7 @@ def get_docker_compose_data_from_json_list(json_list):
             "container": container_name,
             "image_prefix": "mendersoftware/" or "someserver.mender.io/blahblah",
             "version": version,
-            "git_version": git_version,
+            "git_version": git version of the assoiated repo,
         }
     }
     """
@@ -448,6 +448,9 @@ def get_docker_compose_data_from_json_list(json_list):
                         )
                         % service
                     )
+                # NOTE: For yaml files containing "git-version" fields (namely git-versions.yml),
+                # these hang on "services" keys representing Docker image names (instead of Docker
+                # containers names). Hence we merge the dicts here assuming "service" == image.
                 data[service].update(
                     {"git_version": git_version,}
                 )
@@ -584,11 +587,18 @@ def do_version_of(args):
         print("Unrecognized repository: %s" % args.version_of)
         sys.exit(1)
 
-    yml_component = comp.yml_components()[0]
-
     assert args.version_type in ["docker", "git"], (
         "%s is not a valid name type!" % args.version_type
     )
+
+    if comp.type in ["docker_image", "docker_container"] and args.version_type == "git":
+        print(
+            "Unsuported %s %s for --version-type git. Use --version-type docker instead"
+            % (comp.type, args.version_of)
+        )
+        sys.exit(1)
+
+    yml_component = comp.yml_components()[0]
 
     print(
         version_of(

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -92,14 +92,14 @@ def run_main_assert_result(capsys, args, expect=None):
 
 def test_version_of(capsys):
     # On a clean checkout, both will be master
-    run_main_assert_result(capsys, ["--version-of", "inventory"], "master")
+    run_main_assert_result(capsys, ["--version-of", "deviceauth"], "master")
     run_main_assert_result(
         capsys,
-        ["--version-of", "inventory", "--version-type", "docker"],
+        ["--version-of", "deviceauth", "--version-type", "docker"],
         "mender-master",
     )
     run_main_assert_result(
-        capsys, ["--version-of", "inventory", "--version-type", "git"], "master"
+        capsys, ["--version-of", "deviceauth", "--version-type", "git"], "master"
     )
 
     # For an independent component, it should still accept docker/git type of the query
@@ -121,18 +121,18 @@ def test_version_of(capsys):
     with open(filename, "w") as fd:
         fd.write(
             """services:
-    inventory:
+    deviceauth:
         git-version: 1.2.3-git
 """
         )
-    run_main_assert_result(capsys, ["--version-of", "inventory"], "1.2.3-git")
+    run_main_assert_result(capsys, ["--version-of", "deviceauth"], "1.2.3-git")
     run_main_assert_result(
         capsys,
-        ["--version-of", "inventory", "--version-type", "docker"],
+        ["--version-of", "deviceauth", "--version-type", "docker"],
         "mender-master",
     )
     run_main_assert_result(
-        capsys, ["--version-of", "inventory", "--version-type", "git"], "1.2.3-git"
+        capsys, ["--version-of", "deviceauth", "--version-type", "git"], "1.2.3-git"
     )
 
     # Manually modifying the Docker version:
@@ -140,18 +140,18 @@ def test_version_of(capsys):
     with open(filename, "w") as fd:
         fd.write(
             """services:
-    mender-inventory:
-        image: mendersoftware/inventory:4.5.6-docker
+    mender-deviceauth:
+        image: mendersoftware/deviceauth:4.5.6-docker
 """
         )
-    run_main_assert_result(capsys, ["--version-of", "inventory"], "1.2.3-git")
+    run_main_assert_result(capsys, ["--version-of", "deviceauth"], "1.2.3-git")
     run_main_assert_result(
         capsys,
-        ["--version-of", "inventory", "--version-type", "docker"],
+        ["--version-of", "deviceauth", "--version-type", "docker"],
         "4.5.6-docker",
     )
     run_main_assert_result(
-        capsys, ["--version-of", "inventory", "--version-type", "git"], "1.2.3-git"
+        capsys, ["--version-of", "deviceauth", "--version-type", "git"], "1.2.3-git"
     )
 
 
@@ -222,14 +222,14 @@ def test_version_of_with_in_integration_version(capsys):
 def test_set_version_of(capsys):
     # Using --set-version-of modifies both versions, regardless of using the repo name
     run_main_assert_result(
-        capsys, ["--set-version-of", "inventory", "--version", "1.2.3-test"]
+        capsys, ["--set-version-of", "deviceauth", "--version", "1.2.3-test"]
     )
-    run_main_assert_result(capsys, ["--version-of", "inventory"], "1.2.3-test")
+    run_main_assert_result(capsys, ["--version-of", "deviceauth"], "1.2.3-test")
     run_main_assert_result(
-        capsys, ["--version-of", "inventory", "--version-type", "docker"], "1.2.3-test"
+        capsys, ["--version-of", "deviceauth", "--version-type", "docker"], "1.2.3-test"
     )
     run_main_assert_result(
-        capsys, ["--version-of", "inventory", "--version-type", "git"], "1.2.3-test"
+        capsys, ["--version-of", "deviceauth", "--version-type", "git"], "1.2.3-test"
     )
 
     # or the container name. However, setting from the container name sets all repos (os + ent)
@@ -241,15 +241,20 @@ def test_set_version_of(capsys):
         ["--version-of", "mender-deployments", "--version-type", "docker"],
         "4.5.6-test",
     )
-    run_main_assert_result(capsys, ["--version-of", "deployments"], "4.5.6-test")
-    run_main_assert_result(
-        capsys,
-        ["--version-of", "deployments", "--version-type", "docker"],
-        "4.5.6-test",
-    )
-    run_main_assert_result(
-        capsys, ["--version-of", "deployments", "--version-type", "git"], "4.5.6-test"
-    )
+    # NOTE: skip check for OS flavor for branches without it (namely staging)
+    list_repos = run_main_assert_result(capsys, ["--list", "git"], None)
+    if "deployments" in list_repos.split("\n"):
+        run_main_assert_result(capsys, ["--version-of", "deployments"], "4.5.6-test")
+        run_main_assert_result(
+            capsys,
+            ["--version-of", "deployments", "--version-type", "docker"],
+            "4.5.6-test",
+        )
+        run_main_assert_result(
+            capsys,
+            ["--version-of", "deployments", "--version-type", "git"],
+            "4.5.6-test",
+        )
     run_main_assert_result(
         capsys, ["--version-of", "deployments-enterprise"], "4.5.6-test"
     )

--- a/git-versions.yml
+++ b/git-versions.yml
@@ -1,17 +1,17 @@
 # This file lists all software components that are part of a Mender
-# release with their internal versions. The keys represent images
-# rather than "services", but we keep it for the sake of parsing it
-# the same way as other-components and docker-compose files.
+# release with their git versions. The keys represent images rather
+# than "services" (or containers), but we keep it for parsing it the
+# same way as other-components and docker-compose files.
 services:
 
     #
-    # backend open source services
+    # backend open source images
     #
     deployments:
         git-version: master
     gui:
         git-version: master
-    mender-api-gateway-docker:
+    api-gateway:
         git-version: master
     deviceauth:
         git-version: master
@@ -25,7 +25,7 @@ services:
         git-version: master
 
     #
-    # backend enterprise services
+    # backend enterprise images
     #
     deployments-enterprise:
         git-version: master


### PR DESCRIPTION
The actual fix in this commit is renaming "mender-api-gateway-docker"
(i.e. git repo name) to "api-gateway" (i.e. docker image name) in
git-versions.yml file.

Added some code comments around to clarify the design, as well as an
strict control for CLI option --version-of to disallow ambiguous uses.
Few components have different name for the repo than for the Docker
image (workflows-worker, api-gateway) which will make this option return
unexpected versions. Throw an informative error for these cases.

Unit tests added for it.
