### PR TITLE
introduce correct addon+plan settings for existing tests

### DIFF
--- a/backend-tests/tests/test_auditlogs.py
+++ b/backend-tests/tests/test_auditlogs.py
@@ -31,6 +31,7 @@ from testutils.common import (
     mongo,
     clean_mongo,
     get_mender_artifact,
+    update_tenant,
 )
 from testutils.api.client import ApiClient
 import testutils.api.useradm as useradm
@@ -63,6 +64,8 @@ def tenant_users(clean_migrated_mongo):
     )
 
     tenant.users.append(user)
+
+    update_tenant(tenant.id, addons=["troubleshoot"])
 
     for u in tenant.users:
         r = ApiClient(useradm.URL_MGMT).call(

--- a/backend-tests/tests/test_rbac.py
+++ b/backend-tests/tests/test_rbac.py
@@ -28,6 +28,7 @@ from testutils.common import (
     make_accepted_device,
     mongo,
     clean_mongo,
+    update_tenant,
 )
 from testutils.util.artifact import Artifact
 from testutils.api.client import ApiClient
@@ -312,6 +313,9 @@ class TestRBACDeviceGroupEnterprise:
             "secretsecret",
         )
         tenant = create_org(tenant, username, password, "enterprise")
+
+        update_tenant(tenant.id, addons=["configure"])
+
         test_case["user"]["name"] = test_case["user"]["name"].replace("UUID", uuidv4)
         test_user = create_user(tid=tenant.id, **test_case["user"])
         tenant.users.append(test_user)
@@ -383,6 +387,8 @@ class TestRBACDeviceGroupEnterprise:
             "secretsecret",
         )
         tenant = create_org(tenant, username, password, "enterprise")
+        update_tenant(tenant.id, addons=["configure"])
+
         admin_user = tenant.users[0]
         test_case["user"]["name"] = test_case["user"]["name"].replace("UUID", uuidv4)
         test_user = create_user(tid=tenant.id, **test_case["user"])

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -47,11 +47,13 @@ services:
     mender-device-auth:
         environment:
             DEVICEAUTH_TENANTADM_ADDR: 'http://mender-tenantadm:8080'
+            DEVICEAUTH_HAVE_ADDONS: 1
 
     mender-useradm:
         image: registry.mender.io/mendersoftware/useradm-enterprise:mender-master
         environment:
             USERADM_TENANTADM_ADDR: 'http://mender-tenantadm:8080'
+            USERADM_HAVE_ADDONS: 1
 
     mender-api-gateway:
         environment:

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -225,6 +225,17 @@ def enterprise_no_client(request):
     return env
 
 
+@pytest.fixture(scope="class")
+def enterprise_no_client_class(request):
+    env = container_factory.getEnterpriseSetup(num_clients=0)
+    request.addfinalizer(env.teardown)
+
+    env.setup()
+    reset_mender_api(env)
+
+    return env
+
+
 @pytest.fixture(scope="function")
 def enterprise_no_client_smtp(request):
     env = container_factory.getEnterpriseSMTPSetup()

--- a/tests/tests/test_configuration.py
+++ b/tests/tests/test_configuration.py
@@ -20,7 +20,7 @@ import redo
 
 from testutils.infra.cli import CliTenantadm
 from testutils.infra.device import MenderDevice
