### PR TITLE
remove deviceadm from component-maps

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -18,11 +18,6 @@ git:
     - mender-deployments
     release_component: true
 
-  deviceadm:
-    docker_image: []
-    docker_container: []
-    release_component: false
-
   deviceauth:
     docker_image:
     - deviceauth


### PR DESCRIPTION
Looks like this is a bug. Most likely it was forgotten from times when we had deviceadm micro service. Currently this is causing constant failing of `release_tool.py --select-test-suite`, which in our current test suite is suppressed by `|| "all"` (for example [here](https://github.com/mendersoftware/mender-qa/blob/6b54c591238d14af2da768b47e3ed6d40238a709/.gitlab-ci.yml#L988)) and it's not possible to use the release tool for os/enterprise tests differentiation.