### PR TITLE
Upgrade minio+traefik

### DIFF
--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -5,7 +5,7 @@ services:
     # minio
     #
     minio:
-        image: minio/minio:RELEASE.2018-09-25T21-34-43Z
+        image: minio/minio:RELEASE.2019-04-23T23-50-36Z
         restart: on-failure
         networks:
             mender:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     # mender-api-gateway
     #
     mender-api-gateway:
-        image: traefik:v2.2
+        image: traefik:v2.4
         extends:
             file: common.yml
             service: mender-base

--- a/extra/failover-testing/docker-compose.failover-server.yml
+++ b/extra/failover-testing/docker-compose.failover-server.yml
@@ -137,7 +137,7 @@ services:
 
     # Start a new minio and storage backend service on failover network
     minio-2:
-        image: minio/minio:RELEASE.2018-09-25T21-34-43Z
+        image: minio/minio:RELEASE.2019-04-23T23-50-36Z
         networks:
             mender-failover:
                 aliases:


### PR DESCRIPTION
just since I came across the minio version (while investigating storage problems that turned out to be a full disk 🙈) - unfortunately the newer ones don't contain a healthcheck, requiring us to maintain our own image if we want to stay up-to-date

and traefik for good measure - as the release is not too long ago + we are still steeped into finding issues 😅