-from testutils.common import Tenant, User
+from testutils.common import Tenant, User, update_tenant
 
 from ..common_setup import standard_setup_one_client, enterprise_no_client
 from ..MenderAPI import (
@@ -88,6 +88,16 @@ class TestConfigurationEnterprise(MenderTesting):
         u = User("", "bugs.bunny@acme.org", "whatsupdoc")
         cli = CliTenantadm(containers_namespace=env.name)
         tid = cli.create_org("enterprise-tenant", u.name, u.pwd, plan="enterprise")
+
+        # what we really need is "configure"
+        # but for trigger tests we're also checking device avail. in "deviceconnect"
+        # so add "troubleshoot" as well
+        update_tenant(
+            tid,
+            addons=["configure", "troubleshoot"],
+            container_manager=get_container_manager(),
+        )
+
         tenant = cli.get_tenant(tid)
         tenant = json.loads(tenant)
         ttoken = tenant["tenant_token"]

--- a/tests/tests/test_filetransfer.py
+++ b/tests/tests/test_filetransfer.py
@@ -13,6 +13,8 @@
 #    limitations under the License.
 #
 
+import json
+import hashlib
 import io
 import os
 import random
@@ -22,13 +24,22 @@ import urllib.parse
 
 from tempfile import NamedTemporaryFile
 
-from ..common_setup import standard_setup_one_client
-from ..MenderAPI import authentication, devauth, get_container_manager, reset_mender_api
+from ..common_setup import standard_setup_one_client, enterprise_no_client
+
+from ..MenderAPI import (
+    authentication,
+    devauth,
+    get_container_manager,
+    reset_mender_api,
+    DeviceAuthV2,
+)
 from .common_connect import wait_for_connect
 from .common import md5sum
 from .mendertesting import MenderTesting
 from testutils.infra.container_manager import factory
 from testutils.infra.device import MenderDevice
+from testutils.common import Tenant, User, update_tenant
+from testutils.infra.cli import CliTenantadm
 
 container_factory = factory.get_factory()
 
@@ -59,28 +70,8 @@ def upload_file(path, file, devid, authtoken, mode="600", uid="0", gid="0"):
     return requests.put(upload_url, verify=False, headers=authtoken, files=files)
 
 
-class TestFileTransfer(MenderTesting):
-    """Tests the file transfer functionality"""
-
-    def test_filetransfer(self, standard_setup_one_client):
-        """Tests the file transfer features"""
-        # accept the device
-        devauth.accept_devices(1)
-
-        # list of devices
-        devices = list(
-            set([device["id"] for device in devauth.get_devices_status("accepted")])
-        )
-        assert 1 == len(devices)
-
-        # wait for the device to connect via websocket
-        auth = authentication.Authentication()
-        wait_for_connect(auth, devices[0])
-
-        # device ID and auth token
-        devid = devices[0]
-        authtoken = auth.get_auth_token()
-
+class _TestFileTransferBase(MenderTesting):
+    def test_filetransfer(self, devid, authtoken):
         # download a file and check its content
         path = "/etc/mender/mender.conf"
         r = download_file(path, devid, authtoken)
@@ -183,6 +174,31 @@ class TestFileTransfer(MenderTesting):
         assert r.status_code == 400, r.json()
         assert "failed to create target file" in r.json().get("error")
 
+
+class TestFileTransfer(_TestFileTransferBase):
+    """Tests the file transfer functionality"""
+
+    def test_filetransfer(self, standard_setup_one_client):
+        """Tests the file transfer features"""
+        # accept the device
+        devauth.accept_devices(1)
+
+        # list of devices
+        devices = list(
+            set([device["id"] for device in devauth.get_devices_status("accepted")])
+        )
+        assert 1 == len(devices)
+
+        # wait for the device to connect via websocket
+        auth = authentication.Authentication()
+        wait_for_connect(auth, devices[0])
+
+        # device ID and auth token
+        devid = devices[0]
+        authtoken = auth.get_auth_token()
+
+        super().test_filetransfer(devid, authtoken)
+
     @pytest.fixture(scope="function")
     def setup_mender_connect_1_0(self, request):
         self.env = container_factory.getMenderClient_2_5()
@@ -215,7 +231,54 @@ class TestFileTransfer(MenderTesting):
         devid = devices[0]
 
         wait_for_connect(auth, devid)
+
         rsp = upload_file("/foo/bar", io.StringIO("foobar"), devid, authtoken)
         assert rsp.status_code == 502
         rsp = download_file("/foo/bar", devid, authtoken)
         assert rsp.status_code == 502
+
+
+class TestFileTransferEnterprise(_TestFileTransferBase):
+    def test_filetransfer(self, enterprise_no_client):
+        u = User("", "bugs.bunny@acme.org", "whatsupdoc")
+        cli = CliTenantadm(containers_namespace=enterprise_no_client.name)
+        tid = cli.create_org("os-tenant", u.name, u.pwd, plan="os")
+
+        # FT requires "troubleshoot"
+        update_tenant(
+            tid, addons=["troubleshoot"], container_manager=get_container_manager(),
+        )
+
+        tenant = cli.get_tenant(tid)
+        tenant = json.loads(tenant)
+
+        auth = authentication.Authentication(
+            name="os-tenant", username=u.name, password=u.pwd
+        )
+        auth.create_org = False
+        auth.reset_auth_token()
+        devauth_tenant = DeviceAuthV2(auth)
+
+        enterprise_no_client.new_tenant_client(
+            "configuration-test-container", tenant["tenant_token"]
+        )
+        mender_device = MenderDevice(enterprise_no_client.get_mender_clients()[0])
+        mender_device.ssh_is_opened()
+
+        devauth_tenant.accept_devices(1)
+
+        devices = list(
+            set(
+                [
+                    device["id"]
+                    for device in devauth_tenant.get_devices_status("accepted")
+                ]
+            )
+        )
+        assert 1 == len(devices)
+
+        wait_for_connect(auth, devices[0])
+
+        authtoken = auth.get_auth_token()
+
+        super().test_filetransfer(devices[0], authtoken)

--- a/testutils/api/tenantadm.py
+++ b/testutils/api/tenantadm.py
@@ -18,9 +18,16 @@ URL_MGMT = "/api/management/v1/tenantadm"
 
 URL_INTERNAL_SUSPEND = "/tenants/{tid}/status"
 URL_INTERNAL_TENANTS = "/tenants"
+URL_INTERNAL_TENANT = "/tenants/{tid}"
 URL_MGMT_TENANTS = "/tenants"
 URL_MGMT_THIS_TENANT = "/user/tenant"
+
+ALL_ADDONS = ["troubleshoot", "configure"]
 
 
 def req_status(status):
     return {"status": status}
+
+
+def make_addons(addons=[]):
+    return [{"name": a, "enabled": a in addons} for a in ALL_ADDONS]

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -265,8 +265,8 @@ def make_accepted_device(dauthd1, dauthm, utoken, tenant_token=""):
 
 
 def make_accepted_devices(devauthd, devauthm, utoken, tenant_token="", num_devices=1):
-    """ Create accepted devices.
-        returns list of Device objects."""
+    """Create accepted devices.
+    returns list of Device objects."""
     devices = []
 
     # some 'accepted' devices, single authset
@@ -321,7 +321,7 @@ def get_mender_artifact(
 
 
 def wait_for_traefik(gateway_host, routers=[]):
-    """ Wait until provided routers are installed.
+    """Wait until provided routers are installed.
     Prevents race conditions where services are already up but traefik hasn't yet registered their routers. This causes subtle timing issues.
     By default checks the basic routers (incl. deployments - startup so time consuming, in practice it guarantees success).
     """
@@ -358,3 +358,23 @@ def wait_for_traefik(gateway_host, routers=[]):
             print("connection error while waiting for routers - but that's ok")
     else:
         assert False, "timeout hit waiting for traefik routers {}".format(rnames)
+
+
+def update_tenant(tid, addons=None, plan=None, container_manager=None):
+    """ Call internal PUT tenantadm/tenants/{tid} """
+    host = tenantadm.HOST
+    if container_manager is not None:
+        host = container_manager.get_ip_of_service("mender-tenantadm")[0] + ":8080"
+
+    update = {}
+    if addons is not None:
+        update["addons"] = tenantadm.make_addons(addons)
+
+    if plan is not None:
+        update["plan"] = plan
+
+    tadm = ApiClient(tenantadm.URL_INTERNAL, host=host, schema="http://")
+    res = tadm.call(
+        "PUT", tenantadm.URL_INTERNAL_TENANT, body=update, path_params={"tid": tid},
+    )
+    assert res.status_code == 202


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-4510

Part 1:
- bring existing tests up to date with regards to addons vs plans vs feature availability
- extend tests where necessary to enterprise versions (with $HAVE_ADDONS), to verify that the access is basically ok (happy paths with correct access levels)

---

_The idea is also to have Part 2 TODO:_
_- will test tenant addon/plan management_
_- so - tenant updates and transitions between plans/addons vs feature availability_
_- organized as a separate test class with an exhaustive list of scenarios (for readability - exploding existing tests across the various plan and addon combinations would be hard to implement and to follow)_

_both parts, together with the already very extensive acceptance tests of the access layers should give us a good coverage of addons in general - both access rules and user flows between tiers._