### PR TITLE
[release_tool] Fix --select-test-suite, use only releasable repos

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -2971,7 +2971,7 @@ def is_repo_on_known_branch(path):
 def select_test_suite():
     """ Check what backend components are checked out in custom revisions and decide
         which integration test suite should be ran - 'open', 'enterprise' or both.
-        To be used when running integration tests to see which components 'triggered' the build 
+        To be used when running integration tests to see which components 'triggered' the build
         (i.e. changed, for lack of a better word - could be just 1 service with a checked out PR, or multiple -
         in case of manually parametrized builds).
         Rules:
@@ -2984,7 +2984,7 @@ def select_test_suite():
     paths = ["..", "../go/src/github.com/mendersoftware"]
 
     built_components = set({})
-    for repo in Component.get_components_of_type("git", only_release=False):
+    for repo in Component.get_components_of_type("git", only_release=True):
         path = find_repo_path(repo.git(), paths)
         if path is None:
             raise RuntimeError(


### PR DESCRIPTION
So that old deprecated ones, like deviceadm, are not even expected to
exist.

Removed also a trailing space in documentation.