### PR TITLE
Fix TestUpdateModules for old Mender client

### DIFF
--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -65,7 +65,7 @@ class TestUpdateModules(MenderTesting):
             deploy.check_expected_statistics(deployment_id, "failure", 1)
             deploy.check_expected_status("finished", deployment_id)
 
-            output = mender_device.run("mender -show-artifact").strip()
+            output = mender_device.run("mender -no-syslog -show-artifact").strip()
             assert output == "original"
 
             # Remove path block.
@@ -83,7 +83,7 @@ class TestUpdateModules(MenderTesting):
                 ).strip()
                 assert output == file_and_content
 
-            output = mender_device.run("mender -show-artifact").strip()
+            output = mender_device.run("mender -no-syslog -show-artifact").strip()
             assert output == expected_image_id
 
         finally:
@@ -115,7 +115,7 @@ class TestUpdateModules(MenderTesting):
             deploy.check_expected_status("finished", deployment_id)
             deploy.check_expected_statistics(deployment_id, "failure", 1)
 
-            output = mender_device.run("mender -show-artifact").strip()
+            output = mender_device.run("mender -no-syslog -show-artifact").strip()
             assert output == "original"
 
             output = standard_setup_one_docker_client_bootstrapped.get_logs_of_service(


### PR DESCRIPTION
For Mender client 2.2.x the warnings are printed into stdout, so the
test receives the warning of not being able to connect to syslog
together with the desired output.