### PR TITLE
MEN-3905 test_mtls_enterprise_hsm

### DIFF
--- a/tests/tests/test_mtls.py
+++ b/tests/tests/test_mtls.py
@@ -24,7 +24,7 @@ from testutils.infra.container_manager import factory
 from testutils.infra.device import MenderDevice
 
 from .. import conftest
-from ..MenderAPI import reset_mender_api, auth, deploy, devauth
+from ..MenderAPI import reset_mender_api, auth, deploy, devauth, logger
 from .common_artifact import get_script_artifact
 from .mendertesting import MenderTesting
 
@@ -76,7 +76,61 @@ exit 0
 
 
 class TestClientMTLSEnterprise:
-    def common_test_mtls_enterprise(self, setup_ent_mtls, algorithm=None):
+    def hsm_setup(self, pin, ssl_engine_id, device):
+        algorithm = "rsa"
+        key = f"/var/lib/mender/client.1.{algorithm}.key"
+        script = f"""\
+#!/bin/bash
+echo "module: /usr/lib/softhsm/libsofthsm2.so" > /usr/share/p11-kit/modules/softhsm2.module
+mkdir -p /softhsm/tokens
+echo "directories.tokendir = /softhsm/tokens" > /softhsm/softhsm2.conf
+export SOFTHSM2_CONF=/softhsm/softhsm2.conf;
+softhsm2-util --init-token --free --label unittoken1 --pin {pin} --so-pin 0002
+pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so --login --pin {pin} --write-object "{key}" --type privkey --id 0909 --label privatekey
+"""
+        tmpdir = tempfile.mkdtemp()
+        initialize_hsm_script = os.path.join(tmpdir, "init-hsm.sh")
+        try:
+            with open(initialize_hsm_script, "w") as fd:
+                fd.write(script)
+            device.put(
+                os.path.basename(initialize_hsm_script),
+                local_path=os.path.dirname(initialize_hsm_script),
+                remote_path="/tmp",
+            )
+            device.run("chmod 755 /tmp/" + os.path.basename(initialize_hsm_script))
+            device.run("/tmp/" + os.path.basename(initialize_hsm_script))
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def hsm_get_key_uri(self, pin, ssl_engine_id, device):
+        key_uri = device.run(
+            "export SOFTHSM2_CONF=/softhsm/softhsm2.conf; p11tool --login --provider=/usr/lib/softhsm/libsofthsm2.so --set-pin="
+            + pin
+            + " --list-all-privkeys | grep URL | sed -e 's/.*URL: //'"
+        ).rstrip("\n")
+        key_uri = key_uri + ";pin-value=" + pin
+        device.run("cp /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf.backup")
+        device.run(
+            'echo -ne "[openssl_init]\nengines=engine_section\n\n[engine_section]\npkcs11 = pkcs11_section\n\n[pkcs11_section]\nengine_id = '
+            + ssl_engine_id
+            + '\nMODULE_PATH = /usr/lib/softhsm/libsofthsm2.so\ninit = 0\n" >> /etc/ssl/openssl.cnf'
+        )
+        device.run(
+            'sed -i.backup -e "/\\[Service\\]/ a Environment=SOFTHSM2_CONF=/softhsm/softhsm2.conf" /lib/systemd/system/mender-client.service'
+        )
+        return key_uri
+
+    def hsm_cleanup(self, device):
+        device.run(
+            "mv /lib/systemd/system/mender-client.service.backup /lib/systemd/system/mender-client.service"
+        )
+        device.run("rm -Rf /softhsm")
+        device.run("mv /etc/ssl/openssl.cnf.backup /etc/ssl/openssl.cnf")
+
+    def common_test_mtls_enterprise(
+        self, setup_ent_mtls, algorithm=None, use_hsm=False
+    ):
         tenant = setup_ent_mtls.tenant
 
         # stop the api gateway
@@ -90,33 +144,6 @@ class TestClientMTLSEnterprise:
             setup_ent_mtls.get_mender_clients()[0]
         )
         device.ssh_is_opened()
-        device.run("systemctl stop mender-client")
-        tmpdir = tempfile.mkdtemp()
-        try:
-            # retrieve the original configuration file
-            output = device.run("cat /etc/mender/mender.conf")
-            config = json.loads(output)
-            # replace mender.conf with an mTLS enabled one
-            config["ServerURL"] = "https://mtls-ambassador:8080"
-            config["ServerCertificate"] = "/etc/mender/server.crt"
-            config["SkipVerify"] = True
-            if algorithm is not None:
-                config["HttpsClient"] = {
-                    "Certificate": f"/var/lib/mender/client.1.{algorithm}.crt",
-                    "Key": f"/var/lib/mender/client.1.{algorithm}.key",
-                }
-            if "ArtifactVerifyKey" in config:
-                del config["ArtifactVerifyKey"]
-            mender_conf = os.path.join(tmpdir, "mender.conf")
-            with open(mender_conf, "w") as fd:
-                json.dump(config, fd)
-            device.put(
-                os.path.basename(mender_conf),
-                local_path=os.path.dirname(mender_conf),
-                remote_path="/etc/mender",
-            )
-        finally:
-            shutil.rmtree(tmpdir)
 
         # upload the certificates
         basedir = os.path.join(os.path.dirname(__file__), "..", "..",)
