### PR TITLE
MEN-3606: Implement `./demo --enterprise-testing` flag.

### DIFF
--- a/demo
+++ b/demo
@@ -2,24 +2,6 @@
 
 ./verify-docker-versions
 
-usage() {
-    cat <<EOF
-$(basename $0) [options] docker-options
-
---client    Enable emulated client
-
-All other arguments passed to this command are passed directly to
-docker-compose, if you want to run the demo, run:
-
-'$(basename $0) up'
-EOF
-}
-
-if [[ "$#" -eq 0 ]] || [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
-    usage
-    exit 1
-fi
-
 # For the integration tests the name of the docker-compose project is generated
 # by pytest. For users, we use the folder name, but strip out a few characters
 # that aren't allowed.
@@ -33,142 +15,180 @@ ENTERPRISE_FILES="-f docker-compose.enterprise.yml"
 CLIENT=0
 ENTERPRISE=0
 RUN_UP=0
+UPLOAD_ARTIFACT=1
+PRINT_LOGIN_INFO=0
+PRINT_USER_EXISTS=0
+RETRY_LIMIT=5
 
-# The demo environment has some external dependencies upon: curl, jq
-hash curl 2>/dev/null || { echo >&2 "The demo script requires the 'curl' tool to be available. Aborting."; exit 1; }
-hash jq 2>/dev/null || { echo >&2 "The demo script requires the 'jq' tool to be available. Aborting."; exit 1; }
+declare -a ARGS
 
-while [[ -n "$1" ]]; do
-    if [[ "$1" = "--no-client" ]]; then
-        echo "--no-client argument is deprecated. Client is now disabled by default and can be enabled with --client"
-    elif [[ "$1" = "--client" ]]; then
-        CLIENT=1
-        echo "-- enabling client container"
-    elif [[ "$1" = "-p" ]] || [[ "$1" = "--project-name" ]]; then
+usage() {
+    cat <<EOF
+$(basename $0) [options] docker-options
+
+--client    Enable emulated client
+
+All other arguments passed to this command are passed directly to
+docker-compose, if you want to run the demo, run:
+
+'$(basename $0) up'
+EOF
+}
+
+parse_args() {
+    if [[ "$#" -eq 0 ]] || [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
+        usage
+        exit 1
+    fi
+
+    while [[ -n "$1" ]]; do
+        if [[ "$1" = "--no-client" ]]; then
+            echo "--no-client argument is deprecated. Client is now disabled by default and can be enabled with --client"
+        elif [[ "$1" = "--client" ]]; then
+            CLIENT=1
+            echo "-- enabling client container"
+        elif [[ "$1" = "-p" ]] || [[ "$1" = "--project-name" ]]; then
+            shift
+            DOCKER_COMPOSE_PROJECT_NAME="$1"
+        elif [[ "$1" = "--kvm" ]]; then
+            echo "--kvm argument is deprecated. KVM will be enabled automatically if available"
+        elif [[ "$1" = "--enterprise-testing" ]]; then
+            # Undocumented flag, we use this for internal testing.
+            EXTRA_FILES="$EXTRA_FILES $ENTERPRISE_FILES"
+            ENTERPRISE=1
+        elif [[ "$1" = "down" ]] || [[ "$1" = "rm" ]] || [[ "$1" = "stop" ]]; then
+            # If the argument is either "down" or "rm", enable the client so that it
+            # gets cleaned up, no matter if `--client` is passed or not.
+            CLIENT=1
+            # Not a flag, so we should break out of the loop.
+            break
+        elif [[ "$1" = "up" ]]; then
+            RUN_UP=1
+            # Not a flag, so we should break out of the loop.
+            break
+        else
+            break
+        fi
         shift
-        DOCKER_COMPOSE_PROJECT_NAME="$1"
-    elif [[ "$1" = "--kvm" ]]; then
-        echo "--kvm argument is deprecated. KVM will be enabled automatically if available"
-    elif [[ "$1" = "--enterprise-testing" ]]; then
-        # Undocumented flag, we use this for internal testing.
-        EXTRA_FILES="$EXTRA_FILES $ENTERPRISE_FILES"
-        ENTERPRISE=1
-    elif [[ "$1" = "down" ]] || [[ "$1" = "rm" ]] || [[ "$1" = "stop" ]]; then
-        # If the argument is either "down" or "rm", enable the client so that it
-        # gets cleaned up, no matter if `--client` is passed or not.
-        CLIENT=1
-        # Not a flag, so we should break out of the loop.
-        break
-    elif [[ "$1" = "up" ]]; then
-        RUN_UP=1
-        # Not a flag, so we should break out of the loop.
-        break
-    else
-        break
-    fi
-    shift
-done
+    done
 
-EXTRA_FILES_NEXT=0
-for i in "$@"; do
-    case $i in
-        -f=*|--file=*)
-            EXTRA_FILES="$EXTRA_FILES $i"
-            ;;
-        -f|--file)
-            EXTRA_FILES="$EXTRA_FILES $i"
-            EXTRA_FILES_NEXT=1
-            ;;
-        *)
-            if [[ $EXTRA_FILES_NEXT -eq 1 ]]; then
+    local EXTRA_FILES_NEXT=0
+    for i in "$@"; do
+        case $i in
+            -f=*|--file=*)
                 EXTRA_FILES="$EXTRA_FILES $i"
-                EXTRA_FILES_NEXT=0
-            fi
-            ;;
-    esac
-done
+                ;;
+            -f|--file)
+                EXTRA_FILES="$EXTRA_FILES $i"
+                EXTRA_FILES_NEXT=1
+                ;;
+            *)
+                if [[ $EXTRA_FILES_NEXT -eq 1 ]]; then
+                    EXTRA_FILES="$EXTRA_FILES $i"
+                    EXTRA_FILES_NEXT=0
+                fi
+                ;;
+        esac
+    done
 
-if [[ $CLIENT -eq 1 ]]; then
-    if [[ $ENTERPRISE -eq 0 ]] || [[ $RUN_UP -eq 0 ]]; then
-        # For Enterprise we need to take special care and fetch the tenant token
-        # first. For Open Source, we can add the client container immediately.
-        EXTRA_FILES="$EXTRA_FILES $CLIENT_FILES"
+    ARGS=($@)
+}
+
+check_tools() {
+    # The demo environment has some external dependencies upon: curl, jq
+    hash curl 2>/dev/null || { echo >&2 "The demo script requires the 'curl' tool to be available. Aborting."; exit 1; }
+    hash jq 2>/dev/null || { echo >&2 "The demo script requires the 'jq' tool to be available. Aborting."; exit 1; }
+}
+
+enterprise_client_early_handling() {
+    if [[ $CLIENT -eq 1 ]]; then
+        if [[ $ENTERPRISE -eq 0 ]] || [[ $RUN_UP -eq 0 ]]; then
+            # For Enterprise we need to take special care and fetch the tenant token
+            # first. For Open Source, we can add the client container immediately.
+            EXTRA_FILES="$EXTRA_FILES $CLIENT_FILES"
+        fi
     fi
-fi
+}
 
