### PR TITLE
backend-tests: auditlogs is part of enterprise setup

### DIFF
--- a/backend-tests/run
+++ b/backend-tests/run
@@ -21,6 +21,7 @@ COMPOSE_CMD_ENTERPRISE="${COMPOSE_CMD_OPEN} \
         -f $INTEGRATION_PATH/extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml \
         -f $INTEGRATION_PATH/extra/smtp-testing/workflows-worker-smtp-test.yml \
         -f $INTEGRATION_PATH/extra/stripe-testing/stripe-test.docker-compose.yml
+        -f $INTEGRATION_PATH/docker-compose.auditlogs.yml
         "
 COMPOSE_CMD=""
 

--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -10,3 +10,8 @@ services:
             - mender
         depends_on:
             - mender-mongo
+        command: server --automigrate
+
+    mender-api-gateway:
+        environment:
+            HAVE_AUDITLOGS: 1


### PR DESCRIPTION
needed for the https://github.com/mendersoftware/mender-api-gateway-docker/pull/149 fix,
and in general https://tracker.mender.io/browse/MEN-3815


https://gitlab.com/Northern.tech/Mender/mender-qa/-/pipelines/192821795