### PR TITLE
[tests] Adjust test_mender_connect.py to expect error msg on error

### DIFF
--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -176,11 +176,12 @@ class TestMenderConnect:
             msg = prot.encode(b"")
             ws.send(msg)
 
-            msg = ws.recv()
-            body = prot.decode(msg)
-            assert prot.props["status"] == protomsg.PROP_STATUS_ERROR
-            assert prot.protoType == 12345
-            assert prot.typ == proto_shell.MSG_TYPE_SPAWN_SHELL
+            data = ws.recv()
+            rsp = protomsg.ProtoMsg(0xFFFF)
+            rsp.decode(data)
+            assert rsp.typ == "error"
+            body = rsp.body
+            assert isinstance(body.get("err"), str) and len(body.get("err")) > 0
 
     def test_session_recording(
         self, class_persistent_standard_setup_one_client_bootstrapped

--- a/testutils/api/protomsg.py
+++ b/testutils/api/protomsg.py
@@ -64,6 +64,7 @@ class ProtoMsg:
 
     # Returns body, attributes can be fetched from the ProtoMsg object.
     def decode(self, buf):
+
         obj = msgpack.unpackb(buf)
         if type(obj.get("hdr")) is not dict:
             raise TypeError("Malformed protomsg received.")
@@ -78,5 +79,14 @@ class ProtoMsg:
         self.typ = hdr.get("typ")
         self.sid = hdr.get("sid")
         self.props = hdr.get("props")
+        self._body = obj.get("body", b"")
 
         return obj.get("body")
+
+    @property
+    def body_raw(self) -> bytes:
+        return self._body
+
+    @property
+    def body(self) -> dict:
+        return msgpack.loads(self._body)


### PR DESCRIPTION
`test_bogus_proto_message` was affected by the changes introduced with mendersoftware/mender-connect#17. Messages with a `proto` header that is not associated with a known protocol will now receive an error control message.