### PR TITLE
prevented login errors from getting masked to allow recognizing 2fa errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,7 +241,7 @@ services:
             - traefik.http.routers.useradmLogin.entrypoints=https
             - traefik.http.routers.useradmLogin.rule=Path(`/api/management/{(v[0-9]+)}/useradm/auth/login`)||PathPrefix(`/api/management/{(v[0-9]+)}/useradm/{(oauth2|auth\/password-reset)}`)
             # traefik should automatically forward the x-forwarded-host header
-            - traefik.http.routers.useradmLogin.middlewares=sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.useradmLogin.middlewares=sec-headers,compression,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.useradmLogin.tls=true
             - traefik.http.routers.useradmLogin.service=useradmLogin
             - traefik.http.services.useradmLogin.loadbalancer.server.port=8080


### PR DESCRIPTION
2fa errors would otherwise be hidden behind a plain `401 - unauthorized` leading to the 2fa input to never being shown

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>