### PR TITLE
QA-268: test_state_scripts to use a lighweight update module

### DIFF
--- a/tests/MenderAPI/artifacts.py
+++ b/tests/MenderAPI/artifacts.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Northern.tech AS
+# Copyright 2021 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ class Artifacts:
         image,
         device_type,
         artifact_name,
-        artifact_file_created,
+        artifact_filename,
         signed=False,
         scripts=[],
         global_flags="",
@@ -55,7 +55,7 @@ class Artifacts:
             image,
             device_type,
             artifact_name,
-            artifact_file_created.name,
+            artifact_filename,
             signed_arg,
             ("-v %d" % version) if version else "",
         )
@@ -71,7 +71,7 @@ class Artifacts:
         logger.info("Running: " + cmd)
         subprocess.check_call(cmd, shell=True)
 
-        return artifact_file_created.name
+        return artifact_filename
 
     def get_mender_conf(self, image):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,7 @@ def pytest_exception_interact(node, call, report):
             for val in node.funcargs.values()
             if isinstance(val, BaseContainerManagerNamespace)
         ]
-        if len(env_candidates) == 1:
+        if len(env_candidates) > 0:
             env = env_candidates[0]
             dev_candidates = [
                 getattr(env, attr)

--- a/tests/module-state-scripts-test
+++ b/tests/module-state-scripts-test
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+STATE="$1"
+
+case "$STATE" in
+
+    NeedsArtifactReboot)
+        echo "Yes"
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    Download|ArtifactInstall|ArtifactRollback)
+        ;;
+
+    ArtifactReboot|ArtifactRollbackReboot)
+        systemctl restart mender-client
+        ;;
+
+esac
+
+exit 0
+

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -364,53 +364,53 @@ TEST_SETS = [
             ],
         },
     ),
-    # TODO: Move this test case out of the rest, requires full rootfs update
-    # (
-    #     "Corrupted_script_version_in_etc",
-    #     {
-    #         "FailureScript": [],
-    #         "ExpectedStatus": "failure",
-    #         "CorruptEtcScriptVersionInUpdate": True,
-    #         "ScriptOrder": [
-    #             "Idle_Enter_08_testing",
-    #             "Idle_Enter_09",
-    #             "Idle_Leave_09",
-    #             "Idle_Leave_10",
-    #             "Sync_Enter_02",
-    #             "Sync_Enter_03",
-    #             "Sync_Leave_04",
-    #             "Sync_Leave_15",
-    #             "Download_Enter_12",
-    #             "Download_Enter_13",
-    #             "Download_Leave_14",
-    #             "Download_Leave_25",
-    #             "ArtifactInstall_Enter_01",
-    #             "ArtifactInstall_Enter_02",
-    #             "ArtifactInstall_Leave_01",
-    #             "ArtifactInstall_Leave_03",
-    #             "ArtifactReboot_Enter_01",
-    #             "ArtifactReboot_Enter_11",
-    #             "ArtifactReboot_Leave_01",
-    #             "ArtifactReboot_Leave_89",
-    #             "ArtifactReboot_Leave_99",
-    #             "ArtifactCommit_Enter_01",
-    #             "ArtifactCommit_Enter_05",
-    #             "ArtifactCommit_Error_91",
-    #             "ArtifactRollback_Enter_00",
-    #             "ArtifactRollback_Enter_01",
-    #             "ArtifactRollback_Leave_00",
-    #             "ArtifactRollback_Leave_01",
-    #             "ArtifactRollbackReboot_Enter_00",
-    #             "ArtifactRollbackReboot_Enter_99",
-    #             "ArtifactRollbackReboot_Leave_01",
-    #             "ArtifactRollbackReboot_Leave_99",
-    #             "ArtifactFailure_Enter_22",
-    #             "ArtifactFailure_Enter_33",
-    #             "ArtifactFailure_Leave_44",
-    #             "ArtifactFailure_Leave_55",
-    #         ],
-    #     },
-    # ),
+    (
+        "Corrupted_script_version_in_etc",
+        {
+            "FailureScript": [],
+            "ExpectedStatus": "failure",
+            "CorruptEtcScriptVersionIn": "ArtifactReboot_Leave_99",
+            "RestoreEtcScriptVersionIn": "ArtifactRollbackReboot_Leave_99",
+            "ScriptOrder": [
+                "Idle_Enter_08_testing",
+                "Idle_Enter_09",
+                "Idle_Leave_09",
+                "Idle_Leave_10",
+                "Sync_Enter_02",
+                "Sync_Enter_03",
+                "Sync_Leave_04",
+                "Sync_Leave_15",
+                "Download_Enter_12",
+                "Download_Enter_13",
+                "Download_Leave_14",
+                "Download_Leave_25",
+                "ArtifactInstall_Enter_01",
+                "ArtifactInstall_Enter_02",
+                "ArtifactInstall_Leave_01",
+                "ArtifactInstall_Leave_03",
+                "ArtifactReboot_Enter_01",
+                "ArtifactReboot_Enter_11",
+                "ArtifactReboot_Leave_01",
+                "ArtifactReboot_Leave_89",
+                "ArtifactReboot_Leave_99",
+                "ArtifactCommit_Enter_01",
+                "ArtifactCommit_Enter_05",
+                "ArtifactCommit_Error_91",
+                "ArtifactRollback_Enter_00",
+                "ArtifactRollback_Enter_01",
+                "ArtifactRollback_Leave_00",
+                "ArtifactRollback_Leave_01",
+                "ArtifactRollbackReboot_Enter_00",
+                "ArtifactRollbackReboot_Enter_99",
+                "ArtifactRollbackReboot_Leave_01",
+                "ArtifactRollbackReboot_Leave_99",
+                "ArtifactFailure_Enter_22",
+                "ArtifactFailure_Enter_33",
+                "ArtifactFailure_Leave_44",
+                "ArtifactFailure_Leave_55",
+            ],
+        },
+    ),
 ]
 
 
@@ -750,6 +750,10 @@ class TestStateScripts(MenderTesting):
                         fd.write(script_content)
                     if test_set.get("CorruptDataScriptVersionIn") == script:
                         fd.write("printf '1000' > /data/mender/scripts/version\n")
+                    if test_set.get("CorruptEtcScriptVersionIn") == script:
+                        fd.write("printf '1000' > /etc/mender/scripts/version\n")
+                    if test_set.get("RestoreEtcScriptVersionIn") == script:
+                        fd.write("printf '2' > /etc/mender/scripts/version\n")
 
             # Callback for our custom artifact maker
             def make_artifact(filename, artifact_name):


### PR DESCRIPTION
* [test_state_scripts] Modify suite to use dummy update module
The update module does nothing, just pretend to reboot by restarting
mender-client systemd service.
With this idea, we cannot check anymore that the device would end up in
the correct partition, but we do verify that the correct state scripts
are run (thus the state machine goes through the expected states).
Commenting out the last test case, which needs an actual full rootfs
update.

* [test_state_scripts] Modify test_reboot_recovery for update module
Similarly to previous commit, modify the reboot recovery cases to use
the dummy update module. Verify that the device reboots once
(spontaneous reboot).