### PR TITLE
[backend-integration] test auth requests submission with ECC keys 

### DIFF
--- a/backend-tests/tests/test_deployments.py
+++ b/backend-tests/tests/test_deployments.py
@@ -60,7 +60,7 @@ def make_pending_device(utoken, tenant_token=""):
 
     id_data = rand_id_data()
 
-    priv, pub = testutils.util.crypto.rsa_get_keypair()
+    priv, pub = testutils.util.crypto.get_keypair_rsa()
     new_set = create_authset(
         devauthd, devauthm, id_data, pub, priv, utoken, tenant_token=tenant_token
     )

--- a/backend-tests/tests/test_devauth.py
+++ b/backend-tests/tests/test_devauth.py
@@ -660,7 +660,11 @@ class TestDeviceMgmtBase:
         assert r.status_code == 404
 
         # check device list unmodified
-        r = da.with_auth(utoken).call("GET", deviceauth.URL_MGMT_DEVICES)
+        r = da.with_auth(utoken).call(
+            "GET",
+            deviceauth.URL_MGMT_DEVICES,
+            qs_params={"per_page": len(devs_authsets)},
+        )
 
         assert r.status_code == 200
         api_devs = r.json()
@@ -689,7 +693,9 @@ class TestDeviceMgmtBase:
             assert r.status_code == 200
             count = r.json()
 
-            ref_devs = filter_and_page_devs(devs_authsets, status=status)
+            ref_devs = filter_and_page_devs(
+                devs_authsets, per_page=len(devs_authsets), status=status
+            )
 
             ref_count = len(ref_devs)
 

--- a/backend-tests/tests/test_devauth.py
+++ b/backend-tests/tests/test_devauth.py
@@ -25,6 +25,7 @@ import testutils.api.tenantadm as tenantadm
 import testutils.api.deployments as deployments
 import testutils.api.inventory as inventory
 import testutils.util.crypto
+
 from testutils.common import (
     User,
     Device,
@@ -138,7 +139,7 @@ class TestPreauthBase:
         utoken = r.text
 
         # preauth device
-        priv, pub = testutils.util.crypto.rsa_get_keypair()
+        priv, pub = testutils.util.crypto.get_keypair_rsa()
         id_data = {"mac": "pretenditsamac"}
         body = deviceauth.preauth_req(id_data, pub)
         r = devauthm.with_auth(utoken).call("POST", deviceauth.URL_MGMT_DEVICES, body)
@@ -194,7 +195,7 @@ class TestPreauthBase:
         utoken = r.text
 
         # preauth duplicate device
-        priv, pub = testutils.util.crypto.rsa_get_keypair()
+        priv, pub = testutils.util.crypto.get_keypair_rsa()
         id_data = devices[0].id_data
         body = deviceauth.preauth_req(id_data, pub)
         r = devauthm.with_auth(utoken).call("POST", deviceauth.URL_MGMT_DEVICES, body)
@@ -236,7 +237,7 @@ class TestPreauth(TestPreauthBase):
         utoken = r.text
 
         # id data not json
-        priv, pub = testutils.util.crypto.rsa_get_keypair()
+        priv, pub = testutils.util.crypto.get_keypair_rsa()
         id_data = '{"mac": "foo"}'
         body = deviceauth.preauth_req(id_data, pub)
         r = devauthm.with_auth(utoken).call("POST", deviceauth.URL_MGMT_DEVICES, body)
@@ -385,7 +386,7 @@ def make_pending_device(utoken, num_auth_sets=1, tenant_token=""):
 
     dev = None
     for i in range(num_auth_sets):
-        priv, pub = testutils.util.crypto.rsa_get_keypair()
+        priv, pub = testutils.util.crypto.get_keypair_rsa()
         new_set = create_authset(
             devauthd, devauthm, id_data, pub, priv, utoken, tenant_token=tenant_token
         )
@@ -437,7 +438,7 @@ def make_rejected_device(utoken, num_auth_sets=1, tenant_token=""):
 def make_preauthd_device(utoken):
     devauthm = ApiClient(deviceauth.URL_MGMT)
 
-    priv, pub = testutils.util.crypto.rsa_get_keypair()
+    priv, pub = testutils.util.crypto.get_keypair_rsa()
     id_data = rand_id_data()
 
     body = deviceauth.preauth_req(id_data, pub)
@@ -465,7 +466,7 @@ def make_preauthd_device_with_pending(utoken, num_pending=1, tenant_token=""):
     dev = make_preauthd_device(utoken)
 
     for i in range(num_pending):
-        priv, pub = testutils.util.crypto.rsa_get_keypair()
+        priv, pub = testutils.util.crypto.get_keypair_rsa()
         aset = create_authset(
             devauthd,
             devauthm,

--- a/backend-tests/tests/test_devauth.py
+++ b/backend-tests/tests/test_devauth.py
@@ -159,6 +159,7 @@ class TestPreauthBase:
                 "id_data": rand_id_data(),
                 "keypair": crypto.get_keypair_ec(crypto.EC_CURVE_521),
             },
+            {"id_data": rand_id_data(), "keypair": crypto.get_keypair_ed(),},
         ]
 
         for d in devs:
