### PR TITLE
release_tool: Fix remote-name being dropped from version ranges.

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -532,24 +532,25 @@ def version_of(
             if len(rev_range) > 1:
                 range_type = ".."
 
-        # Figure out if the user string contained a remote or not
-        remote = ""
-        split = rev_range[0].split("/", 1)
-        if len(split) > 1:
-            remote_candidate = split[0]
-            ref_name = split[1]
-            if (
-                subprocess.call(
-                    "git rev-parse -q --verify refs/heads/%s > /dev/null" % ref_name,
-                    shell=True,
-                    cwd=integration_dir,
-                )
-                == 0
-            ):
-                remote = remote_candidate + "/"
-
         repo_range = []
         for rev in rev_range:
+            # Figure out if the user string contained a remote or not
+            remote = ""
+            split = rev.split("/", 1)
+            if len(split) > 1:
+                remote_candidate = split[0]
+                ref_name = split[1]
+                if (
+                    subprocess.call(
+                        "git rev-parse -q --verify refs/heads/%s > /dev/null"
+                        % ref_name,
+                        shell=True,
+                        cwd=integration_dir,
+                    )
+                    == 0
+                ):
+                    remote = remote_candidate + "/"
+
             if not git_version:
                 data = get_docker_compose_data_for_rev(integration_dir, rev, "docker")
             else:


### PR DESCRIPTION
This happens when using -g and -i together with a range where one end
uses a remote reference and the other one doesn't. We are checking
whether the supplied reference is a remote or not, but only for the
first element of a range. We need to check it for all elements in the
range.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>