### PR TITLE
prevented test failures due to too strict string arg typings

### DIFF
--- a/testutils/api/protomsg.py
+++ b/testutils/api/protomsg.py
@@ -72,8 +72,7 @@ class ProtoMsg:
         hdr = obj["hdr"]
         if hdr.get("proto") != self.protoType:
             raise TypeError(
-                "Decoded message is not the right type, expected %d, got %d"
-                % (self.protoType, obj.get("proto"))
+                f'Decoded message is not the right type, expected {self.protoType}, got {obj.get("proto")}'
             )
 
         self.typ = hdr.get("typ")


### PR DESCRIPTION
- while keeping the failure intact

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>