### PR TITLE
test: upgrade the test_forced_inventory to wait for longer

### DIFF
--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -232,12 +232,12 @@ class TestBasicIntegration(MenderTesting):
         mender_device.run("mender -send-inventory")
         logger.info("mender client has forced an inventory update")
 
-        # Give the client some time to send the inventory.
-        time.sleep(5)
+        for i in range(10):
+            # Check that the updated inventory value is now present.
+            invJSON = inv.get_devices()
+            for element in invJSON[0]["attributes"]:
+                if element["name"] == "host" and element["value"] == "foobar":
+                    return
+            time.sleep(10)
 
-        # Check that the updated inventory value is now present.
-        invJSON = inv.get_devices()
-        for element in invJSON[0]["attributes"]:
-            if element["name"] == "host" and element["value"] == "foobar":
-                return
         pytest.fail("The inventory was not updated")


### PR DESCRIPTION
The previous iteration slept for 5 seconds and only gave one shot at verifying
the inventory was properly updated.

This version tries 10 times with a 10 second period to see if the inventory was
indeed updated.

This should be ample in the case of slow test runners.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>