### PR TITLE
[release_tool] Update yml name for integration special logic

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -525,7 +525,8 @@ def get_docker_compose_data_for_rev(git_dir, rev, version="git"):
 def version_of(
     integration_dir, yml_component, in_integration_version=None, git_version=True
 ):
-    if yml_component.yml() == "integration":
+    if yml_component.yml() == "mender-client-docker-addons":
+        # Also known as "integration"
         if in_integration_version is not None:
             # Just return the supplied version string.
             return in_integration_version


### PR DESCRIPTION
The "yaml" version of integration is now the name of the Docker image
that publishes. In order for the special handling in `version_of` to
kick in, it needs to use the Docker image name