### PR TITLE
Restore docker-compose.storage.s3.yml

### DIFF
--- a/docker-compose.storage.s3.yml
+++ b/docker-compose.storage.s3.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+
+    #
+    # mender-deployments
+    #
+
+    #
+    # storage backend proxy used in conjunction with minio, applies
+    # rate & connection limiting
+    #
+
+    mender-deployments:
+        # S3 access configuration - override with your own values
+        # Keys have to grant access to default bucket: mender-artifact-storage
+        environment:
+            DEPLOYMENTS_AWS_TAG_ARTIFACT: "true"
+            DEPLOYMENTS_AWS_AUTH_KEY: ${AWS_ACCESS_KEY_ID}
+            DEPLOYMENTS_AWS_AUTH_SECRET: ${AWS_SECRET_ACCESS_KEY}
+            DEPLOYMENTS_AWS_REGION: us-west-1
+            DEPLOYMENTS_AWS_URI: https://s3-us-west-1.amazonaws.com
+            DEPLOYMENTS_AWS_BUCKET: mender-artifacts-int-testing-us
+

--- a/docker-compose.storage.s3.yml
+++ b/docker-compose.storage.s3.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
 
     #


### PR DESCRIPTION
The file was removed by mistake at bc39515 as it was mistakenly
concluded that was used only for tests. However it is used by on-prem
setups for some community users.