@@ -341,6 +342,7 @@ def make_devs_with_authsets(user, tenant_token=""):
 
     keygen_rsa = lambda: crypto.get_keypair_rsa()
     keygen_ec_256 = lambda: crypto.get_keypair_ec(crypto.EC_CURVE_256)
+    keygen_ed = lambda: crypto.get_keypair_ed()
 
     # some vanilla 'pending' devices, single authset
     for _ in range(3):
@@ -351,6 +353,9 @@ def make_devs_with_authsets(user, tenant_token=""):
         dev = make_pending_device(utoken, keygen_ec_256, 1, tenant_token=tenant_token)
         devices.append(dev)
 
+    dev = make_pending_device(utoken, keygen_ed, 1, tenant_token=tenant_token)
+    devices.append(dev)
+
     # some pending devices with > 1 authsets
     for i in range(2):
         dev = make_pending_device(utoken, keygen_rsa, 3, tenant_token=tenant_token)
@@ -359,6 +364,9 @@ def make_devs_with_authsets(user, tenant_token=""):
     for i in range(2):
         dev = make_pending_device(utoken, keygen_ec_256, 3, tenant_token=tenant_token)
         devices.append(dev)
+
+    dev = make_pending_device(utoken, keygen_ed, 3, tenant_token=tenant_token)
+    devices.append(dev)
 
     # some 'accepted' devices, single authset
     for _ in range(3):
@@ -373,6 +381,11 @@ def make_devs_with_authsets(user, tenant_token=""):
         )
         devices.append(dev)
 
+    dev = make_accepted_device_with_multiple_authsets(
+        utoken, keygen_ed, 1, tenant_token=tenant_token
+    )
+    devices.append(dev)
+
     # some 'accepted' devices with >1 authsets
     for _ in range(2):
         dev = make_accepted_device_with_multiple_authsets(
@@ -386,6 +399,11 @@ def make_devs_with_authsets(user, tenant_token=""):
         )
         devices.append(dev)
 
+    dev = make_accepted_device_with_multiple_authsets(
+        utoken, keygen_ed, 2, tenant_token=tenant_token
+    )
+    devices.append(dev)
+
     # some rejected devices
     for _ in range(2):
         dev = make_rejected_device(utoken, keygen_rsa, 3, tenant_token=tenant_token)
@@ -395,11 +413,17 @@ def make_devs_with_authsets(user, tenant_token=""):
         dev = make_rejected_device(utoken, keygen_ec_256, 2, tenant_token=tenant_token)
         devices.append(dev)
 
+    dev = make_rejected_device(utoken, keygen_ed, 2, tenant_token=tenant_token)
+    devices.append(dev)
+
     # preauth'd devices
     dev = make_preauthd_device(utoken, keygen_rsa)
     devices.append(dev)
 
     dev = make_preauthd_device(utoken, keygen_ec_256)
+    devices.append(dev)
+
+    dev = make_preauthd_device(utoken, keygen_ed)
     devices.append(dev)
 
     # preauth'd devices with extra 'pending' sets
@@ -411,6 +435,11 @@ def make_devs_with_authsets(user, tenant_token=""):
 
     dev = make_preauthd_device_with_pending(
         utoken, keygen_ec_256, num_pending=2, tenant_token=tenant_token
+    )
+    devices.append(dev)
+
+    dev = make_preauthd_device_with_pending(
+        utoken, keygen_ed, num_pending=2, tenant_token=tenant_token
     )
     devices.append(dev)
 
@@ -1520,6 +1549,7 @@ class TestAuthReqBase:
                 "id_data": rand_id_data(),
                 "keypair": crypto.get_keypair_ec(crypto.EC_CURVE_521),
             },
+            {"id_data": rand_id_data(), "keypair": crypto.get_keypair_ed(),},
         ]
 
         r = uadm.call("POST", useradm.URL_LOGIN, auth=(user.name, user.pwd))

--- a/backend-tests/tests/test_devauth.py
+++ b/backend-tests/tests/test_devauth.py
@@ -159,7 +159,7 @@ class TestPreauthBase:
         aset = api_dev["auth_sets"][0]
 
         assert aset["identity_data"] == id_data
-        assert testutils.util.crypto.rsa_compare_keys(aset["pubkey"], pub)
+        assert testutils.util.crypto.compare_keys(aset["pubkey"], pub)
         assert aset["status"] == "preauthorized"
 
         # actual device can obtain auth token