-# Check if the demo-Artifact has been downloaded,
-# or if there exists a newer one in storage.
-DEMO_ARTIFACT_NAME="mender-demo-artifact.mender"
-curl -q -sz mender-demo-artifact.mender -o mender-demo-artifact.mender https://dgsbl4vditpls.cloudfront.net/${DEMO_ARTIFACT_NAME}
+download_demo_artifact() {
+    # Check if the demo-Artifact has been downloaded,
+    # or if there exists a newer one in storage.
+    DEMO_ARTIFACT_NAME="mender-demo-artifact.mender"
+    curl -q -sz mender-demo-artifact.mender -o mender-demo-artifact.mender https://dgsbl4vditpls.cloudfront.net/${DEMO_ARTIFACT_NAME}
 
-retval=$?
-if [[ $retval -ne 0 ]]; then
-    echo "Failed to download the demo Artifact"
-    exit $retval
-fi
+    retval=$?
+    if [[ $retval -ne 0 ]]; then
+        echo "Failed to download the demo Artifact"
+        exit $retval
+    fi
+}
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    ARTIFACT_SIZE_BYTES=$(stat -f %z ${DEMO_ARTIFACT_NAME}) # BSD is not GNU -_-
-    export GATEWAY_IP=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -1)
-else
-    ARTIFACT_SIZE_BYTES=$(stat -c %s ${DEMO_ARTIFACT_NAME})
-    export GATEWAY_IP=$(ip route get 1 | awk '{print $7;exit}')
-fi
+platform_dependent_setup() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        ARTIFACT_SIZE_BYTES=$(stat -f %z ${DEMO_ARTIFACT_NAME}) # BSD is not GNU -_-
+        export GATEWAY_IP=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -1)
+    else
+        ARTIFACT_SIZE_BYTES=$(stat -c %s ${DEMO_ARTIFACT_NAME})
+        export GATEWAY_IP=$(ip route get 1 | awk '{print $7;exit}')
+    fi
+}
 
-# speed up first start by pulling containers in parallel
-docker images | grep -q 'mendersoftware/deployments'
+pull_docker_containers() {
+    # speed up first start by pulling containers in parallel
+    docker images | grep -q 'mendersoftware/deployments'
 
-if [[ "$?" -eq 1 ]]; then
-    compose_args=""
-    docker_compose_output=$(docker-compose pull -h)
-
-    # If --no-parallel option exists, it means that docker-compose is
-    # running a version where --parallel is default and will warn about
-    # deprecated option if used.
-    #
-    # This behavior was changed in version docker-compose 1.21.0
-    echo "$docker_compose_output" | grep -q -- '--no-parallel'
     if [[ "$?" -eq 1 ]]; then
-        compose_args="--parallel"
+        compose_args=""
+        docker_compose_output=$(docker-compose pull -h)
+
+        # If --no-parallel option exists, it means that docker-compose is
+        # running a version where --parallel is default and will warn about
+        # deprecated option if used.
+        #
+        # This behavior was changed in version docker-compose 1.21.0
+        echo "$docker_compose_output" | grep -q -- '--no-parallel'
+        if [[ "$?" -eq 1 ]]; then
+            compose_args="--parallel"
+        fi
+
+        docker-compose pull ${compose_args}
+    fi
+}
+
+env_setup() {
+    # Pass this value on to the GUI container as an env variable
+    export INTEGRATION_VERSION=$(git describe --tags --abbrev=0)
+    # Parse the Mender-Artifact version used from the other-components.yml file's image tag
+    export MENDER_ARTIFACT_VERSION=$(awk -F':' '/mendersoftware\/mender-artifact/ {print $3}' other-components.yml)
+    # Parse the mender version from docker-compose.yml mender image's tag
+    export MENDER_VERSION=$(awk -F':' '/mendersoftware\/mender-client/ {print $3}' docker-compose.client.yml)
+    export MENDER_DEB_PACKAGE_VERSION=$MENDER_VERSION
+
+    MENDER_SERVER_URI="https://localhost"
+    # use http when providing no-ssl config
+    if [[ "${ARGS[*]}" == *"-f docker-compose.no-ssl.yml"* ]]
+    then
+        MENDER_SERVER_URI="http://localhost"
     fi
 
-    docker-compose pull ${compose_args}
-fi
+    USER='mender-demo@example.com'
+    PASSWORD=$(hexdump -n 8 -e '"%X"' < /dev/urandom | cut -c1-12)
+}
 
