### PR TITLE
QA-226: Add --feature-branches CLI option

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -2609,6 +2609,8 @@ def do_integration_versions_including(args):
     ]
     if args.all:
         git_query += ["refs/heads/**"]
+    if args.feature_branches:
+        git_query += ["refs/remotes/%s/feature-*" % remote]
     output = execute_git(None, git_dir, git_query, capture=True)
     candidates = []
     for line in output.strip().split("\n"):
@@ -3072,6 +3074,12 @@ def main():
         metavar="SERVICE",
         help="Find version(s) of integration repository that contain the given version of SERVICE, "
         + " where version is given with --version. Returned as a newline separated list",
+    )
+    parser.add_argument(
+        "--feature-branches",
+        action="store_true",
+        default=False,
+        help="When used with -f, include upstream feature branches",
     )
     parser.add_argument(
         "-v",

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -398,6 +398,7 @@ def filter_docker_compose_files_list(list, version):
         "docker-compose.yml",
         "docker-compose.enterprise.yml",
         "docker-compose.auditlogs.yml",
+        "docker-compose.connect.yml",
         "other-components-docker.yml",
     ]
     _GIT_ONLY_YML = ["git-versions.yml", "git-versions-enterprise.yml"]


### PR DESCRIPTION
* [release_tool] Add connect yaml file to the list of Docker-only
This is a new file added in feature-deviceconnect file for which
release_tool (master) is not aware of, hence failing with "More than one
container is using the image name 'deviceconnect'."

* [release_tool] QA-226: Add --feature-branches CLI option
Which in combination with --integration-versions-including option will
add the upstream remote branches to the candidates to check.