### PR TITLE
Restore mender-shell from other-components.yml

### DIFF
--- a/other-components.yml
+++ b/other-components.yml
@@ -9,3 +9,6 @@ services:
 
     mender-cli:
         image: mendersoftware/mender-cli:1.5.0
+
+    mender-shell:
+        image: mendersoftware/mender-shell:master


### PR DESCRIPTION
Probably removed by mistake on conflicts resolution merging from master.