### PR TITLE
[changelog-generator] Search the dependabot message in all commit entry

### DIFF
--- a/extra/changelog-generator/changelog-generator
+++ b/extra/changelog-generator/changelog-generator
@@ -27,7 +27,7 @@ def aggregate_dependabot_changelogs(entry_list):
     new_entry_list = []
     aggregated_dependabot_changelogs = ""
     for entry in entry_list:
-        if re.match("[Bb]umps? .* from .* to .*", entry):
+        if re.search("[Bb]umps? .* from .* to .*", entry):
             aggregated_dependabot_changelogs += "\n* " + "\n  ".join(
                 [s for n, s in enumerate(entry.split("\n")) if s != "" and n != 0]
             )

--- a/extra/changelog-generator/test-changelog-generator
+++ b/extra/changelog-generator/test-changelog-generator
@@ -390,6 +390,16 @@ Signed-off-by: dependabot[bot] <support@github.com>'
 
 ################################################################################
 
+git commit --allow-empty -m 'Changelog:All: Bump pytest-html in /tests/requirements
+
+Bumps [pytest-html](https://github.com/pytest-dev/pytest-html) from 2.0.1 to 2.1.1.
+- [Release notes](https://github.com/pytest-dev/pytest-html/releases)
+- [Changelog](https://github.com/pytest-dev/pytest-html/blob/master/CHANGES.rst)
+- [Commits](https://github.com/pytest-dev/pytest-html/compare/v2.0.1...v2.1.1)
+
+Signed-off-by: dependabot[bot] <support@github.com>'
+
+################################################################################
 
 git commit --allow-empty -m 'Changelog: All bugs fixed N75
 
@@ -433,6 +443,10 @@ _Released xx.xx.xxxx_
   * Bumps [github.com/klauspost/pgzip](https://github.com/klauspost/pgzip) from 1.2.3 to 1.2.4.
     - [Release notes](https://github.com/klauspost/pgzip/releases)
     - [Commits](klauspost/pgzip@v1.2.3...v1.2.4)
+  * Bumps [pytest-html](https://github.com/pytest-dev/pytest-html) from 2.0.1 to 2.1.1.
+    - [Release notes](https://github.com/pytest-dev/pytest-html/releases)
+    - [Changelog](https://github.com/pytest-dev/pytest-html/blob/master/CHANGES.rst)
+    - [Commits](https://github.com/pytest-dev/pytest-html/compare/v2.0.1...v2.1.1)
   * Bumps golang from 1.14 to 1.15.0.
 * All bugs fixed N75
 * AllSomethingElse N77


### PR DESCRIPTION
Some times dependabot titles the commit with "Bump `<something>` in
`<somewhere>`", while only having the "from `<this>` to `<that>`" in the
commit body.