### PR TITLE
EXPERIMENTAL integration: actually wait for traefik

### DIFF
--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -19,6 +19,8 @@ import subprocess
 import filelock
 import logging
 import copy
+import redo
+from testutils.common import wait_for_traefik
 
 from .docker_manager import DockerNamespace
 
@@ -153,7 +155,7 @@ class DockerComposeNamespace(DockerNamespace):
             )
             running_countainers_count = len(out.split())
             if running_countainers_count == expected_containers:
-                time.sleep(60)
+                wait_for_traefik(self.get_mender_gateway())
                 return
             else:
                 time.sleep(1)


### PR DESCRIPTION
general improvement, but may also help https://tracker.mender.io/browse/MEN-4412

---

the wait_for_traefik util was already in testutils, and meant to
be shared between integration and backend-integration.

by mistake however, it's only used in backend-integration.

work it into integration tests by piggybacking it on
wait_for_containers. this way each setup waits for its
number of containers, but instead of sleeping a random
60 sec, it actually waits for traefik to be set up.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>