-# Pass this value on to the GUI container as an env variable
-export INTEGRATION_VERSION=$(git describe --tags --abbrev=0)
-# Parse the Mender-Artifact version used from the other-components.yml file's image tag
-export MENDER_ARTIFACT_VERSION=$(awk -F':' '/mendersoftware\/mender-artifact/ {print $3}' other-components.yml)
-# Parse the mender version from docker-compose.yml mender image's tag
-export MENDER_VERSION=$(awk -F':' '/mendersoftware\/mender-client/ {print $3}' docker-compose.client.yml)
-export MENDER_DEB_PACKAGE_VERSION=$MENDER_VERSION
-
-if [[ $RUN_UP -eq 0 ]]; then
-    # exec steals the shell, so unless docker-compose is not found,
-    # exit 1 will never happen.
-    exec docker-compose \
-         -f docker-compose.yml \
-         -f docker-compose.storage.minio.yml \
-         -f docker-compose.demo.yml \
-         -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-         $EXTRA_FILES \
-         "$@"
-    exit 1
-fi
-
-# ------------------------------------------------------------------------------
-#
-#       The following code will only be run in the case ./demo up [[args]]
-#
-# ------------------------------------------------------------------------------
-
-MENDER_SERVER_URI="https://localhost"
-
-# use http when providing no-ssl config
-if [[ "$@" == *"-f docker-compose.no-ssl.yml"* ]]
-then
-    MENDER_SERVER_URI="http://localhost"
-fi
+run_non_up_commands() {
+    if [[ $RUN_UP -eq 0 ]]; then
+        # exec steals the shell, so unless docker-compose is not found,
+        # exit 1 will never happen.
+        exec docker-compose \
+             -f docker-compose.yml \
+             -f docker-compose.storage.minio.yml \
+             -f docker-compose.demo.yml \
+             -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+             $EXTRA_FILES \
+             "${ARGS[@]}"
+        exit 1
+    fi
+}
 
 # Make sure that the demo environment is brought down on SIGINT
 exitfunc() {
@@ -182,214 +202,254 @@ exitfunc() {
     exit $retval
 }
 
-trap exitfunc SIGINT
-trap exitfunc SIGTERM
+start_server() {
+    echo "Starting the Mender demo environment..."
 
-echo "Starting the Mender demo environment..."
+    docker-compose \
+        -f docker-compose.yml \
+        -f docker-compose.storage.minio.yml \
+        -f docker-compose.demo.yml \
+        -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+        $EXTRA_FILES \
+        "${ARGS[@]}" -d
 
-docker-compose \
-    -f docker-compose.yml \
-    -f docker-compose.storage.minio.yml \
-    -f docker-compose.demo.yml \
-    -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-    $EXTRA_FILES \
-    "$@" -d
-
-retval=$?
-if [[ $retval -ne 0 ]]; then
-    echo "Failed to start docker compose"
-    exit $retval
-fi
-
-USER='mender-demo@example.com'
-PASSWORD=$(hexdump -n 8 -e '"%X"' < /dev/urandom | cut -c1-12)
-
-
-RETRY_LIMIT=5
-
-# Block until the useradm service returns an HTTP 4xx response
-RETRIES=0
-while :
-do
-    curl --silent -k -X POST -u ${USER}:${PASSWORD} \
-         --fail\
-         --connect-timeout 5\
-         $MENDER_SERVER_URI/api/management/v1/useradm/auth/login
-    retval=$?
-    case $retval in
-        0)  break ;; # User exists - continue.
-        22) break ;; # Server 400 error, ie, server is up - continue.
-        *) echo "It does not seem the useradm service is up and running yet. Retrying..." ;;
-    esac
-    if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
-        echo "Retried $RETRIES times without success. Giving up."
-        exit 1
-    fi
-    RETRIES=$((RETRIES+1))
-    sleep 5
-done
-
-
-echo "Creating a new user..."
-UPLOAD_ARTIFACT=1
-PRINT_LOGIN_INFO=0
-PRINT_USER_EXISTS=1
-if [[ $ENTERPRISE -eq 1 ]]; then
-    TENANT_ID=$(docker exec \
-            ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
-            /usr/bin/tenantadm create-org \
-            --name=DemoOrganization \
-            --username=${USER} \
-            --password=${PASSWORD})
-    retval=$?
-    EXISTS_ERROR=1
-    if [[ $retval -eq 0 ]]; then
-        TENANT_ID=$(echo "$TENANT_ID" | tr -d '\r')
-    else
-        TENANT_ID=
-    fi
-else
-    docker exec \
-            ${DOCKER_COMPOSE_PROJECT_NAME}_mender-useradm_1 \
-            /usr/bin/useradm create-user \
-            --username=${USER} \
-            --password=${PASSWORD} \
-            > /dev/null
-    retval=$?
-    EXISTS_ERROR=5
-fi
-if [[ $retval -eq 0 ]]; then
-    PRINT_LOGIN_INFO=1
-elif [[ $retval -eq $EXISTS_ERROR ]]; then
-    # If the user exists, skip uploading the Artifact
-    UPLOAD_ARTIFACT=0
-    PRINT_USER_EXISTS=1
-else
-    echo "docker exec error: " $retval
-    exit $retval
-fi
-
-if [[ $ENTERPRISE -eq 1 ]] && [[ $CLIENT -eq 1 ]]; then
-    if [[ $(docker ps -q -f name=${DOCKER_COMPOSE_PROJECT_NAME}_mender-client_1 | wc -l) -gt 0 ]]; then
-        # If already launched, we don't need to do anything.
-        :
-    elif [[ -n "$TENANT_ID" ]]; then
-        TENANT_TOKEN=$(docker exec \
-                ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
-                /usr/bin/tenantadm get-tenant \
-                --id $TENANT_ID \
-                | jq -r .tenant_token)
-        # Now that we have the tenant token we can enable the client.
-        EXTRA_FILES="$EXTRA_FILES $CLIENT_FILES"
-        TENANT_TOKEN=$TENANT_TOKEN docker-compose \
-                -f docker-compose.yml \
-                -f docker-compose.storage.minio.yml \
-                -f docker-compose.demo.yml \
-                -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-                $EXTRA_FILES \
-                "$@" -d mender-client
-    else
-        echo "WARNING: Ignoring request to launch the Mender client."
-        echo "In Enterprise mode, the client can only be launched the first time the server"
-        echo "is started, when the first user is created. If you wish to start from scratch,"
-        echo "replace \`up\` with \`down -v\` first to reset, then rerun."
-    fi
-fi
-
-if [[ $UPLOAD_ARTIFACT -eq 1 ]]; then
-
-    RETRIES=0
-    until [[ -n "$JWT" ]]; do
-        JWT=$(curl --silent -k -X POST -u ${USER}:${PASSWORD}\
-            --fail\
-            --connect-timeout 5\
-            $MENDER_SERVER_URI/api/management/v1/useradm/auth/login)
-        retval=$?
-        if [[ $retval -ne 0 ]]; then
-            echo "Failed to get the 'JWT' token from the useradm service."
-            echo "This is needed in order to upload the demo Artifact."
-            echo "curl exit code: " $retval
-            echo "Retrying in 5..."
-        fi
-        if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
-            echo "Retried $RETRIES times without success. Giving up."
-            exit 1
-        fi
-        RETRIES=$((RETRIES+1))
-        sleep 5
-    done
-
-    cout=
-    RETRIES=0
-    while :
-    do
-        cout=$(curl --silent -k -X POST \
-                    --fail\
-                    --show-error\
-                    --connect-timeout 5\
-                    --header "Authorization: Bearer ${JWT}"\
-                    --form "size=${ARTIFACT_SIZE_BYTES}"\
-                    --form "artifact=@${DEMO_ARTIFACT_NAME}"\
-                    $MENDER_SERVER_URI/api/management/v1/deployments/artifacts)
-        retval=$?
-        if [[ $retval -ne 0 ]]; then
-            echo "Failed to upload the Artifact to the demo server. curl error code: " $retval
-            echo "Sleeping for 5 seconds before making another attempt..."
-        else
-            break
-        fi
-        if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
-            echo "Retried $RETRIES times without success. Giving up."
-            exit 1
-        fi
-        RETRIES=$((RETRIES+1))
-        sleep 5
-    done
-
-    errout=$(jq '.error' <<< $cout)
-
-    retval=$?
+    local retval=$?
     if [[ $retval -ne 0 ]]; then
-        echo "Failed to parse the json response from the Mender server"
-        echo "Response: "
-        echo $cout
+        echo "Failed to start docker compose"
         exit $retval
     fi
 
-    case "$errout" in
-    " Artifact not unique"*) ;;  # Artifact already exists on the server
-        "") ;;  # Artifact uploaded to the demo server
-        *) echo "Uploading the demo Artifact failed with error: " $errout
-        exit 1 ;;
-    esac
+    # Block until the useradm service returns an HTTP 4xx response
+    local RETRIES=0
+    while :
+    do
+        curl --silent -k -X POST -u ${USER}:${PASSWORD} \
+             --fail\
+             --connect-timeout 5\
+             $MENDER_SERVER_URI/api/management/v1/useradm/auth/login
+        retval=$?
+        case $retval in
+            0)  break ;; # User exists - continue.
+            22) break ;; # Server 400 error, ie, server is up - continue.
+            *) echo "It does not seem the useradm service is up and running yet. Retrying..." ;;
+        esac
+        if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
+            echo "Retried $RETRIES times without success. Giving up."
+            exit 1
+        fi
+        RETRIES=$((RETRIES+1))
+        sleep 5
+    done
+}
 
-fi
+create_user() {
+    echo "Creating a new user..."
 
-if [[ $PRINT_LOGIN_INFO -eq 1 ]]; then
-    echo "****************************************"
-    echo
-    echo "Username: mender-demo@example.com"
-    echo "Login password: ${PASSWORD}"
-    echo
-    echo "****************************************"
-    echo "Please keep the password available, it will not be cached by the login script."
-elif [[ $PRINT_USER_EXISTS -eq 1 ]]; then
-    echo "The user already exists. Skipping"
-    echo "If you don't remember the password, you can run '$(basename $0) down' to delete"
-    echo "the old user and rerun '$(basename $0) up' to create a new one."
-    echo "Please note that all data will be deleted from the old demo server."
-fi
+    if [[ $ENTERPRISE -eq 1 ]]; then
+        TENANT_ID=$(docker exec \
+                           ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
+                           /usr/bin/tenantadm create-org \
+                           --name=DemoOrganization \
+                           --username=${USER} \
+                           --password=${PASSWORD})
+        retval=$?
+        EXISTS_ERROR=1
+        if [[ $retval -eq 0 ]]; then
+            TENANT_ID=$(echo "$TENANT_ID" | tr -d '\r')
+        else
+            TENANT_ID=
+        fi
+    else
+        docker exec \
+               ${DOCKER_COMPOSE_PROJECT_NAME}_mender-useradm_1 \
+               /usr/bin/useradm create-user \
+               --username=${USER} \
+               --password=${PASSWORD} \
+               > /dev/null
+        retval=$?
+        EXISTS_ERROR=5
+    fi
+    if [[ $retval -eq 0 ]]; then
+        PRINT_LOGIN_INFO=1
+    elif [[ $retval -eq $EXISTS_ERROR ]]; then
+        # If the user exists, skip uploading the Artifact
+        UPLOAD_ARTIFACT=0
+        PRINT_USER_EXISTS=1
+    else
+        echo "docker exec error: " $retval
+        exit $retval
+    fi
+}
 
