### PR TITLE
demo: Do not download the demo artifact if it is already downloaded.

### DIFF
--- a/demo
+++ b/demo
@@ -57,7 +57,7 @@ done
 # Check if the demo-Artifact has been downloaded,
 # or if there exists a newer one in storage.
 DEMO_ARTIFACT_NAME="mender-demo-artifact.mender"
-curl -sz mender-demo-artifact.mender -o mender-demo-artifact.mender https://dgsbl4vditpls.cloudfront.net/${DEMO_ARTIFACT_NAME}
+curl -q -sz mender-demo-artifact.mender -o mender-demo-artifact.mender https://dgsbl4vditpls.cloudfront.net/${DEMO_ARTIFACT_NAME}
 
 retval=$?
 if [ $retval -ne 0 ]; then


### PR DESCRIPTION
Currently curl will fail if the file exists with the error message:
     Failed to download the demo Artifact

Changelog: None
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>