### PR TITLE
client-docker-addons: fixed mender client blocking connect from starting

### DIFF
--- a/extra/mender-client-docker-addons/entrypoint.sh
+++ b/extra/mender-client-docker-addons/entrypoint.sh
@@ -5,6 +5,6 @@ set -e
 cp /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf /etc/dbus-1/system-local.conf
 dbus-daemon --nofork --nopidfile --system &
 sleep 8
-mender --no-syslog daemon
+mender --no-syslog daemon &
 sleep 8
 mender-connect daemon


### PR DESCRIPTION
the missing `&` evaded my review, however we need it or the `mender-connect` will never happen, preventing the deviceconnect connection from being connected...

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>