-echo "Mender demo server ready and running in the background. Copy credentials above and log in at $MENDER_SERVER_URI"
+maybe_launch_enterprise_client() {
+    if [[ $ENTERPRISE -eq 1 ]] && [[ $CLIENT -eq 1 ]]; then
+        if [[ $(docker ps -q -f name=${DOCKER_COMPOSE_PROJECT_NAME}_mender-client_1 | wc -l) -gt 0 ]]; then
+            # If already launched, we don't need to do anything.
+            :
+        elif [[ -n "$TENANT_ID" ]]; then
+            TENANT_TOKEN=$(docker exec \
+                                  ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
+                                  /usr/bin/tenantadm get-tenant \
+                                  --id $TENANT_ID \
+                               | jq -r .tenant_token)
+            # Now that we have the tenant token we can enable the client.
+            EXTRA_FILES="$EXTRA_FILES $CLIENT_FILES"
+            TENANT_TOKEN=$TENANT_TOKEN docker-compose \
+                        -f docker-compose.yml \
+                        -f docker-compose.storage.minio.yml \
+                        -f docker-compose.demo.yml \
+                        -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+                        $EXTRA_FILES \
+                        "${ARGS[@]}" -d mender-client
+        else
+            echo "WARNING: Ignoring request to launch the Mender client."
+            echo "In Enterprise mode, the client can only be launched the first time the server"
+            echo "is started, when the first user is created. If you wish to start from scratch,"
+            echo "replace \`up\` with \`down -v\` first to reset, then rerun."
+        fi
+    fi
+}
 
-echo "Press Enter to show the logs."
-echo "Press Ctrl-C to stop the backend and quit."
-read -se
+maybe_upload_artifact() {
+    if [[ $UPLOAD_ARTIFACT -eq 1 ]]; then
 
-docker-compose \
-    -f docker-compose.yml \
-    -f docker-compose.storage.minio.yml \
-    -f docker-compose.demo.yml \
-    -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-    $EXTRA_FILES \
-    logs --follow
+        local RETRIES=0
+        local retval=0
+        until [[ -n "$JWT" ]]; do
+            JWT=$(curl --silent -k -X POST -u ${USER}:${PASSWORD}\
+                       --fail\
+                       --connect-timeout 5\
+                       $MENDER_SERVER_URI/api/management/v1/useradm/auth/login)
+            retval=$?
+            if [[ $retval -ne 0 ]]; then
+                echo "Failed to get the 'JWT' token from the useradm service."
+                echo "This is needed in order to upload the demo Artifact."
+                echo "curl exit code: " $retval
+                echo "Retrying in 5..."
+            fi
+            if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
+                echo "Retried $RETRIES times without success. Giving up."
+                exit 1
+            fi
+            RETRIES=$((RETRIES+1))
+            sleep 5
+        done
+
+        local cout=
+        RETRIES=0
+        while :
+        do
+            cout=$(curl --silent -k -X POST \
+                        --fail\
+                        --show-error\
+                        --connect-timeout 5\
+                        --header "Authorization: Bearer ${JWT}"\
+                        --form "size=${ARTIFACT_SIZE_BYTES}"\
+                        --form "artifact=@${DEMO_ARTIFACT_NAME}"\
+                        $MENDER_SERVER_URI/api/management/v1/deployments/artifacts)
+            retval=$?
+            if [[ $retval -ne 0 ]]; then
+                echo "Failed to upload the Artifact to the demo server. curl error code: " $retval
+                echo "Sleeping for 5 seconds before making another attempt..."
+            else
+                break
+            fi
+            if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
+                echo "Retried $RETRIES times without success. Giving up."
+                exit 1
+            fi
+            RETRIES=$((RETRIES+1))
+            sleep 5
+        done
+
+        local errout=$(jq '.error' <<< $cout)
+
+        retval=$?
+        if [[ $retval -ne 0 ]]; then
+            echo "Failed to parse the json response from the Mender server"
+            echo "Response: "
+            echo $cout
+            exit $retval
+        fi
+
+        case "$errout" in
+            " Artifact not unique"*) ;;  # Artifact already exists on the server
+            "") ;;  # Artifact uploaded to the demo server
+            *) echo "Uploading the demo Artifact failed with error: " $errout
+               exit 1 ;;
+        esac
+
+    fi
+}
+
+print_info() {
+    if [[ $PRINT_LOGIN_INFO -eq 1 ]]; then
+        echo "****************************************"
+        echo
+        echo "Username: mender-demo@example.com"
+        echo "Login password: ${PASSWORD}"
+        echo
+        echo "****************************************"
+        echo "Please keep the password available, it will not be cached by the login script."
+    elif [[ $PRINT_USER_EXISTS -eq 1 ]]; then
+        echo "The user already exists. Skipping"
+        echo "If you don't remember the password, you can run '$(basename $0) down' to delete"
+        echo "the old user and rerun '$(basename $0) up' to create a new one."
+        echo "Please note that all data will be deleted from the old demo server."
+    fi
+
+    echo "Mender demo server ready and running in the background. Copy credentials above and log in at $MENDER_SERVER_URI"
+}
+
+wait_for_user() {
+    echo "Press Enter to show the logs."
+    echo "Press Ctrl-C to stop the backend and quit."
+    read -se
+}
+
+follow_logs() {
+    docker-compose \
+        -f docker-compose.yml \
+        -f docker-compose.storage.minio.yml \
+        -f docker-compose.demo.yml \
+        -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+        $EXTRA_FILES \
+        logs --follow
+}
+
+#-------------------------------------------------------------------------------
+#
+# Start execution
+#
+#-------------------------------------------------------------------------------
+
+check_tools
+parse_args "$@"
+enterprise_client_early_handling
+download_demo_artifact
+platform_dependent_setup
+pull_docker_containers
+env_setup
+run_non_up_commands
+
+# ------------------------------------------------------------------------------
+#
+#       The following code will only be run in the case ./demo up [[args]]
+#
+# ------------------------------------------------------------------------------
+trap exitfunc SIGINT
+trap exitfunc SIGTERM
+
+start_server
+create_user
+maybe_launch_enterprise_client
+maybe_upload_artifact
+print_info
+wait_for_user
+
+# ------------------------------------------------------------------------------
+#
+# We will only get here if the user presses Enter.
+#
+# ------------------------------------------------------------------------------
+follow_logs

