### PR TITLE
docker compose: minio now restart on-failure

### DIFF
--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -6,6 +6,7 @@ services:
     #
     minio:
         image: minio/minio:RELEASE.2018-09-25T21-34-43Z
+        restart: on-failure
         networks:
             mender:
                 aliases:
@@ -20,6 +21,7 @@ services:
     #
     storage-proxy:
         image: openresty/openresty:1.13.6.2-0-alpine
+        restart: on-failure
         networks:
             mender:
                 aliases:


### PR DESCRIPTION
Mender storage minio doesn't restart in case of failure.

Fix this by adding the restart rule in the docker compose file.

Changelog: Title