### PR TITLE
Add mender-client-docker-addons Docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,9 +6,13 @@ include:
     file: '.gitlab-ci-check-python3-format.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-docker-build.yml'
 
 stages:
   - test
+  - build
+  - publish
 
 test:check-commits:
   except:
@@ -111,3 +115,13 @@ test:staging:backend-tests:
       - backend-tests/report_backend_integration_*.html
     reports:
       junit: backend-tests/results_backend_integration_*.xml
+
+build:docker:
+  variables:
+    DOCKER_REPOSITORY: mendersoftware/mender-client-docker-addons
+    DOCKER_DIR: extra/mender-client-docker-addons
+
+publish:image:
+  variables:
+    DOCKER_REPOSITORY: mendersoftware/mender-client-docker-addons
+    DOCKER_DIR: extra/mender-client-docker-addons

--- a/component-maps.yml
+++ b/component-maps.yml
@@ -38,8 +38,10 @@ git:
     release_component: true
 
   integration:
-    docker_image: []
-    docker_container: []
+    docker_image:
+    - mender-client-docker-addons
+    docker_container:
+    - mender-client
     release_component: true
     independent_component: true
 
@@ -59,8 +61,8 @@ git:
 
   mender:
     docker_image:
-    - mender-client-qemu
     - mender-client-docker
+    - mender-client-qemu
     - mender-client-qemu-rofs
     docker_container:
     - mender-client
@@ -230,6 +232,13 @@ docker_image:
   mender-client-docker:
     git:
     - mender
+    docker_container:
+    - mender-client
+    release_component: true
+
+  mender-client-docker-addons:
+    git:
+    - integration
     docker_container:
     - mender-client
     release_component: true
@@ -404,8 +413,9 @@ docker_container:
     git:
     - mender
     docker_image:
-    - mender-client-qemu
     - mender-client-docker
+    - mender-client-docker-addons
+    - mender-client-qemu
     - mender-client-qemu-rofs
     release_component: true
 

--- a/docker-compose.docker-client.addons.yml
+++ b/docker-compose.docker-client.addons.yml
@@ -1,0 +1,8 @@
+version: '2.1'
+services:
+
+    mender-client:
+        # Needs to be built in extra/mender-client-docker-addons
+        image: mendersoftware/mender-client-docker-addons:master
+        networks:
+            - mender

--- a/extra/mender-client-docker-addons/Dockerfile
+++ b/extra/mender-client-docker-addons/Dockerfile
@@ -1,0 +1,63 @@
+# Creates a container which acts as a bare bones non-VM based Mender
+# installation, for use in tests.
+FROM ubuntu:20.04 AS build
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y make git build-essential golang liblzma-dev \
+    jq libssl-dev libglib2.0-dev
+
+ARG MENDER_CLIENT_VERSION=master
+ARG MENDER_CONNECT_VERSION=master
+
+RUN git clone https://github.com/mendersoftware/mender /src/mender
+RUN (cd /src/mender && git checkout $MENDER_CLIENT_VERSION)
+
+RUN git clone https://github.com/mendersoftware/mender-connect /src/mender-connect
+RUN (cd /src/mender-connect && git checkout $MENDER_CONNECT_VERSION)
+
+RUN git clone https://github.com/mendersoftware/mender-configure-module /src/mender-configure-module
+# Checkout latest tag. No-op if there are no tags (stay in master)
+RUN (cd /src/mender-configure-module && \
+    latest=$(git tag | egrep ^[0-9]+\.[0-9]+\.[0-9]+*$ | sort | tail -n1) && \
+    git checkout $latest)
+
+WORKDIR /src/mender
+RUN make prefix=/mender-install install
+RUN jq ".ServerCertificate=\"/usr/share/doc/mender-client/examples/demo.crt\" | .ServerURL=\"https://docker.mender.io/\"" \
+    < examples/mender.conf.demo > /mender-install/etc/mender/mender.conf
+RUN echo artifact_name=original > /mender-install/etc/mender/artifact_info
+
+WORKDIR /src/mender-connect
+RUN make prefix=/mender-install install
+RUN jq ".User=\"root\"" \
+    < examples/mender-connect.conf > /mender-install/etc/mender/mender-connect.conf
+
+WORKDIR /src/mender-configure-module
+RUN make prefix=/mender-install install
+
+RUN mkdir -p /mender-install/var/lib/mender && echo device_type=docker-client > /mender-install/var/lib/mender/device_type
+
+FROM ubuntu:20.04
+
+RUN mkdir -p /run/dbus && apt update && apt install -y liblzma5 dbus openssh-server
+
+# Set no password
+RUN sed -ie 's/^root:[^:]*:/root::/' /etc/shadow
+RUN sed -ie 's/^UsePAM/#UsePam/' /etc/ssh/sshd_config
+RUN echo 'PermitEmptyPasswords yes\n\
+PermitRootLogin yes\n\
+Port 22\n\
+Port 8822\n' >> /etc/ssh/sshd_config
+
+COPY --from=build /mender-install/usr/bin/mender /usr/bin/mender
+COPY --from=build /mender-install/usr/bin/mender-connect /usr/bin/mender-connect
+COPY --from=build /mender-install/etc/mender /etc/mender
+COPY --from=build /mender-install/usr/share/mender /usr/share/mender
+COPY --from=build /mender-install/usr/share/doc/mender-client /usr/share/doc/mender-client
+COPY --from=build /mender-install/lib/systemd/system/mender-client.service /lib/systemd/system/mender-client.service
+COPY --from=build /mender-install/lib/systemd/system/mender-connect.service /lib/systemd/system/mender-connect.service
+COPY --from=build /mender-install/usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf
+COPY --from=build /mender-install/var/lib/mender /var/lib/mender
+
+COPY entrypoint.sh /
+CMD /entrypoint.sh

--- a/extra/mender-client-docker-addons/entrypoint.sh
+++ b/extra/mender-client-docker-addons/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+/etc/init.d/ssh start
+cp /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf /etc/dbus-1/system-local.conf
+dbus-daemon --nofork --nopidfile --system &
+sleep 8
+mender --no-syslog daemon
+sleep 8
+mender-connect daemon

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -1299,9 +1299,6 @@ def tag_and_push(state, tag_avail, next_tag_avail, final):
 
         # Modify docker tags in docker-compose file.
         for repo in sorted(Component.get_components_of_type("git"), key=repo_sort_key):
-            if repo.git() == "integration":
-                continue
-
             if repo.is_independent_component():
                 set_docker_compose_version_to(
                     tmpdir, repo, next_tag_avail[repo.git()]["build_tag"]
@@ -2900,8 +2897,6 @@ def do_hosted_release(version=None):
     for non_backend_comp in Component.get_components_of_type(
         "git", only_independent_component=True
     ):
-        if non_backend_comp.git() == "integration":
-            continue
         yml_component = non_backend_comp.yml_components()[0]
 
         non_backend_versions[non_backend_comp.git()] = version_of(


### PR DESCRIPTION
This will be a lightweight Docker image containing all Mender device
components (client + add-ons) but without dual rootfs (nor QEMU). To be
used in tests.

Integrated it also in release_tool as an image to be published from
integration repo itself.