### PR TITLE
[pipeline] Override staging specific jobs to no-op

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,3 +167,11 @@ publish:image:mender:
   variables:
     DOCKER_REPOSITORY: mendersoftware/mender-client-docker-addons
     DOCKER_DIR: extra/mender-client-docker-addons
+
+trigger:saas:sync-staging-component:
+  rules:
+    - when: never
+
+publish:image:saas:
+  rules:
+    - when: never


### PR DESCRIPTION
integration is an special repo, which has an "staging" branch but not
with the same meaning as other repos (iow it does not build a Docker
image meant to be deployed in stating).

Kill this functionality from the templates by overriding the jobs.