### PR TITLE
MEN-2894: Make integration test which tests old clients with new server

### DIFF
--- a/backend-tests/tests/test_account_suspension.py
+++ b/backend-tests/tests/test_account_suspension.py
@@ -69,7 +69,7 @@ def tenants_users_devices(tenants, mongo):
 
 class TestAccountSuspensionEnterprise:
     def test_user_cannot_log_in(self, tenants):
-        tc = ApiClient(tenantadm.URL_INTERNAL)
+        tc = ApiClient(tenantadm.URL_INTERNAL, host=tenantadm.HOST, schema="http://")
 
         uc = ApiClient(useradm.URL_MGMT)
 
@@ -106,7 +106,7 @@ class TestAccountSuspensionEnterprise:
             assert r.status_code == 200
 
     def test_authenticated_user_is_rejected(self, tenants):
-        tc = ApiClient(tenantadm.URL_INTERNAL)
+        tc = ApiClient(tenantadm.URL_INTERNAL, host=tenantadm.HOST, schema="http://")
         uc = ApiClient(useradm.URL_MGMT)
         dc = ApiClient(deviceauth.URL_MGMT)
 
@@ -141,7 +141,7 @@ class TestAccountSuspensionEnterprise:
         dacd = ApiClient(deviceauth.URL_DEVICES)
         devauthm = ApiClient(deviceauth.URL_MGMT)
         uc = ApiClient(useradm.URL_MGMT)
-        tc = ApiClient(tenantadm.URL_INTERNAL)
+        tc = ApiClient(tenantadm.URL_INTERNAL, host=tenantadm.HOST, schema="http://")
 
         # accept a dev
         device = tenants_users_devices[0].devices[0]
@@ -182,7 +182,7 @@ class TestAccountSuspensionEnterprise:
         dacd = ApiClient(deviceauth.URL_DEVICES)
         devauthm = ApiClient(deviceauth.URL_MGMT)
         uc = ApiClient(useradm.URL_MGMT)
-        tc = ApiClient(tenantadm.URL_INTERNAL)
+        tc = ApiClient(tenantadm.URL_INTERNAL, host=tenantadm.HOST, schema="http://")
         dc = ApiClient(deployments.URL_DEVICES)
 
         # accept a dev

--- a/backend-tests/tests/test_create_org.py
+++ b/backend-tests/tests/test_create_org.py
@@ -40,10 +40,14 @@ class TestCreateOrganizationEnterprise:
         stripeutils.delete_cust(cust["id"])
 
     def test_success(self, clean_migrated_mongo):
-        tc = ApiClient(tenantadm.URL_MGMT)
+        tc = ApiClient(tenantadm.URL_MGMT, host=tenantadm.HOST, schema="http://")
         uc = ApiClient(useradm.URL_MGMT)
-        tenantadmi = ApiClient(tenantadm.URL_INTERNAL)
-        devauthi = ApiClient(deviceauth_v1.URL_INTERNAL)
+        tenantadmi = ApiClient(
+            tenantadm.URL_INTERNAL, host=tenantadm.HOST, schema="http://"
+        )
+        devauthi = ApiClient(
+            deviceauth_v1.URL_INTERNAL, host=deviceauth_v1.HOST, schema="http://"
+        )
 
         logging.info("Starting TestCreateOrganizationEnterprise")
 
@@ -99,10 +103,14 @@ class TestCreateOrganizationEnterprise:
         self._cleanup_stripe(email)
 
     def test_success_with_plan(self, clean_migrated_mongo):
-        tc = ApiClient(tenantadm.URL_MGMT)
+        tc = ApiClient(tenantadm.URL_MGMT, host=tenantadm.HOST, schema="http://")
         uc = ApiClient(useradm.URL_MGMT)
-        tenantadmi = ApiClient(tenantadm.URL_INTERNAL)
-        devauthi = ApiClient(deviceauth_v1.URL_INTERNAL)
+        tenantadmi = ApiClient(
+            tenantadm.URL_INTERNAL, host=tenantadm.HOST, schema="http://"
+        )
+        devauthi = ApiClient(
+            deviceauth_v1.URL_INTERNAL, host=deviceauth_v1.HOST, schema="http://"
+        )
 
         logging.info("Starting TestCreateOrganizationEnterprise")
 
@@ -154,7 +162,7 @@ class TestCreateOrganizationEnterprise:
         self._cleanup_stripe(email)
 
     def test_duplicate_organization_name(self, clean_migrated_mongo):
-        tc = ApiClient(tenantadm.URL_MGMT)
+        tc = ApiClient(tenantadm.URL_MGMT, host=tenantadm.HOST, schema="http://")
 
         tenant = "tenant{}".format(randstr())
         email = "some.user@{}.com".format(tenant)
@@ -187,7 +195,7 @@ class TestCreateOrganizationEnterprise:
         self._cleanup_stripe(email2)
 
     def test_duplicate_email(self, clean_migrated_mongo):
