### PR TITLE
MEN-3819 changed mac ipaddress derivation to use connectivity information

### DIFF
--- a/demo
+++ b/demo
@@ -126,7 +126,7 @@ download_demo_artifact() {
 platform_dependent_setup() {
     if [[ "$OSTYPE" == "darwin"* ]]; then
         ARTIFACT_SIZE_BYTES=$(stat -f %z ${DEMO_ARTIFACT_NAME}) # BSD is not GNU -_-
-        export GATEWAY_IP=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -1)
+        export GATEWAY_IP=$(ifconfig $(netstat -rn | grep default | head -1 | awk '{print($NF)}') inet | grep -F 'inet '| sed -e 's/.*inet \([^ ]*\) .*/\1/')
     else
         ARTIFACT_SIZE_BYTES=$(stat -c %s ${DEMO_ARTIFACT_NAME})
         export GATEWAY_IP=$(ip route get 1 | awk '{print $7;exit}')


### PR DESCRIPTION
this assumes, the host system has had some outside connectivity

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>