@@ -215,7 +215,7 @@ class TestPreauthBase:
 
         assert len(existing["auth_sets"]) == 1
         aset = existing["auth_sets"][0]
-        assert testutils.util.crypto.rsa_compare_keys(aset["pubkey"], devices[0].pubkey)
+        assert testutils.util.crypto.compare_keys(aset["pubkey"], devices[0].pubkey)
         assert aset["status"] == "pending"
 
 
@@ -295,7 +295,7 @@ class TestPreauthEnterprise(TestPreauthBase):
 
             assert len(ad["auth_sets"]) == 1
             aset = ad["auth_sets"][0]
-            assert testutils.util.crypto.rsa_compare_keys(
+            assert testutils.util.crypto.compare_keys(
                 aset["pubkey"], orig_device.pubkey
             )
 
@@ -693,7 +693,7 @@ class TestDeviceMgmtBase:
             aset = [
                 a
                 for a in dev.authsets
-                if testutils.util.crypto.rsa_compare_keys(a.pubkey, api_aset["pubkey"])
+                if testutils.util.crypto.compare_keys(a.pubkey, api_aset["pubkey"])
             ]
             assert len(aset) == 1
             aset = aset[0]
@@ -1255,7 +1255,7 @@ def filter_and_page_devs(devs, page=None, per_page=None, status=None):
 def compare_aset(authset, api_authset):
     assert authset.id == api_authset["id"]
     assert authset.id_data == api_authset["identity_data"]
-    assert testutils.util.crypto.rsa_compare_keys(authset.pubkey, api_authset["pubkey"])
+    assert testutils.util.crypto.compare_keys(authset.pubkey, api_authset["pubkey"])
     assert authset.status == api_authset["status"]
 
 

--- a/backend-tests/tests/test_inventory.py
+++ b/backend-tests/tests/test_inventory.py
@@ -22,6 +22,7 @@ import testutils.api.useradm as useradm
 import testutils.api.inventory as inventory
 import testutils.api.tenantadm as tenantadm
 import testutils.util.crypto
+
 from testutils.common import (
     User,
     Device,
@@ -93,7 +94,7 @@ def make_pending_device(utoken, tenant_token=""):
 
     id_data = rand_id_data()
 
-    priv, pub = testutils.util.crypto.rsa_get_keypair()
+    priv, pub = testutils.util.crypto.get_keypair_rsa()
     new_set = create_authset(
         devauthd, devauthm, id_data, pub, priv, utoken, tenant_token=tenant_token
     )

--- a/testutils/api/deviceauth.py
+++ b/testutils/api/deviceauth.py
@@ -48,5 +48,5 @@ def auth_req(id_data, pubkey, privkey, tenant_token=""):
         "tenant_token": tenant_token,
         "pubkey": pubkey,
     }
-    signature = testutils.util.crypto.rsa_sign_data(json.dumps(payload), privkey)
+    signature = testutils.util.crypto.auth_req_sign(json.dumps(payload), privkey)
     return payload, {"X-MEN-Signature": signature}

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -86,7 +86,7 @@ class Tenant:
 
 def create_random_authset(dauthd1, dauthm, utoken, tenant_token=""):
     """ create_device with random id data and keypair"""
-    priv, pub = testutils.util.crypto.rsa_get_keypair()
+    priv, pub = testutils.util.crypto.get_keypair_rsa()
     mac = ":".join(["{:02x}".format(random.randint(0x00, 0xFF), "x") for i in range(6)])
     id_data = {"mac": mac}
 
@@ -210,7 +210,7 @@ def rand_id_data():
 def make_pending_device(dauthd1, dauthm, utoken, tenant_token=""):
     id_data = rand_id_data()
 
-    priv, pub = testutils.util.crypto.rsa_get_keypair()
+    priv, pub = testutils.util.crypto.get_keypair_rsa()
     new_set = create_authset(
         dauthd1, dauthm, id_data, pub, priv, utoken, tenant_token=tenant_token
     )

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -107,7 +107,7 @@ def create_authset(dauthd1, dauthm, id_data, pubkey, privkey, utoken, tenant_tok
     aset = [
         a
         for a in api_dev["auth_sets"]
-        if testutils.util.crypto.rsa_compare_keys(a["pubkey"], pubkey)
+        if testutils.util.crypto.compare_keys(a["pubkey"], pubkey)
     ]
     assert len(aset) == 1, str(aset)
 

--- a/testutils/util/crypto.py
+++ b/testutils/util/crypto.py
@@ -16,7 +16,17 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import padding
+
+# enum for EC curve types to avoid naming confusion, e.g.
+# NIST P-256 (FIPS 186 standard name) ==
+# golang's elliptic.P256 ==
+# hazmat's ec.SECP256R1
+EC_CURVE_224 = ec.SECP224R1
+EC_CURVE_256 = ec.SECP256R1
+EC_CURVE_384 = ec.SECP384R1
+EC_CURVE_521 = ec.SECP521R1
 
 
 def rsa_compare_keys(a, b):
@@ -30,11 +40,20 @@ def rsa_compare_keys(a, b):
     return a_b64 == b_b64
 
 
-def rsa_get_keypair():
+def get_keypair_rsa(public_exponent=65537, key_size=1024):
     private_key = rsa.generate_private_key(
-        public_exponent=65537, key_size=1024, backend=default_backend()
+        public_exponent=public_exponent, key_size=key_size, backend=default_backend(),
     )
-    public_key = private_key.public_key()
+
+    return keypair_pem(private_key, private_key.public_key())
+
+
+def get_keypair_ec(curve):
+    private_key = ec.generate_private_key(curve=curve, backend=default_backend(),)
+    return keypair_pem(private_key, private_key.public_key())
+
+
+def keypair_pem(private_key, public_key):
     private_pem = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
@@ -47,15 +66,33 @@ def rsa_get_keypair():
     return private_pem.decode(), public_pem.decode()
 
 
-def rsa_sign_data(data, private_key):
-    _private_key = serialization.load_pem_private_key(
-        private_key if isinstance(private_key, bytes) else private_key.encode(),
-        password=None,
-        backend=default_backend(),
-    )
-    signature = _private_key.sign(
+def auth_req_sign_rsa(data, private_key):
+    signature = private_key.sign(
         data if isinstance(data, bytes) else data.encode(),
         padding.PKCS1v15(),
         hashes.SHA256(),
     )
     return b64encode(signature).decode()
+
+
+def auth_req_sign_ec(data, private_key):
+    signature = private_key.sign(
+        data if isinstance(data, bytes) else data.encode(), ec.ECDSA(hashes.SHA256()),
+    )
+    # signature is already an ANSI-X9-62 DER sequence (as bytes)
+    return b64encode(signature).decode()
+
+
+def auth_req_sign(data, private_key):
+    key = serialization.load_pem_private_key(
+        private_key if isinstance(private_key, bytes) else private_key.encode(),
+        password=None,
+        backend=default_backend(),
+    )
+
+    if isinstance(key, rsa.RSAPrivateKey):
+        return auth_req_sign_rsa(data, key)
+    elif isinstance(key, ec.EllipticCurvePrivateKey):
+        return auth_req_sign_ec(data, key)
+    else:
+        raise RuntimeError("unsupported key type")

--- a/testutils/util/crypto.py
+++ b/testutils/util/crypto.py
@@ -17,6 +17,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives.asymmetric import padding
 
 # enum for EC curve types to avoid naming confusion, e.g.
@@ -53,6 +54,11 @@ def get_keypair_ec(curve):
     return keypair_pem(private_key, private_key.public_key())
 
 
+def get_keypair_ed():
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    return keypair_pem(private_key, private_key.public_key())
+
+
 def keypair_pem(private_key, public_key):
     private_pem = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -83,6 +89,11 @@ def auth_req_sign_ec(data, private_key):
     return b64encode(signature).decode()
 
 
+def auth_req_sign_ed(data, private_key):
+    signature = private_key.sign(data if isinstance(data, bytes) else data.encode(),)
+    return b64encode(signature).decode()
+
+
 def auth_req_sign(data, private_key):
     key = serialization.load_pem_private_key(
         private_key if isinstance(private_key, bytes) else private_key.encode(),
@@ -94,5 +105,7 @@ def auth_req_sign(data, private_key):
         return auth_req_sign_rsa(data, key)
     elif isinstance(key, ec.EllipticCurvePrivateKey):
         return auth_req_sign_ec(data, key)
+    elif isinstance(key, ed25519.Ed25519PrivateKey):
+        return auth_req_sign_ed(data, key)
     else:
         raise RuntimeError("unsupported key type")

--- a/testutils/util/crypto.py
+++ b/testutils/util/crypto.py
@@ -29,7 +29,7 @@ EC_CURVE_384 = ec.SECP384R1
 EC_CURVE_521 = ec.SECP521R1
 
 
-def rsa_compare_keys(a, b):
+def compare_keys(a, b):
     """
     Compares the base64 encoded DER structure of the keys
     """


### PR DESCRIPTION
most of it deals with testing ECC keys in auth req submission:
https://tracker.mender.io/browse/MEN-3732

but the last 2 commits handle adding ECC keys to preauth-specific scenarios:
https://tracker.mender.io/browse/MEN-3731

needs https://github.com/mendersoftware/deviceauth/pull/369
Link: https://gitlab.com/Northern.tech/Mender/mender-qa/-/pipelines/162751532


