### PR TITLE
Remove mender-api-gateway from git-versions, no longer part of release.

### DIFF
--- a/git-versions.yml
+++ b/git-versions.yml
@@ -13,9 +13,6 @@ services:
     mender-gui:
         image: mendersoftware/gui:master
 
-    mender-api-gateway:
-        image: mendersoftware/api-gateway:master
-
     mender-device-auth:
         image: mendersoftware/deviceauth:master
 


### PR DESCRIPTION
Changelog: Remove nginx-based api-gateway and replace with Traefik.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>