### PR TITLE
Fix: warning about MENDER_TESTPREFIX

### DIFF
--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -22,7 +22,7 @@ services:
             - traefik.http.routers.auditlogs.tls=true
             - traefik.http.routers.auditlogs.service=auditlogs
             - traefik.http.services.auditlogs.loadbalancer.server.port=8080
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
 
     mender-api-gateway:
         environment:

--- a/docker-compose.config.yml
+++ b/docker-compose.config.yml
@@ -19,7 +19,7 @@ services:
             - traefik.http.routers.deviceconfig.tls=true
             - traefik.http.routers.deviceconfig.service=deviceconfig
             - traefik.http.services.deviceconfig.loadbalancer.server.port=8080
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
 
     mender-api-gateway:
         environment:

--- a/docker-compose.connect.yml
+++ b/docker-compose.connect.yml
@@ -32,7 +32,7 @@ services:
             - traefik.http.routers.deviceconnectMgmt.tls=true
             - traefik.http.routers.deviceconnectMgmt.service=deviceconnectMgmt
             - traefik.http.services.deviceconnectMgmt.loadbalancer.server.port=8080
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
 
 
     mender-nats:

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -25,7 +25,7 @@ services:
             - --accesslog=true
             - --log.level=DEBUG
             - --providers.file.filename=/config/tls.toml
-            - --providers.docker.constraints=Label(`mender.testprefix`,`${MENDER_TESTPREFIX}`)
+            - --providers.docker.constraints=Label(`mender.testprefix`,`${MENDER_TESTPREFIX:-""}`)
             - --providers.docker=true
             - --providers.docker.exposedbydefault=false
             - --entrypoints.http.address=:80

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -36,7 +36,7 @@ services:
             - traefik.http.routers.tenantadmMgmt.tls=true
             - traefik.http.routers.tenantadmMgmt.service=tenantadmMgmt
             - traefik.http.services.tenantadmMgmt.loadbalancer.server.port=8080
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
         networks:
             - mender
         depends_on:

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -19,7 +19,7 @@ services:
             - "traefik.http.routers.minio.rule=Host(`${STORAGE_URL:-s3.docker.mender.io}`)||Headers(`X-Forwarded-Host`,`${STORAGE_URL:-s3.docker.mender.io}`)||PathPrefix(`/mender-artifact-storage`)"
             - "traefik.http.routers.minio.tls=true"
             - "traefik.http.services.minio.loadbalancer.server.port=9000"
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
         command: server /export
 
     #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
             - traefik.http.services.deployments.loadbalancer.healthcheck.port=8080
             - traefik.http.services.deployments.loadbalancer.healthcheck.interval=5s
             - traefik.http.services.deployments.loadbalancer.healthcheck.timeout=3s
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
         networks:
             - mender
         depends_on:
@@ -92,7 +92,7 @@ services:
             - traefik.http.middlewares.json-error-responder4.errors.service=error-responder
             - traefik.http.middlewares.json-error-responder4.errors.query=/{status}.json
             - traefik.http.middlewares.json-error-responder4.errors.status=429
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
         networks:
             - mender
         environment:
@@ -161,7 +161,7 @@ services:
             - traefik.http.services.deviceauthMgmt.loadbalancer.server.port=8080
             # the X-Original-URI and X-Original-Method headers are added by traefik automatically, however as X-Forwarded-Uri and X-Forwarded-Method
             # https://github.com/containous/traefik/blob/125470f1106373ff42cf03ae28467055a8186de5/pkg/middlewares/forwardedheaders/forwarded_header.go#L12-L38
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
         networks:
             - mender
         depends_on:
@@ -202,7 +202,7 @@ services:
             - traefik.http.routers.inventoryV1.service=inventoryV1
             - traefik.http.routers.inventoryV1.tls=true
             - traefik.http.services.inventoryV1.loadbalancer.server.port=8080
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
         networks:
             - mender
         depends_on:
@@ -232,7 +232,7 @@ services:
             - traefik.http.routers.useradmLogin.tls=true
             - traefik.http.routers.useradmLogin.service=useradmLogin
             - traefik.http.services.useradmLogin.loadbalancer.server.port=8080
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
         networks:
             - mender
         depends_on:

--- a/extra/mtls/mtls-ambassador-test.yml
+++ b/extra/mtls/mtls-ambassador-test.yml
@@ -14,4 +14,4 @@ services:
       MTLS_DEBUG_LOG: "true"
       MTLS_INSECURE_SKIP_VERIFY: "true"
     labels:
-        - mender.testprefix=${MENDER_TESTPREFIX}
+        - mender.testprefix=${MENDER_TESTPREFIX:-""}

--- a/storage-proxy/docker-compose.storage-proxy.demo.yml
+++ b/storage-proxy/docker-compose.storage-proxy.demo.yml
@@ -17,7 +17,7 @@ services:
             - ./storage-proxy/nginx.conf.demo:/usr/local/openresty/nginx/conf/nginx.conf
         labels:
             - traefik.enable=false
-            - mender.testprefix=${MENDER_TESTPREFIX}
+            - mender.testprefix=${MENDER_TESTPREFIX:-""}
 
     #                  
     # mender-api-gateway


### PR DESCRIPTION
Export the MENDER_TESTPREFIX env variable to its current value, or empty string
if not set, to avoid the warning message below:

WARNING: The MENDER_TESTPREFIX variable is not set. Defaulting to a blank
string.

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>