### PR TITLE
Add auditlogs and deviceconnect to production templates

### DIFF
--- a/production/config/enterprise.yml.template
+++ b/production/config/enterprise.yml.template
@@ -14,3 +14,7 @@ services:
             # don't supply a tenant token. If empty, clients without a tenant
             # token will be rejected.
             DEVICEAUTH_DEFAULT_TENANT_TOKEN: ''
+
+    mender-deviceconnect:
+        environment:
+            DEVICECONNECT_ENABLE_AUDIT: "1"

--- a/production/run
+++ b/production/run
@@ -20,7 +20,7 @@ fi
 ENTERPRISE_DOCKER_COMPOSE=
 ENTERPRISE_PROD=
 if [ -f ./config/enterprise.yml ]; then
-    ENTERPRISE_DOCKER_COMPOSE="-f ../docker-compose.enterprise.yml"
+    ENTERPRISE_DOCKER_COMPOSE="-f ../docker-compose.enterprise.yml -f ../docker-compose.auditlogs.yml"
     ENTERPRISE_PROD="-f ./config/enterprise.yml"
 fi
 
@@ -28,6 +28,7 @@ exec docker-compose \
      -p menderproduction \
      -f ../docker-compose.yml \
      -f ../docker-compose.storage.minio.yml \
+     -f ../docker-compose.connect.yml \
      $ENTERPRISE_DOCKER_COMPOSE \
      -f ./config/prod.yml \
      $ENTERPRISE_PROD \


### PR DESCRIPTION
I noticed that auditlogs and deviceconnect were never added to the production templates, and no compose file enables audit logging for deviceconnect so I figured it might be best to put it in the enterprise template.