@@ -154,9 +181,54 @@ class TestClientMTLSEnterprise:
                 remote_path="/var/lib/mender",
             )
 
+        device.run("systemctl stop mender-client")
+        tmpdir = tempfile.mkdtemp()
+
+        ssl_engine_id = "pkcs11"
+        pin = "0001"
+        if algorithm is not None and use_hsm is True:
+            self.hsm_setup(pin, ssl_engine_id, device)
+            key_uri = self.hsm_get_key_uri(pin, ssl_engine_id, device)
+
+        try:
+            # retrieve the original configuration file
+            output = device.run("cat /etc/mender/mender.conf")
+            config = json.loads(output)
+            # replace mender.conf with an mTLS enabled one
+            config["ServerURL"] = "https://mtls-ambassador:8080"
+            config["ServerCertificate"] = "/etc/mender/server.crt"
+            config["SkipVerify"] = True
+            if algorithm is not None:
+                if use_hsm is True:
+                    config["HttpsClient"] = {
+                        "SSLEngine": ssl_engine_id,
+                        "Certificate": f"/var/lib/mender/client.1.{algorithm}.crt",
+                        "Key": key_uri,
+                    }
+                    logger.info('client key set to "%s"' % key_uri)
+                else:
+                    config["HttpsClient"] = {
+                        "Certificate": f"/var/lib/mender/client.1.{algorithm}.crt",
+                        "Key": f"/var/lib/mender/client.1.{algorithm}.key",
+                    }
+            if "ArtifactVerifyKey" in config:
+                del config["ArtifactVerifyKey"]
+            mender_conf = os.path.join(tmpdir, "mender.conf")
+            with open(mender_conf, "w") as fd:
+                json.dump(config, fd)
+            device.put(
+                os.path.basename(mender_conf),
+                local_path=os.path.dirname(mender_conf),
+                remote_path="/etc/mender",
+            )
+        finally:
+            shutil.rmtree(tmpdir)
+
+        device.run("systemctl daemon-reload")
         # start the api gateway
         setup_ent_mtls.start_api_gateway()
 
+        logger.info("starting the client.")
         # start the Mender client
         device.run("systemctl start mender-client")
         return device
@@ -188,8 +260,50 @@ class TestClientMTLSEnterprise:
         deploy.check_expected_status("finished", deployment_id)
 
         # verify the update was actually installed on the device
-        out = device.run("mender -show-artifact").strip()
+        out = device.run(
+            "export SOFTHSM2_CONF=/softhsm/softhsm2.conf; mender -show-artifact"
+        ).strip()
         assert out == "mtls-artifact"
+
+    @MenderTesting.fast
+    @pytest.mark.parametrize("algorithm", ["rsa"])
+    def test_mtls_enterprise_hsm(self, setup_ent_mtls, algorithm):
+        try:
+            # set up the mTLS test environment and return the device
+            device = self.common_test_mtls_enterprise(setup_ent_mtls, algorithm, True)
+
+            output = device.run(
+                "journalctl -u %s | cat" % device.get_client_service_name()
+            )
+            assert "ded private key: '" in output
+
+            # prepare a test artifact
+            with tempfile.NamedTemporaryFile() as tf:
+                artifact = make_script_artifact(
+                    "mtls-artifact", conftest.machine_name, tf.name
+                )
+                deploy.upload_image(artifact)
+
+            # deploy the update to the device
+            devices = list(
+                set([device["id"] for device in devauth.get_devices_status("accepted")])
+            )
+            assert len(devices) == 1
+            deployment_id = deploy.trigger_deployment(
+                "mtls-test", artifact_name="mtls-artifact", devices=devices,
+            )
+
+            # now just wait for the update to succeed
+            deploy.check_expected_statistics(deployment_id, "success", 1)
+            deploy.check_expected_status("finished", deployment_id)
+
+            # verify the update was actually installed on the device
+            out = device.run(
+                "export SOFTHSM2_CONF=/softhsm/softhsm2.conf; mender -show-artifact"
+            ).strip()
+            assert out == "mtls-artifact"
+        finally:
+            self.hsm_cleanup(device)
 
     @MenderTesting.fast
     def test_mtls_enterprise_without_client_cert(self, setup_ent_mtls):


### PR DESCRIPTION
Use SoftHSM2 to emulate private key from hardware security module in the mTLS test.

* setup the SoftHSM
* initialize token
* store private key in the slot
* get the key PKCS#11 URI
* configure OpenSSL
* configure Mender to use the key via URI and SSLEngine configured
* configure the mender-client service to be aware of SoftHSM emulation
* run the test (only RSA keys are supported currently)
* test_mtls_enterprise_hsm is a copy of test_mtls_enterprise with use_hsm->True

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>