### PR TITLE
release_tool: Fix exception when pushing Docker final release tags.

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -950,6 +950,7 @@ def check_tag_availability(state):
 
     tag_avail = {}
     highest_overall = -1
+    all_released = True
     for repo in Component.get_components_of_type("git"):
         tag_avail[repo.git()] = {}
         missing_repos = False
@@ -972,6 +973,7 @@ def check_tag_availability(state):
             # Exception happened during Git call. This tag doesn't exist, and
             # we must look for and/or create build tags.
             tag_avail[repo.git()]["already_released"] = False
+            all_released = False
 
             # Find highest <version>-buildX tag, where X is a number.
             tags = execute_git(state, repo.git(), ["tag"], capture=True)
@@ -1004,6 +1006,8 @@ def check_tag_availability(state):
             state["version"],
             highest_overall,
         )
+    elif all_released:
+        tag_avail["image_tag"] = "mender-%s" % state["version"]
 
     if missing_repos:
         print("Error: missing repos directories.")


### PR DESCRIPTION
When looking for tags, we need to keep track of whether any repository
has a build tag. If none have it, then it is a final release, and
global image_tag must be set specifically for that.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>