--- a/demo
+++ b/demo
@@ -25,8 +25,15 @@ fi
 # that aren't allowed.
 DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME:-$(tr -d ".-" <<<${PWD##*/})}
 
-CLIENT=
-CLIENT_ARGS="-f docker-compose.client.yml -f docker-compose.client.demo.yml"
+EXTRA_FILES=
+
+CLIENT_FILES="-f docker-compose.client.yml -f docker-compose.client.demo.yml"
+ENTERPRISE_FILES="-f docker-compose.enterprise.yml"
+
+CLIENT=0
+ENTERPRISE=0
+RUN_UP=0
+
 # The demo environment has some external dependencies upon: curl, jq
 hash curl 2>/dev/null || { echo >&2 "The demo script requires the 'curl' tool to be available. Aborting."; exit 1; }
 hash jq 2>/dev/null || { echo >&2 "The demo script requires the 'jq' tool to be available. Aborting."; exit 1; }
@@ -35,17 +42,25 @@ while [ -n "$1" ]; do
     if [ "$1" = "--no-client" ]; then
         echo "--no-client argument is deprecated. Client is now disabled by default and can be enabled with --client"
     elif [ "$1" = "--client" ]; then
-        CLIENT="$CLIENT_ARGS"
+        CLIENT=1
         echo "-- enabling client container"
     elif [ "$1" = "-p" ] || [ "$1" = "--project-name" ]; then
         shift
         DOCKER_COMPOSE_PROJECT_NAME="$1"
     elif [ "$1" = "--kvm" ]; then
         echo "--kvm argument is deprecated. KVM will be enabled automatically if available"
+    elif [ "$1" = "--enterprise-testing" ]; then
+        # Undocumented flag, we use this for internal testing.
+        EXTRA_FILES="$EXTRA_FILES $ENTERPRISE_FILES"
+        ENTERPRISE=1
     elif [ "$1" = "down" ] || [ "$1" = "rm" ] || [ "$1" = "stop" ]; then
         # If the argument is either "down" or "rm", enable the client so that it
         # gets cleaned up, no matter if `--client` is passed or not.
-        CLIENT="$CLIENT_ARGS"
+        CLIENT=1
+        # Not a flag, so we should break out of the loop.
+        break
+    elif [ "$1" = "up" ]; then
+        RUN_UP=1
         # Not a flag, so we should break out of the loop.
         break
     else
@@ -53,6 +68,14 @@ while [ -n "$1" ]; do
     fi
     shift
 done
+
+if [ $CLIENT = 1 ]; then
+    if [ $ENTERPRISE != 1 -o $RUN_UP != 1 ]; then
+        # For Enterprise we need to take special care and fetch the tenant token
+        # first. For Open Source, we can add the client container immediately.
+        EXTRA_FILES="$EXTRA_FILES $CLIENT_FILES"
+    fi
+fi
 
 # Check if the demo-Artifact has been downloaded,
 # or if there exists a newer one in storage.
@@ -101,8 +124,7 @@ export MENDER_ARTIFACT_VERSION=$(awk -F':' '/mendersoftware\/mender-artifact/ {p
 export MENDER_VERSION=$(awk -F':' '/mendersoftware\/mender-client/ {print $3}' docker-compose.client.yml)
 export MENDER_DEB_PACKAGE_VERSION=$MENDER_VERSION
 
-RUN_UP=$(echo "$@" | grep '\bup\b')
-if [[ "$RUN_UP" == "" ]]; then
+if [ $RUN_UP != 1 ]; then
     # exec steals the shell, so unless docker-compose is not found,
     # exit 1 will never happen.
     exec docker-compose \
@@ -110,7 +132,7 @@ if [[ "$RUN_UP" == "" ]]; then
          -f docker-compose.storage.minio.yml \
          -f docker-compose.demo.yml \
          -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-         $CLIENT \
+         $EXTRA_FILES \
          "$@"
     exit 1
 fi
@@ -129,21 +151,21 @@ then
     MENDER_SERVER_URI="http://localhost"
 fi
 
-EXTRA_FILES=""
-EXTRA_FILES_NEXT=0
+USER_EXTRA_FILES=""
+USER_EXTRA_FILES_NEXT=0
 for i in "$@"; do
     case $i in
         -f=*|--file=*)
-            EXTRA_FILES="$EXTRA_FILES $i"
+            USER_EXTRA_FILES="$USER_EXTRA_FILES $i"
             ;;
         -f|--file)
-            EXTRA_FILES="$EXTRA_FILES $i"
-            EXTRA_FILES_NEXT=1
+            USER_EXTRA_FILES="$USER_EXTRA_FILES $i"
+            USER_EXTRA_FILES_NEXT=1
             ;;
         *)
-            if [ $EXTRA_FILES_NEXT -eq 1 ]; then
-                EXTRA_FILES="$EXTRA_FILES $i"
-                EXTRA_FILES_NEXT=0
+            if [ $USER_EXTRA_FILES_NEXT -eq 1 ]; then
+                USER_EXTRA_FILES="$USER_EXTRA_FILES $i"
+                USER_EXTRA_FILES_NEXT=0
             fi
             ;;
     esac
@@ -156,8 +178,8 @@ exitfunc() {
          -f docker-compose.storage.minio.yml \
          -f docker-compose.demo.yml \
          -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-         $CLIENT \
          $EXTRA_FILES \
+         $USER_EXTRA_FILES \
          stop)
     exit $retval
 }
@@ -172,7 +194,7 @@ docker-compose \
     -f docker-compose.storage.minio.yml \
     -f docker-compose.demo.yml \
     -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-    $CLIENT \
+    $EXTRA_FILES \
     "$@" -d
 
 retval=$?
@@ -211,45 +233,72 @@ done
 
 
 echo "Creating a new user..."
-UPLOAD_ARTIFACT="true"
-RETRIES=0
-while :
-do
-    docker exec \
-             ${DOCKER_COMPOSE_PROJECT_NAME}_mender-useradm_1 \
-             /usr/bin/useradm create-user \
-             --username=${USER} \
-             --password=${PASSWORD} \
-             > /dev/null
+UPLOAD_ARTIFACT=1
+PRINT_LOGIN_INFO=0
+PRINT_USER_EXISTS=1
+if [ $ENTERPRISE = 1 ]; then
+    TENANT_ID=$(docker exec \
+            ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
+            /usr/bin/tenantadm create-org \
+            --name=DemoOrganization \
+            --username=${USER} \
+            --password=${PASSWORD})
     retval=$?
-    case $retval in
-        0)
-            echo "****************************************"
-            echo
-            echo "Username: mender-demo@example.com"
-            echo  "Login password: ${PASSWORD}"
-            echo
-            echo "****************************************"
-            echo "Please keep the password available, it will not be cached by the login script."
-            break ;;
-        5) # If the user exists, skip uploading the Artifact
-            UPLOAD_ARTIFACT=""
-            echo "The user already exists. Skipping"
-            echo "If you don't remember the password, you can run '$(basename $0) down' to delete"
-            echo "the old user and rerun '$(basename $0) up' to create a new one."
-            echo "Please note that all data will be deleted from the old demo server."
-            break ;;
-        *) echo "docker exec error: " $retval; exit $retval ;;
-    esac
-    if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
-        echo "Retried $RETRIES times without success. Giving up."
-        exit 1
+    EXISTS_ERROR=1
+    if [ $retval -eq 0 ]; then
+        TENANT_ID=$(echo "$TENANT_ID" | tr -d '\r')
+    else
+        TENANT_ID=
     fi
-    RETRIES=$((RETRIES+1))
-    sleep 5
-done
+else
+    docker exec \
+            ${DOCKER_COMPOSE_PROJECT_NAME}_mender-useradm_1 \
+            /usr/bin/useradm create-user \
+            --username=${USER} \
+            --password=${PASSWORD} \
+            > /dev/null
+    retval=$?
+    EXISTS_ERROR=5
+fi
+if [ $retval -eq 0 ]; then
+    PRINT_LOGIN_INFO=1
+elif [ $retval -eq $EXISTS_ERROR ]; then
+    # If the user exists, skip uploading the Artifact
+    UPLOAD_ARTIFACT=0
+    PRINT_USER_EXISTS=1
+else
+    echo "docker exec error: " $retval
+    exit $retval
+fi
 
-if [[ $UPLOAD_ARTIFACT == "true" ]]; then
+if [ $ENTERPRISE = 1 -a $CLIENT = 1 ]; then
+    if [ $(docker ps -q -f name=${DOCKER_COMPOSE_PROJECT_NAME}_mender-client_1 | wc -l) -gt 0 ]; then
+        # If already launched, we don't need to do anything.
+        :
+    elif [ -n "$TENANT_ID" ]; then
+        TENANT_TOKEN=$(docker exec \
+                ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
+                /usr/bin/tenantadm get-tenant \
+                --id $TENANT_ID \
+                | jq -r .tenant_token)
+        # Now that we have the tenant token we can enable the client.
+        EXTRA_FILES="$EXTRA_FILES $CLIENT_FILES"
+        TENANT_TOKEN=$TENANT_TOKEN docker-compose \
+                -f docker-compose.yml \
+                -f docker-compose.storage.minio.yml \
+                -f docker-compose.demo.yml \
+                -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+                $EXTRA_FILES \
+                "$@" -d mender-client
+    else
+        echo "WARNING: Ignoring request to launch the Mender client."
+        echo "In Enterprise mode, the client can only be launched the first time the server"
+        echo "is started, when the first user is created. If you wish to start from scratch,"
+        echo "replace \`up\` with \`down -v\` first to reset, then rerun."
+    fi
+fi
+
+if [[ $UPLOAD_ARTIFACT -eq 1 ]]; then
 
     RETRIES=0
     until [[ "$JWT" != "" ]]; do
