### PR TITLE
changelog-generator fix and gitm update

### DIFF
--- a/extra/changelog-generator/changelog-generator
+++ b/extra/changelog-generator/changelog-generator
@@ -346,10 +346,10 @@ for repo in repos:
             if len(jiras) > 0:
                 tracker += "(" + ", ".join(sorted(jiras)) + ")"
         for entry in ENTRIES[sha_entry]:
-            # Safety check. See if there are still numbers at least four digits long in
-            # the output, and if so, warn about it. This may be ticket references that
-            # we missed.
-            match = re.search("[0-9]{4,}", entry)
+            # Safety check. See if there are still numbers at least four digits
+            # long not preceded by '#' in the output and if so, warn about it.
+            # This may be ticket references that we missed.
+            match = re.search("(?<!#)[0-9]{4,}", entry)
             if match:
                 POSSIBLE_PROBLEMS.append(
                     "*** Commit %s had a number %s which may be a ticket reference we missed. Should be manually checked."

--- a/extra/gitdm/company-map
+++ b/extra/gitdm/company-map
@@ -35,3 +35,6 @@ wifx.net Wifx
 chora.dk Chora
 linutronix.de Linutronix GmbH
 cisco.com Cisco Systems, Inc.
+innobyte.com INNOBYTE
+touchtunes.com TouchTunes Music Corporation
+6253936+Styne13@users.noreply.github.com Styne13@users.noreply.github.com

--- a/extra/gitdm/mailmap
+++ b/extra/gitdm/mailmap
@@ -7,3 +7,4 @@ Dominik Adamski <adamski.dominik@gmail.com>
 Alex Miliukov <28045858+0lmi@users.noreply.github.com>
 Lluis Campos <lluis.campos@northern.tech>
 Ossian Riday <Ossian.Riday@gmail.com>
+Nils Olav Kvelvane Johansen <nils.olav@northern.tech>


### PR DESCRIPTION
* [changelog-generator] Do not warn about #1234 kind of numbers
As these are likely to be PR references.
* [gitdm] Update company-map and mailmap for release