### PR TITLE
[conftest] pytest_exception_interact: Handle start-up time exceptions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,11 +109,13 @@ def pytest_exception_interact(node, call, report):
 
         # Hack-ish way to inspect the fixtures in use by the node to find a MenderDevice/MenderDeviceGroup
         device = None
-        env_candidates = [
-            val
-            for val in node.funcargs.values()
-            if isinstance(val, BaseContainerManagerNamespace)
-        ]
+        env_candidates = []
+        if getattr(node, "funcargs", None) is not None:
+            env_candidates = [
+                val
+                for val in node.funcargs.values()
+                if isinstance(val, BaseContainerManagerNamespace)
+            ]
         if len(env_candidates) > 0:
             env = env_candidates[0]
             dev_candidates = [


### PR DESCRIPTION
By checking for 'funcargs' attribute in the node before accessing it.
This makes the hook not be in the way for any exception that might
happen before a test starts, for example a syntax error.