### PR TITLE
demo script: Fix misparsing of commands when using `-f` argument.

### DIFF
--- a/demo
+++ b/demo
@@ -56,16 +56,6 @@ parse_args() {
             # Undocumented flag, we use this for internal testing.
             EXTRA_FILES="$EXTRA_FILES $ENTERPRISE_FILES"
             ENTERPRISE=1
-        elif [[ "$1" = "down" ]] || [[ "$1" = "rm" ]] || [[ "$1" = "stop" ]]; then
-            # If the argument is either "down" or "rm", enable the client so that it
-            # gets cleaned up, no matter if `--client` is passed or not.
-            CLIENT=1
-            # Not a flag, so we should break out of the loop.
-            break
-        elif [[ "$1" = "up" ]]; then
-            RUN_UP=1
-            # Not a flag, so we should break out of the loop.
-            break
         else
             break
         fi
@@ -75,6 +65,15 @@ parse_args() {
     local EXTRA_FILES_NEXT=0
     for i in "$@"; do
         case $i in
+            down|rm|stop)
+                # If the argument is either "down" or "rm", enable the client so
+                # that it gets cleaned up, no matter if `--client` is passed or
+                # not.
+                CLIENT=1
+                ;;
+            up)
+                RUN_UP=1
+                ;;
             -f=*|--file=*)
                 EXTRA_FILES="$EXTRA_FILES $i"
                 ;;


### PR DESCRIPTION
If the `-f` argument is specified, we jump to the next parsing loop,
which doesn't contain parsing for docker commands. Move the parsing
there so it will be done correctly. This is fine because the first
loop will exit on unknown arguments, so we are guaranteed to get to
the second loop.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>