### PR TITLE
Mark test_mtls_enterprise_hsm and test_demo_artifact with xfail

### DIFF
--- a/tests/tests/test_demo_artifact.py
+++ b/tests/tests/test_demo_artifact.py
@@ -103,6 +103,7 @@ class TestDemoArtifact(MenderTesting):
     # Give the test a timeframe, as the script might run forever,
     # if something goes awry, or the script is not brought down properly.
     @pytest.mark.timeout(3000)
+    @pytest.mark.xfail(reason="Test is known to be unstable: FIXME")
     def test_demo_artifact(self, run_demo_script):
         """Tests that the demo script does indeed upload the demo Artifact to the server."""
 

--- a/tests/tests/test_mtls.py
+++ b/tests/tests/test_mtls.py
@@ -236,6 +236,7 @@ pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so --login --pin {pin} --write
 
     @MenderTesting.fast
     @pytest.mark.parametrize("algorithm", ["rsa", "ec256", "ed25519"])
+    @pytest.mark.xfail(reason="Test is known to be unstable: FIXME")
     def test_mtls_enterprise(self, setup_ent_mtls, algorithm):
         self.common_test_mtls_enterprise(setup_ent_mtls, algorithm, use_hsm=False)
 
@@ -267,6 +268,7 @@ pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so --login --pin {pin} --write
 
     @MenderTesting.fast
     @pytest.mark.parametrize("algorithm", ["rsa"])
+    @pytest.mark.xfail(reason="Test is known to be unstable: FIXME")
     def test_mtls_enterprise_hsm(self, setup_ent_mtls, algorithm):
 
         # Check if the client has has SoftHSM (from yocto dunfell forward)

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -59,12 +59,6 @@ class DockerComposeNamespace(DockerNamespace):
         COMPOSE_FILES_PATH + "/storage-proxy/docker-compose.storage-proxy.yml",
         COMPOSE_FILES_PATH + "/storage-proxy/docker-compose.storage-proxy.demo.yml",
     ]
-    LEGACY_CLIENT_FILES = [
-        COMPOSE_FILES_PATH + "/docker-compose.client.yml",
-        COMPOSE_FILES_PATH + "/tests/legacy-v1-client.yml",
-        COMPOSE_FILES_PATH + "/storage-proxy/docker-compose.storage-proxy.yml",
-        COMPOSE_FILES_PATH + "/storage-proxy/docker-compose.storage-proxy.demo.yml",
-    ]
     SIGNED_ARTIFACT_CLIENT_FILES = [
         COMPOSE_FILES_PATH
         + "/extra/signed-artifact-client-testing/docker-compose.signed-client.yml"


### PR DESCRIPTION
Allow these tests (yet still keep track of their failure statistics) until the issues have been resolved.
I also cleaned up the duplicate variable introduced in #1264.