@@ -318,6 +367,21 @@ if [[ $UPLOAD_ARTIFACT == "true" ]]; then
 
 fi
 
+if [ $PRINT_LOGIN_INFO -eq 1 ]; then
+    echo "****************************************"
+    echo
+    echo "Username: mender-demo@example.com"
+    echo "Login password: ${PASSWORD}"
+    echo
+    echo "****************************************"
+    echo "Please keep the password available, it will not be cached by the login script."
+elif [ $PRINT_USER_EXISTS -eq 1 ]; then
+    echo "The user already exists. Skipping"
+    echo "If you don't remember the password, you can run '$(basename $0) down' to delete"
+    echo "the old user and rerun '$(basename $0) up' to create a new one."
+    echo "Please note that all data will be deleted from the old demo server."
+fi
+
 echo "Mender demo server ready and running in the background. Copy credentials above and log in at $MENDER_SERVER_URI"
 
 echo "Press Enter to show the logs."
@@ -329,5 +393,5 @@ docker-compose \
     -f docker-compose.storage.minio.yml \
     -f docker-compose.demo.yml \
     -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-    $CLIENT \
+    $EXTRA_FILES \
     logs --follow

--- a/demo
+++ b/demo
@@ -15,7 +15,7 @@ docker-compose, if you want to run the demo, run:
 EOF
 }
 
