### PR TITLE
[staging] Update mtls-ambassador tag to mender-2.5.0

### DIFF
--- a/other-components-docker.yml
+++ b/other-components-docker.yml
@@ -3,4 +3,4 @@
 # installation (have no docker-compose file).
 services:
     mtls-ambassador:
-        image: registry.mender.io/mendersoftware/mtls-ambassador:1.0.0
+        image: registry.mender.io/mendersoftware/mtls-ambassador:mender-2.5.0


### PR DESCRIPTION
This is the tag that we build/test during releases and the one that we
should document for users to pull.