### PR TITLE
[release_tool] Add connect yaml file to the list of Docker-only 

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -393,6 +393,7 @@ def filter_docker_compose_files_list(list, version):
         "docker-compose.yml",
         "docker-compose.enterprise.yml",
         "docker-compose.auditlogs.yml",
+        "docker-compose.connect.yml",
     ]
     _GIT_ONLY_YML = ["git-versions.yml", "git-versions-enterprise.yml"]
 


### PR DESCRIPTION
This is a new file added in feature-deviceconnect file for which
release_tool (master) is not aware of, hence failing with "More than one
container is using the image name 'deviceconnect'."

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit 863b4b3b76358f3bb5f2c6e6bcf7d92bc8d6dac8)