### PR TITLE
[python-requirements.txt] Specify paramiko version

### DIFF
--- a/tests/requirements/python-requirements.txt
+++ b/tests/requirements/python-requirements.txt
@@ -15,7 +15,4 @@ psutil                     ; python_version >= "3.0"
 pymongo==3.10.1            ; python_version >= "3.0"
 fabric==2.5.0              ; python_version >= "3.0"
 pycrypto                   ; python_version >= "3.0"
-
-# docker-compose 1.24.0 has requirements:
-#  PyYAML<4.3,>=3.10, but you'll have pyyaml 5.1.2 which is incompatible.
-#  requests!=2.11.0,!=2.12.2,!=2.18.0,<2.21,>=2.6.1, but you'll have requests 2.22.0 which is incompatible.
+paramiko==2.6.0            ; python_version >= "3.0"


### PR DESCRIPTION
Latest paramiko 2.7.1 does not seem to work on a fresh Ubuntu.