-if [ "$#" -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+if [[ "$#" -eq 0 ]] || [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
     usage
     exit 1
 fi
@@ -38,28 +38,28 @@ RUN_UP=0
 hash curl 2>/dev/null || { echo >&2 "The demo script requires the 'curl' tool to be available. Aborting."; exit 1; }
 hash jq 2>/dev/null || { echo >&2 "The demo script requires the 'jq' tool to be available. Aborting."; exit 1; }
 
-while [ -n "$1" ]; do
-    if [ "$1" = "--no-client" ]; then
+while [[ -n "$1" ]]; do
+    if [[ "$1" = "--no-client" ]]; then
         echo "--no-client argument is deprecated. Client is now disabled by default and can be enabled with --client"
-    elif [ "$1" = "--client" ]; then
+    elif [[ "$1" = "--client" ]]; then
         CLIENT=1
         echo "-- enabling client container"
-    elif [ "$1" = "-p" ] || [ "$1" = "--project-name" ]; then
+    elif [[ "$1" = "-p" ]] || [[ "$1" = "--project-name" ]]; then
         shift
         DOCKER_COMPOSE_PROJECT_NAME="$1"
-    elif [ "$1" = "--kvm" ]; then
+    elif [[ "$1" = "--kvm" ]]; then
         echo "--kvm argument is deprecated. KVM will be enabled automatically if available"
-    elif [ "$1" = "--enterprise-testing" ]; then
+    elif [[ "$1" = "--enterprise-testing" ]]; then
         # Undocumented flag, we use this for internal testing.
         EXTRA_FILES="$EXTRA_FILES $ENTERPRISE_FILES"
         ENTERPRISE=1
-    elif [ "$1" = "down" ] || [ "$1" = "rm" ] || [ "$1" = "stop" ]; then
+    elif [[ "$1" = "down" ]] || [[ "$1" = "rm" ]] || [[ "$1" = "stop" ]]; then
         # If the argument is either "down" or "rm", enable the client so that it
         # gets cleaned up, no matter if `--client` is passed or not.
         CLIENT=1
         # Not a flag, so we should break out of the loop.
         break
-    elif [ "$1" = "up" ]; then
+    elif [[ "$1" = "up" ]]; then
         RUN_UP=1
         # Not a flag, so we should break out of the loop.
         break
@@ -69,8 +69,8 @@ while [ -n "$1" ]; do
     shift
 done
 
-if [ $CLIENT = 1 ]; then
-    if [ $ENTERPRISE != 1 -o $RUN_UP != 1 ]; then
+if [[ $CLIENT -eq 1 ]]; then
+    if [[ $ENTERPRISE -eq 0 ]] || [[ $RUN_UP -eq 0 ]]; then
         # For Enterprise we need to take special care and fetch the tenant token
         # first. For Open Source, we can add the client container immediately.
         EXTRA_FILES="$EXTRA_FILES $CLIENT_FILES"
@@ -83,7 +83,7 @@ DEMO_ARTIFACT_NAME="mender-demo-artifact.mender"
 curl -q -sz mender-demo-artifact.mender -o mender-demo-artifact.mender https://dgsbl4vditpls.cloudfront.net/${DEMO_ARTIFACT_NAME}
 
 retval=$?
-if [ $retval -ne 0 ]; then
+if [[ $retval -ne 0 ]]; then
     echo "Failed to download the demo Artifact"
     exit $retval
 fi
@@ -124,7 +124,7 @@ export MENDER_ARTIFACT_VERSION=$(awk -F':' '/mendersoftware\/mender-artifact/ {p
 export MENDER_VERSION=$(awk -F':' '/mendersoftware\/mender-client/ {print $3}' docker-compose.client.yml)
 export MENDER_DEB_PACKAGE_VERSION=$MENDER_VERSION
 
-if [ $RUN_UP != 1 ]; then
+if [[ $RUN_UP -eq 0 ]]; then
     # exec steals the shell, so unless docker-compose is not found,
     # exit 1 will never happen.
     exec docker-compose \
@@ -139,7 +139,7 @@ fi
 
 # ------------------------------------------------------------------------------
 #
-#       The following code will only be run in the case ./demo up [args]
+#       The following code will only be run in the case ./demo up [[args]]
 #
 # ------------------------------------------------------------------------------
 
@@ -163,7 +163,7 @@ for i in "$@"; do
             USER_EXTRA_FILES_NEXT=1
             ;;
         *)
-            if [ $USER_EXTRA_FILES_NEXT -eq 1 ]; then
+            if [[ $USER_EXTRA_FILES_NEXT -eq 1 ]]; then
                 USER_EXTRA_FILES="$USER_EXTRA_FILES $i"
                 USER_EXTRA_FILES_NEXT=0
             fi
@@ -236,7 +236,7 @@ echo "Creating a new user..."
 UPLOAD_ARTIFACT=1
 PRINT_LOGIN_INFO=0
 PRINT_USER_EXISTS=1
-if [ $ENTERPRISE = 1 ]; then
+if [[ $ENTERPRISE -eq 1 ]]; then
     TENANT_ID=$(docker exec \
             ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
             /usr/bin/tenantadm create-org \
@@ -245,7 +245,7 @@ if [ $ENTERPRISE = 1 ]; then
             --password=${PASSWORD})
     retval=$?
     EXISTS_ERROR=1
-    if [ $retval -eq 0 ]; then
+    if [[ $retval -eq 0 ]]; then
         TENANT_ID=$(echo "$TENANT_ID" | tr -d '\r')
     else
         TENANT_ID=
@@ -260,9 +260,9 @@ else
     retval=$?
     EXISTS_ERROR=5
 fi
-if [ $retval -eq 0 ]; then
+if [[ $retval -eq 0 ]]; then
     PRINT_LOGIN_INFO=1
-elif [ $retval -eq $EXISTS_ERROR ]; then
+elif [[ $retval -eq $EXISTS_ERROR ]]; then
     # If the user exists, skip uploading the Artifact
     UPLOAD_ARTIFACT=0
     PRINT_USER_EXISTS=1
@@ -271,11 +271,11 @@ else
     exit $retval
 fi
 
-if [ $ENTERPRISE = 1 -a $CLIENT = 1 ]; then
-    if [ $(docker ps -q -f name=${DOCKER_COMPOSE_PROJECT_NAME}_mender-client_1 | wc -l) -gt 0 ]; then
+if [[ $ENTERPRISE -eq 1 ]] && [[ $CLIENT -eq 1 ]]; then
+    if [[ $(docker ps -q -f name=${DOCKER_COMPOSE_PROJECT_NAME}_mender-client_1 | wc -l) -gt 0 ]]; then
         # If already launched, we don't need to do anything.
         :
-    elif [ -n "$TENANT_ID" ]; then
+    elif [[ -n "$TENANT_ID" ]]; then
         TENANT_TOKEN=$(docker exec \
                 ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
                 /usr/bin/tenantadm get-tenant \
@@ -301,7 +301,7 @@ fi
 if [[ $UPLOAD_ARTIFACT -eq 1 ]]; then
 
     RETRIES=0
-    until [[ "$JWT" != "" ]]; do
+    until [[ -n "$JWT" ]]; do
         JWT=$(curl --silent -k -X POST -u ${USER}:${PASSWORD}\
             --fail\
             --connect-timeout 5\
@@ -367,7 +367,7 @@ if [[ $UPLOAD_ARTIFACT -eq 1 ]]; then
 
 fi
 
-if [ $PRINT_LOGIN_INFO -eq 1 ]; then
+if [[ $PRINT_LOGIN_INFO -eq 1 ]]; then
     echo "****************************************"
     echo
     echo "Username: mender-demo@example.com"
@@ -375,7 +375,7 @@ if [ $PRINT_LOGIN_INFO -eq 1 ]; then
     echo
     echo "****************************************"
     echo "Please keep the password available, it will not be cached by the login script."
-elif [ $PRINT_USER_EXISTS -eq 1 ]; then
+elif [[ $PRINT_USER_EXISTS -eq 1 ]]; then
     echo "The user already exists. Skipping"
     echo "If you don't remember the password, you can run '$(basename $0) down' to delete"
     echo "the old user and rerun '$(basename $0) up' to create a new one."

--- a/demo
+++ b/demo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -u
 
 ./verify-docker-versions
 
@@ -315,6 +315,7 @@ maybe_upload_artifact() {
 
         local RETRIES=0
         local retval=0
+        local JWT=
         until [[ -n "$JWT" ]]; do
             JWT=$(curl --silent -k -X POST -u ${USER}:${PASSWORD}\
                        --fail\

--- a/demo
+++ b/demo
@@ -69,6 +69,25 @@ while [[ -n "$1" ]]; do
     shift
 done
 
+EXTRA_FILES_NEXT=0
+for i in "$@"; do
+    case $i in
+        -f=*|--file=*)
+            EXTRA_FILES="$EXTRA_FILES $i"
+            ;;
+        -f|--file)
+            EXTRA_FILES="$EXTRA_FILES $i"
+            EXTRA_FILES_NEXT=1
+            ;;
+        *)
+            if [[ $EXTRA_FILES_NEXT -eq 1 ]]; then
+                EXTRA_FILES="$EXTRA_FILES $i"
+                EXTRA_FILES_NEXT=0
+            fi
+            ;;
+    esac
+done
+
 if [[ $CLIENT -eq 1 ]]; then
     if [[ $ENTERPRISE -eq 0 ]] || [[ $RUN_UP -eq 0 ]]; then
         # For Enterprise we need to take special care and fetch the tenant token
@@ -151,26 +170,6 @@ then
     MENDER_SERVER_URI="http://localhost"
 fi
 
-USER_EXTRA_FILES=""
-USER_EXTRA_FILES_NEXT=0
-for i in "$@"; do
-    case $i in
-        -f=*|--file=*)
-            USER_EXTRA_FILES="$USER_EXTRA_FILES $i"
-            ;;
-        -f|--file)
-            USER_EXTRA_FILES="$USER_EXTRA_FILES $i"
-            USER_EXTRA_FILES_NEXT=1
-            ;;
-        *)
-            if [[ $USER_EXTRA_FILES_NEXT -eq 1 ]]; then
-                USER_EXTRA_FILES="$USER_EXTRA_FILES $i"
-                USER_EXTRA_FILES_NEXT=0
-            fi
-            ;;
-    esac
-done
-
 # Make sure that the demo environment is brought down on SIGINT
 exitfunc() {
     retval=$(docker-compose \
@@ -179,7 +178,6 @@ exitfunc() {
          -f docker-compose.demo.yml \
          -p ${DOCKER_COMPOSE_PROJECT_NAME} \
          $EXTRA_FILES \
-         $USER_EXTRA_FILES \
          stop)
     exit $retval
 }

--- a/demo
+++ b/demo
@@ -180,12 +180,12 @@ run_non_up_commands() {
         # exec steals the shell, so unless docker-compose is not found,
         # exit 1 will never happen.
         exec docker-compose \
-             -f docker-compose.yml \
-             -f docker-compose.storage.minio.yml \
-             -f docker-compose.demo.yml \
-             -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-             $EXTRA_FILES \
-             "${ARGS[@]}"
+                -f docker-compose.yml \
+                -f docker-compose.storage.minio.yml \
+                -f docker-compose.demo.yml \
+                -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+                $EXTRA_FILES \
+                "${ARGS[@]}"
         exit 1
     fi
 }
@@ -193,12 +193,12 @@ run_non_up_commands() {
 # Make sure that the demo environment is brought down on SIGINT
 exitfunc() {
     retval=$(docker-compose \
-         -f docker-compose.yml \
-         -f docker-compose.storage.minio.yml \
-         -f docker-compose.demo.yml \
-         -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-         $EXTRA_FILES \
-         stop)
+            -f docker-compose.yml \
+            -f docker-compose.storage.minio.yml \
+            -f docker-compose.demo.yml \
+            -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+            $EXTRA_FILES \
+            stop)
     exit $retval
 }
 
@@ -206,12 +206,12 @@ start_server() {
     echo "Starting the Mender demo environment..."
 
     docker-compose \
-        -f docker-compose.yml \
-        -f docker-compose.storage.minio.yml \
-        -f docker-compose.demo.yml \
-        -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-        $EXTRA_FILES \
-        "${ARGS[@]}" -d
+            -f docker-compose.yml \
+            -f docker-compose.storage.minio.yml \
+            -f docker-compose.demo.yml \
+            -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+            $EXTRA_FILES \
+            "${ARGS[@]}" -d
 
     local retval=$?
     if [[ $retval -ne 0 ]]; then
@@ -224,9 +224,9 @@ start_server() {
     while :
     do
         curl --silent -k -X POST -u ${USER}:${PASSWORD} \
-             --fail\
-             --connect-timeout 5\
-             $MENDER_SERVER_URI/api/management/v1/useradm/auth/login
+                --fail \
+                --connect-timeout 5 \
+                $MENDER_SERVER_URI/api/management/v1/useradm/auth/login
         retval=$?
         case $retval in
             0)  break ;; # User exists - continue.
@@ -247,11 +247,11 @@ create_user() {
 
     if [[ $ENTERPRISE -eq 1 ]]; then
         TENANT_ID=$(docker exec \
-                           ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
-                           /usr/bin/tenantadm create-org \
-                           --name=DemoOrganization \
-                           --username=${USER} \
-                           --password=${PASSWORD})
+                ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
+                /usr/bin/tenantadm create-org \
+                --name=DemoOrganization \
+                --username=${USER} \
+                --password=${PASSWORD})
         retval=$?
         EXISTS_ERROR=1
         if [[ $retval -eq 0 ]]; then
@@ -261,11 +261,11 @@ create_user() {
         fi
     else
         docker exec \
-               ${DOCKER_COMPOSE_PROJECT_NAME}_mender-useradm_1 \
-               /usr/bin/useradm create-user \
-               --username=${USER} \
-               --password=${PASSWORD} \
-               > /dev/null
+                ${DOCKER_COMPOSE_PROJECT_NAME}_mender-useradm_1 \
+                /usr/bin/useradm create-user \
+                --username=${USER} \
+                --password=${PASSWORD} \
+                > /dev/null
         retval=$?
         EXISTS_ERROR=5
     fi
@@ -288,19 +288,19 @@ maybe_launch_enterprise_client() {
             :
         elif [[ -n "$TENANT_ID" ]]; then
             TENANT_TOKEN=$(docker exec \
-                                  ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
-                                  /usr/bin/tenantadm get-tenant \
-                                  --id $TENANT_ID \
-                               | jq -r .tenant_token)
+                    ${DOCKER_COMPOSE_PROJECT_NAME}_mender-tenantadm_1 \
+                    /usr/bin/tenantadm get-tenant \
+                    --id $TENANT_ID \
+                    | jq -r .tenant_token)
             # Now that we have the tenant token we can enable the client.
             EXTRA_FILES="$EXTRA_FILES $CLIENT_FILES"
             TENANT_TOKEN=$TENANT_TOKEN docker-compose \
-                        -f docker-compose.yml \
-                        -f docker-compose.storage.minio.yml \
-                        -f docker-compose.demo.yml \
-                        -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-                        $EXTRA_FILES \
-                        "${ARGS[@]}" -d mender-client
+                    -f docker-compose.yml \
+                    -f docker-compose.storage.minio.yml \
+                    -f docker-compose.demo.yml \
+                    -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+                    $EXTRA_FILES \
+                    "${ARGS[@]}" -d mender-client
         else
             echo "WARNING: Ignoring request to launch the Mender client."
             echo "In Enterprise mode, the client can only be launched the first time the server"
@@ -317,10 +317,10 @@ maybe_upload_artifact() {
         local retval=0
         local JWT=
         until [[ -n "$JWT" ]]; do
-            JWT=$(curl --silent -k -X POST -u ${USER}:${PASSWORD}\
-                       --fail\
-                       --connect-timeout 5\
-                       $MENDER_SERVER_URI/api/management/v1/useradm/auth/login)
+            JWT=$(curl --silent -k -X POST -u ${USER}:${PASSWORD} \
+                    --fail \
+                    --connect-timeout 5 \
+                    $MENDER_SERVER_URI/api/management/v1/useradm/auth/login)
             retval=$?
             if [[ $retval -ne 0 ]]; then
                 echo "Failed to get the 'JWT' token from the useradm service."
@@ -341,13 +341,13 @@ maybe_upload_artifact() {
         while :
         do
             cout=$(curl --silent -k -X POST \
-                        --fail\
-                        --show-error\
-                        --connect-timeout 5\
-                        --header "Authorization: Bearer ${JWT}"\
-                        --form "size=${ARTIFACT_SIZE_BYTES}"\
-                        --form "artifact=@${DEMO_ARTIFACT_NAME}"\
-                        $MENDER_SERVER_URI/api/management/v1/deployments/artifacts)
+                    --fail \
+                    --show-error \
+                    --connect-timeout 5 \
+                    --header "Authorization: Bearer ${JWT}" \
+                    --form "size=${ARTIFACT_SIZE_BYTES}" \
+                    --form "artifact=@${DEMO_ARTIFACT_NAME}" \
+                    $MENDER_SERVER_URI/api/management/v1/deployments/artifacts)
             retval=$?
             if [[ $retval -ne 0 ]]; then
                 echo "Failed to upload the Artifact to the demo server. curl error code: " $retval
@@ -410,12 +410,12 @@ wait_for_user() {
 
 follow_logs() {
     docker-compose \
-        -f docker-compose.yml \
-        -f docker-compose.storage.minio.yml \
-        -f docker-compose.demo.yml \
-        -p ${DOCKER_COMPOSE_PROJECT_NAME} \
-        $EXTRA_FILES \
-        logs --follow
+            -f docker-compose.yml \
+            -f docker-compose.storage.minio.yml \
+            -f docker-compose.demo.yml \
+            -p ${DOCKER_COMPOSE_PROJECT_NAME} \
+            $EXTRA_FILES \
+            logs --follow
 }
 
 #-------------------------------------------------------------------------------

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -11,3 +11,5 @@ services:
         stdin_open: true
         tty: true
         privileged: true
+        environment:
+          TENANT_TOKEN:

--- a/tests/tests/test_demo_artifact.py
+++ b/tests/tests/test_demo_artifact.py
@@ -27,6 +27,8 @@ from .mendertesting import MenderTesting
 class TestDemoArtifact(MenderTesting):
     """A simple class for testing the demo-Artifact upload."""
 
+    EXTRA_ARGS = []
+
     # NOTE - The password is set on a per test-basis,
     # as it is generated on the fly by the demo script.
     auth = authentication.Authentication(
@@ -55,14 +57,17 @@ class TestDemoArtifact(MenderTesting):
             test_env[
                 "DOCKER_COMPOSE_PROJECT_NAME"
             ] = running_custom_production_setup.name
+            args = [
+                "./demo",
+                "--client",
+                "-p",
+                running_custom_production_setup.name,
+            ]
+            args += self.EXTRA_ARGS
+            args.append("up")
+
             proc = subprocess.Popen(
-                [
-                    "./demo",
-                    "--client",
-                    "-p",
-                    running_custom_production_setup.name,
-                    "up",
-                ],
+                args,
                 cwd="..",
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
@@ -170,3 +175,10 @@ class TestDemoArtifact(MenderTesting):
         # the environment up a second time
         self.demo_artifact_upload(run_demo_script, exit_cond="The user already exists")
         logger.info("Finished")
+
+
+class TestDemoArtifactEnterprise(TestDemoArtifact):
+    """A subclass of the TestDemoArtifact class for testing the demo-Artifact
+    upload in Enterprise mode."""
+
+    EXTRA_ARGS = ["--enterprise-testing"]

--- a/tests/tests/test_demo_artifact.py
+++ b/tests/tests/test_demo_artifact.py
@@ -71,7 +71,7 @@ class TestDemoArtifact(MenderTesting):
             logger.info("Started the demo script")
             password = ""
             time.sleep(60)
-            for line in iter(proc.stdout.readline, ""):
+            for line in proc.stdout:
                 line = line.decode()
                 logger.info(line)
                 if exit_cond in line.strip():


### PR DESCRIPTION
```
commit cfa1b40e20b2afca30f52d45017524e4bd3dd8c6
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Jun 12 14:53:53 2020

    MEN-3606: Implement `./demo --enterprise-testing` flag.
    
    This required some significant refactoring because with Enterprise we
    have to launch the client in a separate step, instead of together as
    in Open Source. Took the opportunity to also clean up a little and
    standardize on number based truth values (both numbers and strings
    were used before).
    
    This is for internal testing and is not meant for consumption by
    users. The client launching is not fully aligned with the onboarding
    experience, because it instructs you to launch the client in a
    separate step, whereas the demo script can only launch the backend and
    the client in the same step (though inside the script it is two steps,
    as described above).
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 8f6a9880bbea1f4ad7eaf81dccf883804eac3974
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Jun 12 15:02:22 2020

    tests: Fix infinite loop when demo script returns error.
    
    This is not actually used in the tests, but I hit the bug while
    debugging, so figured I would fix it. The built-in fd reader is much
    smarter than an `iter` with a sentinel.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```