### PR TITLE
release_tool: Better recovery when tag deletion fails.

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -1814,7 +1814,6 @@ def purge_build_tags(state, tag_avail):
             ):
                 to_purge.append(tag)
         if len(to_purge) > 0:
-            git_list.append((state, repo.git(), ["tag", "-d"] + to_purge))
             git_list.append(
                 (
                     state,
@@ -1822,6 +1821,7 @@ def purge_build_tags(state, tag_avail):
                     ["push", remote] + [":%s" % tag for tag in to_purge],
                 )
             )
+            git_list.append((state, repo.git(), ["tag", "-d"] + to_purge))
 
     query_execute_git_list(git_list)
 


### PR DESCRIPTION
Do the local tag deletion after the remote deletion, instead of vice
versa. This means that we can immediately pick up where we left off if
we get an exception for whatever reason (network error, etc.). Without
this we have to refetch the remote tags in order to delete them
afterwards.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>