-        tc = ApiClient(tenantadm.URL_MGMT)
+        tc = ApiClient(tenantadm.URL_MGMT, host=tenantadm.HOST, schema="http://")
 
         tenant = "tenant{}".format(randstr())
         email = "some.user@{}.com".format(tenant)
@@ -219,7 +227,7 @@ class TestCreateOrganizationEnterprise:
         self._cleanup_stripe(email)
 
     def test_plan_invalid(self, clean_migrated_mongo):
-        tc = ApiClient(tenantadm.URL_MGMT)
+        tc = ApiClient(tenantadm.URL_MGMT, host=tenantadm.HOST, schema="http://")
         payload = {
             "request_id": "123456",
             "organization": "tenant-foo",

--- a/backend-tests/tests/test_devauth.py
+++ b/backend-tests/tests/test_devauth.py
@@ -95,7 +95,7 @@ def devices(clean_migrated_mongo, user):
 @pytest.yield_fixture(scope="function")
 def tenants_users(clean_migrated_mongo_mt):
     cli = CliTenantadm()
-    api = ApiClient(tenantadm.URL_INTERNAL)
+    api = ApiClient(tenantadm.URL_INTERNAL, host=tenantadm.HOST, schema="http://")
 
     names = ["tenant1", "tenant2"]
     tenants = []
@@ -618,9 +618,6 @@ class TestDeviceMgmtBase:
                 devs_authsets, page=page, per_page=per_page, status=status
             )
 
-            print("XXXXXXXXXXXX api_devs {}\n".format(api_devs))
-            print("XXXXXXXXXXXX ref_devs {}\n".format(ref_devs))
-
             self._compare_devs(ref_devs, api_devs)
 
     def do_test_get_device(self, devs_authsets, user):
@@ -856,7 +853,9 @@ class TestDeviceMgmtEnterprise(TestDeviceMgmtBase):
             self.do_test_device_count(t.devices, t.users[0])
 
     def test_limits_max_devices(self, tenants_devs_authsets):
-        devauthi = ApiClient(deviceauth.URL_INTERNAL)
+        devauthi = ApiClient(
+            deviceauth.URL_INTERNAL, host=deviceauth.HOST, schema="http://"
+        )
         devauthm = ApiClient(deviceauth.URL_MGMT)
         devauthd = ApiClient(deviceauth.URL_DEVICES)
         useradmm = ApiClient(useradm.URL_MGMT)

--- a/backend-tests/tests/test_inventory.py
+++ b/backend-tests/tests/test_inventory.py
@@ -795,7 +795,9 @@ class TestDeviceFilteringEnterprise:
                 "status_code": 400,
             },
         ]
-        invm_v2 = ApiClient(inventory_v2.URL_INTERNAL)
+        invm_v2 = ApiClient(
+            inventory_v2.URL_INTERNAL, host=inventory_v2.HOST, schema="http://"
+        )
 
         for test_case in test_cases:
             self.logger.info("Running test case: %s" % test_case["name"])

--- a/backend-tests/tests/test_tenantadm_v2.py
+++ b/backend-tests/tests/test_tenantadm_v2.py
@@ -35,8 +35,8 @@ import testutils.api.tenantadm_v2 as tenantadm_v2
 import testutils.integration.stripe as stripeutils
 from testutils.api.client import ApiClient
 
-api_tadm_v1 = ApiClient(tenantadm_v1.URL_MGMT)
-api_tadm_v2 = ApiClient(tenantadm_v2.URL_MGMT)
+api_tadm_v1 = ApiClient(tenantadm_v1.URL_MGMT, host=tenantadm_v1.HOST, schema="http://")
+api_tadm_v2 = ApiClient(tenantadm_v2.URL_MGMT, host=tenantadm_v2.HOST, schema="http://")
 
 api_uadm = ApiClient(useradm.URL_MGMT)
 stripe.api_key = os.environ.get("TENANTADM_STRIPE_API_KEY")

--- a/backend-tests/tests/test_useradm_enterprise.py
+++ b/backend-tests/tests/test_useradm_enterprise.py
@@ -55,7 +55,7 @@ def tenants_users(clean_migrated_mongo):
     tenants = []
 
     cli = CliTenantadm()
-    api = ApiClient(tenantadm.URL_INTERNAL)
+    api = ApiClient(tenantadm.URL_INTERNAL, host=tenantadm.HOST, schema="http://")
 
     for n in ["tenant1", "tenant2"]:
         username = "user%d@%s.com"  # user[12]@tenant[12].com

