### PR TITLE
master: tests: Work around errors and warnings printed on stdout, not stderr.

### DIFF
--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -65,7 +65,7 @@ class TestUpdateModules(MenderTesting):
             deploy.check_expected_statistics(deployment_id, "failure", 1)
             deploy.check_expected_status("finished", deployment_id)
 
-            output = mender_device.run("mender -show-artifact").strip()
+            output = mender_device.run("mender -no-syslog -show-artifact").strip()
             assert output == "original"
 
             # Remove path block.
@@ -83,7 +83,7 @@ class TestUpdateModules(MenderTesting):
                 ).strip()
                 assert output == file_and_content
 
-            output = mender_device.run("mender -show-artifact").strip()
+            output = mender_device.run("mender -no-syslog -show-artifact").strip()
             assert output == expected_image_id
 
         finally:
@@ -115,7 +115,7 @@ class TestUpdateModules(MenderTesting):
             deploy.check_expected_status("finished", deployment_id)
             deploy.check_expected_statistics(deployment_id, "failure", 1)
 
-            output = mender_device.run("mender -show-artifact").strip()
+            output = mender_device.run("mender -no-syslog -show-artifact").strip()
             assert output == "original"
 
             output = standard_setup_one_docker_client_bootstrapped.get_logs_of_service(


### PR DESCRIPTION
The "payload" in the text is the Artifact name, but this is mixed with
warnings about not being able to connect to the syslog. This is not a
problem on later branches because stdout and stderr are properly
separated there.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit f3437167b6bb342c5bbb51220d441db44077f1f7)

Backported-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit b3b52089a66249ffebce7cb6f3280e849333a13d)