### PR TITLE
backend-tests: auditlogs for useradm

### DIFF
--- a/backend-tests/requirements-py3.txt
+++ b/backend-tests/requirements-py3.txt
@@ -7,3 +7,4 @@ pyzbar==0.1.8
 pyotp==2.4.0
 pillow==7.2.0
 stripe==2.51.0
+redo==2.0.4

--- a/backend-tests/tests/test_auditlogs.py
+++ b/backend-tests/tests/test_auditlogs.py
@@ -76,16 +76,7 @@ class TestAuditLogsEnterprise:
         user = tenant_users.users[0]
 
         d = make_deployment(user.token)
-
-        expected = {
-            "action": "create",
-            "actor": {"id": user.id, "type": "user", "email": user.name,},
-            "object": {
-                "id": d["id"],
-                "type": "deployment",
-                "deployment": {"name": d["name"], "artifact_name": d["artifact_name"],},
-            },
-        }
+        expected = evt_deployment_create(user, d)
 
         time.sleep(0.5)
         alogs = ApiClient(auditlogs.URL_MGMT)
@@ -105,19 +96,7 @@ class TestAuditLogsEnterprise:
             user = tenant_users.users[uidx]
 
             d = make_deployment(user.token)
-
-            evt = {
-                "action": "create",
-                "actor": {"id": user.id, "type": "user", "email": user.name,},
-                "object": {
-                    "id": d["id"],
-                    "type": "deployment",
-                    "deployment": {
-                        "name": d["name"],
-                        "artifact_name": d["artifact_name"],
-                    },
-                },
-            }
+            evt = evt_deployment_create(user, d)
 
             time.sleep(0.5)
 
@@ -350,6 +329,21 @@ def make_deployment(token):
     assert len(found) == 1
 
     return found[0]
+
+
+def evt_deployment_create(user, deployment):
+    return {
+        "action": "create",
+        "actor": {"id": user.id, "type": "user", "email": user.name},
+        "object": {
+            "id": deployment["id"],
+            "type": "deployment",
+            "deployment": {
+                "name": deployment["name"],
+                "artifact_name": deployment["artifact_name"],
+            },
+        },
+    }
 
 
 def check_log(log, expected):


### PR DESCRIPTION
part 2 of:
https://tracker.mender.io/browse/MEN-3815

test log emission from useradm events.

needs the last bunch of fixes still:
https://github.com/mendersoftware/useradm-enterprise/pull/138

combined pipeline:
https://gitlab.com/Northern.tech/Mender/mender-qa/-/pipelines/194456139