--- a/demo
+++ b/demo
@@ -126,7 +126,7 @@ download_demo_artifact() {
 platform_dependent_setup() {
     if [[ "$OSTYPE" == "darwin"* ]]; then
         ARTIFACT_SIZE_BYTES=$(stat -f %z ${DEMO_ARTIFACT_NAME}) # BSD is not GNU -_-
-        export GATEWAY_IP=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -1)
+        export GATEWAY_IP=$(ifconfig $(netstat -rn | grep default | head -1 | awk '{print($NF)}') inet | grep -F 'inet '| sed -e 's/.*inet \([^ ]*\) .*/\1/')
     else
         ARTIFACT_SIZE_BYTES=$(stat -c %s ${DEMO_ARTIFACT_NAME})
         export GATEWAY_IP=$(ip route get 1 | awk '{print $7;exit}')

--- a/extra/integration-testing/docker-compose.compat.yml
+++ b/extra/integration-testing/docker-compose.compat.yml
@@ -1,0 +1,44 @@
+version: '2.1'
+services:
+  #
+  # Setup including older clients: 2.3 -> 2.0
+  #
+  mender-client-2-3:
+    image: mendersoftware/mender-client-qemu:2.3
+    networks:
+       - mender
+    stdin_open: true
+    tty: true
+    privileged: true
+    environment:
+      TENANT_TOKEN: ""
+
+  mender-client-2-2:
+    image: mendersoftware/mender-client-qemu:2.2
+    networks:
+       - mender
+    stdin_open: true
+    tty: true
+    privileged: true
+    environment:
+      TENANT_TOKEN: ""
+
+  mender-client-2-1:
+    image: mendersoftware/mender-client-qemu:2.1
+    networks:
+       - mender
+    stdin_open: true
+    tty: true
+    privileged: true
+    environment:
+      TENANT_TOKEN: ""
+
+  mender-client-2-0:
+    image: mendersoftware/mender-client-qemu:2.0
+    networks:
+       - mender
+    stdin_open: true
+    tty: true
+    privileged: true
+    environment:
+      TENANT_TOKEN: ""

--- a/tests/tests/test_compat.py
+++ b/tests/tests/test_compat.py
@@ -1,0 +1,296 @@
+# Copyright 2020 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import pytest
+import time
+
+from datetime import datetime, timedelta, timezone
+
+from testutils.util.artifact import Artifact
+from testutils.infra.container_manager import factory
+from testutils.infra.device import MenderDevice
+from testutils.common import create_org, create_user
+from testutils.api.client import ApiClient
+from testutils.api import deviceauth, useradm, inventory, deployments
+
+from .. import conftest
+
+container_factory = factory.get_factory()
+
+TIMEOUT = timedelta(minutes=5)
+
+
+@pytest.fixture(scope="function")
+def setup_os_compat(request):
+    env = container_factory.getCompatibilitySetup()
+    request.addfinalizer(env.teardown)
+    env.setup()
+
+    env.user = create_user(
+        "test@mender.io", "correcthorse", containers_namespace=env.name
+    )
+    env.populate_clients()
+
+    clients = env.get_mender_clients()
+    assert len(clients) > 0, "Failed to setup clients"
+    env.devices = []
+    for client in clients:
+        dev = MenderDevice(client)
+        dev.ssh_is_opened()
+        env.devices.append(dev)
+
+    return env
+
+
+@pytest.fixture(scope="function")
+def setup_ent_compat(request):
+    env = container_factory.getCompatibilitySetup(enterprise=True)
+    request.addfinalizer(env.teardown)
+    env.setup()
+
+    env.tenant = create_org(
+        "Mender",
+        "test@mender.io",
+        "correcthorse",
+        containers_namespace=env.name,
+        container_manager=env,
+    )
+    env.user = env.tenant.users[0]
+
+    env.populate_clients(tenant_token=env.tenant.tenant_token)
+
+    clients = env.get_mender_clients()
+    assert len(clients) > 0, "Failed to setup clients"
+    env.devices = []
+    for client in clients:
+        dev = MenderDevice(client)
+        dev.ssh_is_opened()
+        env.devices.append(dev)
+
+    return env
+
+
+def accept_devices(api_deviceauth, devices=None):
+    """
+    Update the device status for the given set of devices to "accepted"
+
+    :param api_deviceauth: testutils.api.client.ApiClient setup and authorized
+                           to use the deviceauth management api,
+                           i.e. api_client.with_auth(api_token)
+    :param devices: list of dict-type devices as returned by
+                    GET /api/management/v1/devauth/devices
+                    If left None, all pending devices are accepted.
+    """
+    if devices is None:
+        rsp = api_deviceauth.call(
+            "GET", deviceauth.URL_MGMT_DEVICES, qs_params={"status": "pending"}
+        )
+        assert rsp.status_code == 200
+        devices = rsp.json()
+
+    for device in devices:
+        rsp = api_deviceauth.call(
+            "PUT",
+            deviceauth.URL_AUTHSET_STATUS.format(
+                did=device["id"], aid=device["auth_sets"][0]["id"]
+            ),
+            body={"status": "accepted"},
+        )
+        assert rsp.status_code == 204
+
+
+def assert_inventory_updated(api_inventory, num_devices, timeout=TIMEOUT):
+    """
+    Polls the inventory every second, checking the returned "updated_ts"
+    properties for each device, waiting for the value to update to a value
+    later than when this function was called.
+    :param api_inventory: testutils.api.client.ApiClient setup and authorized
+                          to use the inventory management api,
+                          i.e. api_client.with_auth(api_token).
+    :param num_devices: the number of devices to wait for.
+    :param timeout: optional timeout (defaults to 5min).
+    """
+    update_after = datetime.now(timezone.utc)
+    deadline = update_after + timeout
+    num_updated = 0
+    while num_updated < num_devices:
+        if datetime.now(timezone.utc) > deadline:
+            pytest.fail("timeout waiting for devices to submit inventory")
+
+        rsp = api_inventory.call(
+            "GET", inventory.URL_DEVICES, qs_params={"per_page": num_devices * 2},
+        )
+        assert rsp.status_code == 200
+        dev_invs = rsp.json()
+        assert (
+            len(dev_invs) <= num_devices
+        ), "Received more devices from inventory than there exists"
+        if len(dev_invs) < num_devices:
+            time.sleep(1)
+            continue
+        # Check if inventories has been updated since starting this loop
+        num_updated = 0
+        for device in dev_invs:
+            # datetime does not have an RFC3339 parser, but we can convert
+            # the timestamp to a compatible ISO format by removing
+            # fractions and replacing the Zulu timezone with GMT.
+            updated_ts = datetime.fromisoformat(
+                device["updated_ts"].split(".")[0] + "+00:00"
+            )
+            if updated_ts > update_after:
+                num_updated += 1
+            else:
+                time.sleep(1)
+                break
+
+
+def assert_successful_deployment(api_deployments, deployment_id, timeout=TIMEOUT):
+    """
+    Waits for the ongoing deployment (specified by deployment_id) to finish
+    and asserting all devices were successfully upgraded.
+    :param api_deployments: testutils.api.client.ApiClient setup and authorized
+                             to use the deployments management api,
+                             i.e. api_client.with_auth(api_token)
+    :param deployment_id: deployment id to watch
+    :param timeout: optional timeout value to wait for deployment (defaults to 5min)
+    """
+    deadline = datetime.now() + timeout
+    while True:
+        rsp = api_deployments.call(
+            "GET", deployments.URL_DEPLOYMENTS_ID.format(id=deployment_id)
+        )
+        assert rsp.status_code == 200
+
+        dpl = rsp.json()
+        if dpl["status"] == "finished":
+            rsp = api_deployments.call(
+                "GET", deployments.URL_DEPLOYMENTS_STATISTICS.format(id=deployment_id),
+            )
+            assert rsp.status_code == 200
+            assert rsp.json()["failure"] == 0
+            assert rsp.json()["success"] == dpl["device_count"]
+            break
+        elif datetime.now() > deadline:
+            pytest.fail("timeout: Waiting for devices to update")
+        else:
+            time.sleep(1)
+
+
+class TestClientCompatibilityBase:
+    """
+    This class contains compatibility tests implementation for assessing
+    server compatibility with older clients.
+    """
+
+    def compatibility_test_impl(self, env):
+        """
+        The actual test implementation:
+         - Accept devices
+         - Verify devices patches inventory
+         - Perform a noop rootfs update and verify the update was successful
+        """
+        gateway_addr = env.get_mender_gateway()
+        URL_MGMT_USERADM = useradm.URL_MGMT.replace("mender-api-gateway", gateway_addr)
+        URL_MGMT_DEVAUTH = deviceauth.URL_MGMT.replace(
+            "mender-api-gateway", gateway_addr
+        )
+        URL_MGMT_INVNTRY = inventory.URL_MGMT.replace(
+            "mender-api-gateway", gateway_addr
+        )
+        URL_MGMT_DPLMNTS = deployments.URL_MGMT.replace(
+            "mender-api-gateway", gateway_addr
+        )
+        api_useradmm = ApiClient(base_url=URL_MGMT_USERADM)
+
+        rsp = api_useradmm.call(
+            "POST", useradm.URL_LOGIN, auth=(env.user.name, env.user.pwd)
+        )
+        assert rsp.status_code == 200, "Failed to log in test user"
+        api_token = rsp.text
+
+        api_useradmm = api_useradmm.with_auth(api_token)
+        api_devauthm = ApiClient(base_url=URL_MGMT_DEVAUTH).with_auth(api_token)
+        api_inventory = ApiClient(base_url=URL_MGMT_INVNTRY).with_auth(api_token)
+        api_deployments = ApiClient(base_url=URL_MGMT_DPLMNTS).with_auth(api_token)
+
+        deadline = datetime.now() + TIMEOUT
+        devices = []
+        while True:
+            rsp = api_devauthm.call(
+                "GET", deviceauth.URL_MGMT_DEVICES, qs_params={"status": "pending"}
+            )
+            assert rsp.status_code == 200
+
+            devices = rsp.json()
+            assert len(devices) <= len(env.devices)
+
+            if len(devices) == len(env.devices):
+                break
+            elif datetime.now() > deadline:
+                pytest.fail("timeout waiting for devices to connect to server")
+            else:
+                time.sleep(1)
+
+        # Accept all devices
+        accept_devices(api_devauthm)
+
+        # Check that inventory gets updated successfully
+        assert_inventory_updated(api_inventory, len(devices))
+
+        # Deploy an update with an artifact with an empty payload which
+        # effectively performs a "rollback" marking the unchanged
+        # passive partition as the new updated active partition.
+        artifact = Artifact(
+            artifact_name="rootfs-noop-update",
+            device_types=["qemux86-64"],
+            payload="",
+            payload_type="rootfs-image",
+        )
+        artifact_file = artifact.make()
+        rsp = api_deployments.call(
+            "POST",
+            deployments.URL_DEPLOYMENTS_ARTIFACTS,
+            files={
+                "artifact": (
+                    "artifact.mender",
+                    artifact_file,
+                    "application/octet-stream",
+                ),
+            },
+        )
+        assert rsp.status_code == 201
+
+        rsp = api_deployments.call(
+            "POST",
+            deployments.URL_DEPLOYMENTS,
+            body={
+                "artifact_name": "rootfs-noop-update",
+                "devices": [device["id"] for device in devices],
+                "name": "noop_deployment",
+            },
+        )
+        assert rsp.status_code == 201
+
+        deployment_id = rsp.headers.get("Location").split("/")[-1]
+        assert_successful_deployment(api_deployments, deployment_id)
+
+
+class TestClientCompatibilityOpenSource(TestClientCompatibilityBase):
+    def test_compatibility(self, setup_os_compat):
+        self.compatibility_test_impl(setup_os_compat)
+
+
+class TestClientCompatibilityEnterprise(TestClientCompatibilityBase):
+    def test_enterprise_compatibility(self, setup_ent_compat):
+        self.compatibility_test_impl(setup_ent_compat)

--- a/tests/tests/test_compat.py
+++ b/tests/tests/test_compat.py
@@ -201,17 +201,10 @@ class TestClientCompatibilityBase:
          - Perform a noop rootfs update and verify the update was successful
         """
         gateway_addr = env.get_mender_gateway()
-        URL_MGMT_USERADM = useradm.URL_MGMT.replace("mender-api-gateway", gateway_addr)
-        URL_MGMT_DEVAUTH = deviceauth.URL_MGMT.replace(
-            "mender-api-gateway", gateway_addr
-        )
-        URL_MGMT_INVNTRY = inventory.URL_MGMT.replace(
-            "mender-api-gateway", gateway_addr
-        )
-        URL_MGMT_DPLMNTS = deployments.URL_MGMT.replace(
-            "mender-api-gateway", gateway_addr
-        )
-        api_useradmm = ApiClient(base_url=URL_MGMT_USERADM)
+        api_useradmm = ApiClient(useradm.URL_MGMT, host=gateway_addr)
+        api_devauthm = ApiClient(deviceauth.URL_MGMT, host=gateway_addr)
+        api_inventory = ApiClient(inventory.URL_MGMT, host=gateway_addr)
+        api_deployments = ApiClient(deployments.URL_MGMT, host=gateway_addr)
 
         rsp = api_useradmm.call(
             "POST", useradm.URL_LOGIN, auth=(env.user.name, env.user.pwd)
@@ -220,9 +213,9 @@ class TestClientCompatibilityBase:
         api_token = rsp.text
 
         api_useradmm = api_useradmm.with_auth(api_token)
-        api_devauthm = ApiClient(base_url=URL_MGMT_DEVAUTH).with_auth(api_token)
-        api_inventory = ApiClient(base_url=URL_MGMT_INVNTRY).with_auth(api_token)
-        api_deployments = ApiClient(base_url=URL_MGMT_DPLMNTS).with_auth(api_token)
+        api_devauthm = api_devauthm.with_auth(api_token)
+        api_inventory = api_inventory.with_auth(api_token)
+        api_deployments = api_deployments.with_auth(api_token)
 
         deadline = datetime.now() + TIMEOUT
         devices = []

--- a/tests/tests/test_os_ent_migration.py
+++ b/tests/tests/test_os_ent_migration.py
@@ -93,15 +93,9 @@ def initialize_os_setup(env):
     """ Seed the OS setup with all operational data - users and devices.
         Return {"os_devs": [...], "os_users": [...]}
     """
-    uadmm = ApiClient(
-        "https://{}/api/management/v1/useradm".format(env.get_mender_gateway())
-    )
-    dauthd = ApiClient(
-        "https://{}/api/devices/v1/authentication".format(env.get_mender_gateway())
-    )
-    dauthm = ApiClient(
-        "https://{}/api/management/v2/devauth".format(env.get_mender_gateway())
-    )
+    uadmm = ApiClient(useradm.URL_MGMT, host=env.get_mender_gateway())
+    dauthd = ApiClient(deviceauth.URL_DEVICES, host=env.get_mender_gateway())
+    dauthm = ApiClient(deviceauth.URL_MGMT, host=env.get_mender_gateway())
 
     users = [
         create_user("foo@tenant.com", "correcthorse", containers_namespace=env.name),
@@ -162,7 +156,7 @@ def migrate_ent_setup(env):
 class TestEntMigration:
     def test_users_ok(self, migrated_enterprise_setup):
         mender_gateway = migrated_enterprise_setup.get_mender_gateway()
-        uadmm = ApiClient("https://{}/api/management/v1/useradm".format(mender_gateway))
+        uadmm = ApiClient(useradm.URL_MGMT, host=mender_gateway)
 
         # os users can't log in
         for u in migrated_enterprise_setup.init_data["os_users"]:
@@ -176,16 +170,10 @@ class TestEntMigration:
 
     def test_devs_ok(self, migrated_enterprise_setup):
         mender_gateway = migrated_enterprise_setup.get_mender_gateway()
-        uadmm = ApiClient("https://{}/api/management/v1/useradm".format(mender_gateway))
-        dauthd = ApiClient(
-            "https://{}/api/devices/v1/authentication".format(mender_gateway)
-        )
-        dauthm = ApiClient(
-            "https://{}/api/management/v2/devauth".format(mender_gateway)
-        )
-        depld = ApiClient(
-            "https://{}/api/devices/v1/deployments".format(mender_gateway)
-        )
+        uadmm = ApiClient(useradm.URL_MGMT, host=mender_gateway)
+        dauthd = ApiClient(deviceauth.URL_DEVICES, host=mender_gateway)
+        dauthm = ApiClient(deviceauth.URL_MGMT, host=mender_gateway)
+        depld = ApiClient(deployments.URL_DEVICES, host=mender_gateway)
 
         # current dev tokens don't work right off the bat
         # the deviceauth db is empty

--- a/testutils/api/client.py
+++ b/testutils/api/client.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Northern.tech AS
+# Copyright 2020 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@ import os.path
 
 import requests
 
-GATEWAY_URL = "https://mender-api-gateway"
+GATEWAY_HOSTNAME = "mender-api-gateway"
 
 
 class ApiClient:
-    def __init__(self, base_url=GATEWAY_URL):
-        self.base_url = base_url
+    def __init__(self, base_url="", host=GATEWAY_HOSTNAME, schema="https://"):
+        self.base_url = schema + host + base_url
         self.headers = {}
 
     def with_auth(self, token):
@@ -56,10 +56,8 @@ class ApiClient:
             files=files,
         )
 
-    def post(self, url, path_params={}, body=None, data=None):
-        url = self.__make_url(url)
-        url = self.__subst_path_params(url, path_params)
-        return requests.request("POST", url, json=body, data=data, verify=False)
+    def post(self, url, *pargs, **kwargs):
+        return self.call("POST", url, *pargs, **kwargs)
 
     def __make_url(self, path):
         return os.path.join(

--- a/testutils/api/deployments.py
+++ b/testutils/api/deployments.py
@@ -11,10 +11,9 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-import testutils.api.client
 
-URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v1/deployments"
-URL_DEVICES = testutils.api.client.GATEWAY_URL + "/api/devices/v1/deployments"
+URL_MGMT = "/api/management/v1/deployments"
+URL_DEVICES = "/api/devices/v1/deployments"
 
 URL_NEXT = "/device/deployments/next"
 URL_LOG = "/device/deployments/{id}/log"

--- a/testutils/api/deployments_v2.py
+++ b/testutils/api/deployments_v2.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-import testutils.api.client
 
-URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v2/deployments"
+URL_MGMT = "/api/management/v2/deployments"
 
 URL_DEPLOYMENTS = "/deployments"

--- a/testutils/api/deviceauth.py
+++ b/testutils/api/deviceauth.py
@@ -13,12 +13,13 @@
 #    limitations under the License.
 import json
 
-import testutils.api.client
 import testutils.util.crypto
 
-URL_DEVICES = testutils.api.client.GATEWAY_URL + "/api/devices/v1/authentication"
-URL_INTERNAL = "http://mender-device-auth:8080/api/internal/v1/devauth"
-URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v2/devauth"
+HOST = "mender-device-auth:8080"
+
+URL_DEVICES = "/api/devices/v1/authentication"
+URL_INTERNAL = "/api/internal/v1/devauth"
+URL_MGMT = "/api/management/v2/devauth"
 
 URL_AUTH_REQS = "/auth_requests"
 

--- a/testutils/api/inventory.py
+++ b/testutils/api/inventory.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Northern.tech AS
+# Copyright 2020 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -11,10 +11,9 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-import testutils.api.client
 
-URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v1/inventory"
-URL_DEV = testutils.api.client.GATEWAY_URL + "/api/devices/v1/inventory"
+URL_MGMT = "/api/management/v1/inventory"
+URL_DEV = "/api/devices/v1/inventory"
 
 URL_DEVICE = "/devices/{id}"
 URL_DEVICES = "/devices"

--- a/testutils/api/inventory_v2.py
+++ b/testutils/api/inventory_v2.py
@@ -13,10 +13,10 @@
 #    limitations under the License.
 import testutils.api.client
 
-SERVICE_URL = "http://mender-inventory:8080"
+HOST = "mender-inventory:8080"
 
-URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v2/inventory"
-URL_INTERNAL = SERVICE_URL + "/api/internal/v2/inventory"
+URL_MGMT = "/api/management/v2/inventory"
+URL_INTERNAL = "/api/internal/v2/inventory"
 
 URL_SEARCH = "/filters/search"
 URL_FILTERS = "/filters"

--- a/testutils/api/tenantadm.py
+++ b/testutils/api/tenantadm.py
@@ -12,9 +12,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-URL = "http://mender-tenantadm:8080/api"
-URL_INTERNAL = URL + "/internal/v1/tenantadm"
-URL_MGMT = URL + "/management/v1/tenantadm"
+HOST = "mender-tenantadm:8080"
+URL_INTERNAL = "/api/internal/v1/tenantadm"
+URL_MGMT = "/api/management/v1/tenantadm"
 
 URL_INTERNAL_SUSPEND = "/tenants/{tid}/status"
 URL_INTERNAL_TENANTS = "/tenants"

--- a/testutils/api/tenantadm_v2.py
+++ b/testutils/api/tenantadm_v2.py
@@ -12,8 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-URL = "http://mender-tenantadm:8080/api"
-URL_MGMT = URL + "/management/v2/tenantadm"
+HOST = "mender-tenantadm:8080"
+URL_MGMT = "/api/management/v2/tenantadm"
 
 URL_CREATE_ORG_TENANT = "/tenants"
 URL_TENANT_STATUS = "/tenants/{id}/status"

--- a/testutils/api/useradm.py
+++ b/testutils/api/useradm.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Northern.tech AS
+# Copyright 2020 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import testutils.api.client
-
-URL_MGMT = testutils.api.client.GATEWAY_URL + "/api/management/v1/useradm"
+URL_MGMT = "/api/management/v1/useradm"
 
 URL_LOGIN = "/auth/login"
 URL_PASSWORD_RESET_START = "/auth/password-reset/start"

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -25,7 +25,7 @@ import testutils.api.deviceauth as deviceauth
 import testutils.api.tenantadm as tenantadm
 import testutils.api.useradm as useradm
 import testutils.util.crypto
-from testutils.api.client import ApiClient
+from testutils.api.client import ApiClient, GATEWAY_HOSTNAME
 from testutils.infra.mongo import MongoClient
 from testutils.infra.cli import CliUseradm, CliTenantadm
 
@@ -141,13 +141,12 @@ def create_org(
     user_id = None
     tenant_id = cli.create_org(name, username, password, plan=plan)
     tenant_token = json.loads(cli.get_tenant(tenant_id))["tenant_token"]
-    url_useradm = useradm.URL_MGMT
+
+    host = GATEWAY_HOSTNAME
     if container_manager is not None:
-        url_useradm = url_useradm.replace(
-            "mender-api-gateway",
-            container_manager.get_ip_of_service("mender-api-gateway")[0],
-        )
-    api = ApiClient(url_useradm)
+        host = container_manager.get_mender_gateway()
+    api = ApiClient(useradm.URL_MGMT, host=host)
+
     # Try log in every second for 3 minutes.
     # - There usually is a slight delay (in order of ms) for propagating
     #   the created user to the db.

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -18,7 +18,6 @@ import socket
 import subprocess
 import filelock
 import logging
-import tempfile
 import copy
 
 from .docker_manager import DockerNamespace
@@ -83,6 +82,9 @@ class DockerComposeNamespace(DockerNamespace):
         COMPOSE_FILES_PATH
         + "/extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml",
     ]
+    COMPAT_FILES = [
+        COMPOSE_FILES_PATH + "/extra/integration-testing/docker-compose.compat.yml"
+    ]
 
     NUM_SERVICES_OPENSOURCE = 11
     NUM_SERVICES_ENTERPRISE = 13
@@ -119,7 +121,7 @@ class DockerComposeNamespace(DockerNamespace):
 
                 except subprocess.CalledProcessError as e:
                     logger.info(
-                        "failed to run docker-compose: error follows:\n%s" % (e.output)
+                        'failed to run "%s": error follows:\n%s' % (cmd, e.output)
                     )
                     self._stop_docker_compose()
 
@@ -280,9 +282,7 @@ class DockerComposeStandardSetup(DockerComposeNamespace):
             DockerComposeNamespace.__init__(self, name, self.QEMU_CLIENT_FILES)
 
     def setup(self):
-        self._docker_compose_cmd("up -d")
-        if self.num_clients > 1:
-            self._docker_compose_cmd("scale mender-client=%d" % self.num_clients)
+        self._docker_compose_cmd("up -d --scale mender-client=%d" % self.num_clients)
 
 
 class DockerComposeDockerClientSetup(DockerComposeNamespace):
@@ -381,6 +381,64 @@ class DockerComposeEnterpriseSMTPSetup(DockerComposeNamespace):
         host_ip = socket.gethostbyname(socket.gethostname())
         self._docker_compose_cmd("up -d", env={"HOST_IP": host_ip})
         self._wait_for_containers(self.NUM_SERVICES_ENTERPRISE)
+
+
+class DockerComposeCompatibilitySetup(DockerComposeNamespace):
+    def __init__(self, name, enterprise=False):
+        self._enterprise = enterprise
+        extra_files = self.COMPAT_FILES
+        if self._enterprise:
+            extra_files += self.ENTERPRISE_FILES
+        super().__init__(name, extra_files)
+
+    def client_services(self):
+        services = self._docker_compose_cmd("ps --service").split()
+        clients = []
+        for service in services:
+            if service.startswith("mender-client"):
+                clients.append(service)
+        return clients
+
+    def setup(self):
+        compose_args = "up -d " + " ".join(
+            ["--scale %s=0" % service for service in self.client_services()]
+        )
+        self._docker_compose_cmd(compose_args)
+
+    def populate_clients(self, name=None, tenant_token="", replicas=1):
+        client_services = self.client_services()
+        compose_cmd = "run -d"
+        if tenant_token != "":
+            compose_cmd += " -e TENANT_TOKEN={tkn}".format(tkn=tenant_token)
+        if name is not None:
+            compose_cmd += " --name '{name}'".format(name=name)
+
+        compose_cmd += " {service}"
+
+        for i in range(replicas):
+            for service in client_services:
+                self._docker_compose_cmd(compose_cmd.format(service=service))
+
+    def get_mender_clients(self):
+        cmd = [
+            "docker",
+            "ps",
+            "--filter=label=com.docker.compose.project=" + self.name,
+            '--format={{.Label "com.docker.compose.service"}}',
+        ]
+
+        services = subprocess.check_output(cmd).decode().split()
+        clients = []
+        for service in services:
+            if service.startswith("mender-client"):
+                clients.append(service)
+
+        addrs = []
+        for client in clients:
+            for ip in self.get_ip_of_service(client):
+                addrs.append(ip + ":8822")
+
+        return addrs
 
 
 class DockerComposeCustomSetup(DockerComposeNamespace):

--- a/testutils/infra/container_manager/factory.py
+++ b/testutils/infra/container_manager/factory.py
@@ -23,6 +23,7 @@ from .docker_compose_manager import DockerComposeFailoverServerSetup
 from .docker_compose_manager import DockerComposeEnterpriseSetup
 from .docker_compose_manager import DockerComposeEnterpriseSMTPSetup
 from .docker_compose_manager import DockerComposeCustomSetup
+from .docker_compose_manager import DockerComposeCompatibilitySetup
 
 
 class ContainerManagerFactory:
@@ -105,6 +106,9 @@ class DockerComposeManagerFactory(ContainerManagerFactory):
 
     def getEnterpriseSMTPSetup(self, name=None):
         return DockerComposeEnterpriseSMTPSetup(name)
+
+    def getCompatibilitySetup(self, name=None, **kwargs):
+        return DockerComposeCompatibilitySetup(name, **kwargs)
 
     def getCustomSetup(self, name=None):
         return DockerComposeCustomSetup(name)

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -18,6 +18,7 @@ import traceback
 import os
 import socket
 import subprocess
+import threading
 
 from fabric import Connection
 from paramiko import SSHException
@@ -138,10 +139,17 @@ class MenderDevice:
 class RebootDetector:
     # This global one is used to increment each port used.
     port = 8181
+    # lock to protect global data
+    lock = threading.Lock()
 
     def __init__(self, device, host_ip):
-        self.port = RebootDetector.port
-        RebootDetector.port += 1
+        try:
+            RebootDetector.lock.acquire()
+            self.port = RebootDetector.port
+            RebootDetector.port += 1
+        finally:
+            RebootDetector.lock.release()
+
         self.host_ip = host_ip
         self.device = device
         self.server = None


### PR DESCRIPTION
Added a new compatibility docker-compose setup which runs all clients within this major release.
Made integration tests verifying the expected client behavior (viewed from the API), that is:

- Setup test environment with one instance of each client defined in extra/integration-testing/docker-compose.compat.yml
- Accept all devices and check that all devices updates their inventory after authorizing.
- Create a deployment with a rootfs artifact with an empty file -- effectively performing a noop update to the identical inactive partition.
- Verify that all devices gets "updated" successfully.