### PR TITLE
[changelog-generator] Accept "Changelog:All" and inline entries

### DIFF
--- a/extra/changelog-generator/changelog-generator
+++ b/extra/changelog-generator/changelog-generator
@@ -148,14 +148,20 @@ for repo in repos:
                 title = line
                 title_fetched = True
 
-            match = re.match("^ *Changelog: *(.*)", line, re.IGNORECASE)
-            if match:
+            match_changelog = re.match("^ *Changelog: *(.*)", line, re.IGNORECASE)
+            if match_changelog:
                 if log_entry:
                     add_entry(sha, log_entry)
                     log_entry = ""
                 log_entry_local = False
 
-                if re.match("^(Title|Commit|None)[ .]*$", match.group(1), re.IGNORECASE):
+                # The logic of this regex is:
+                # - Shall start with Title|Commit|All|None
+                # - From here, if [.:]+ then capture the rest in a new group
+                # - Else just expect end line
+                match_keyword = re.match("^(Title|Commit|All|None) *(?:[.:]+ *(.*)$|$)", match_changelog.group(1), re.IGNORECASE)
+
+                if match_keyword:
                     if exclusive_tag_seen:
                         # This doesn't really mean that the tags are exclusive, but rather that it
                         # is quite uncommon to see any of them together, and might indicate a
@@ -166,15 +172,20 @@ for repo in repos:
                                                  % sha)
                     exclusive_tag_seen = True
 
-                if re.match("^Title[ .]*$", match.group(1), re.IGNORECASE):
-                    log_entry = title
-                elif re.match("^Commit[ .]*$", match.group(1), re.IGNORECASE):
-                    log_entry_commit = True
-                elif re.match("^None[ .]*$", match.group(1), re.IGNORECASE):
-                    log_entry_commit = False
+                    if match_keyword.group(1).lower() == "title":
+                        log_entry = title
+                    elif match_keyword.group(1).lower() == "none":
+                        log_entry_commit = False
+                    elif match_keyword.group(1).lower() in ["commit", "all"]:
+                        log_entry_commit = True
+                        if match_keyword.group(2):
+                            # Log the rest of the line
+                            if commit_msg:
+                                commit_msg += "\n"
+                            commit_msg += match_keyword.group(2)
                 else:
                     log_entry_local = True
-                    log_entry = match.group(1)
+                    log_entry = match_changelog.group(1)
                 continue
 
             for cancel_expr in ["^ *Cancel-Changelog: *([0-9a-f]+).*",

--- a/extra/changelog-generator/test-changelog-generator
+++ b/extra/changelog-generator/test-changelog-generator
@@ -364,6 +364,24 @@ Acked-by: Test3 <test3@test.com>'
 
 ################################################################################
 
+git commit --allow-empty -m 'Changelog:All : Complete commit with inline entry N73
+
+Should be included N74'
+
+################################################################################
+
+git commit --allow-empty -m 'Changelog: All bugs fixed N75
+
+Should not be included N76'
+
+################################################################################
+
+git commit --allow-empty -m 'Changelog: AllSomethingElse N77
+
+Should not be included N78'
+
+################################################################################
+
 "$SRC_DIR/changelog-generator" --repo --sort-changelog HEAD > result.txt 2>stderr.txt || {
     echo "Script failed with $?"
     echo "--------"
@@ -381,6 +399,8 @@ _Released xx.xx.xxxx_
 
 #### test-changelog-generator.$$ (HEAD)
 
+* All bugs fixed N75
+* AllSomethingElse N77
 * As well as this. N34
 * Changelog commit with trailing dot. N53
 * Changelog title with trailing dot. N54
@@ -406,6 +426,8 @@ _Released xx.xx.xxxx_
   Only this line should show in changelog N72
 * Complete Fix for changelog N4
   Should be included N5
+* Complete commit with inline entry N73
+  Should be included N74
 * Fix for changelog N1
 * Jira duplicate (commit) N51
   More stuff. N52


### PR DESCRIPTION
This adds to changes to changelog-generator to accommodate commits by
dependabot, which use titles like "Changelog:All : Important info here"

See new entry in the test for better understanding.