### PR TITLE
compose: fix useradm verification

### DIFF
--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -18,7 +18,7 @@ services:
             - traefik.enable=true
             - traefik.http.routers.auditlogs.entrypoints=https
             - traefik.http.routers.auditlogs.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder4
-            - traefik.http.routers.auditlogs.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/auditlogs`)
+            - traefik.http.routers.auditlogs.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/auditlogs`)
             - traefik.http.routers.auditlogs.tls=true
             - traefik.http.routers.auditlogs.service=auditlogs
             - traefik.http.services.auditlogs.loadbalancer.server.port=8080

--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -18,7 +18,7 @@ services:
             - traefik.enable=true
             - traefik.http.routers.auditlogs.entrypoints=https
             - traefik.http.routers.auditlogs.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder4
-            - traefik.http.routers.auditlogs.rule=PathPrefix(`/api/management/{(v[0-9]+)}/auditlogs`)
+            - traefik.http.routers.auditlogs.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/auditlogs`)
             - traefik.http.routers.auditlogs.tls=true
             - traefik.http.routers.auditlogs.service=auditlogs
             - traefik.http.services.auditlogs.loadbalancer.server.port=8080

--- a/docker-compose.config.yml
+++ b/docker-compose.config.yml
@@ -17,14 +17,14 @@ services:
         labels:
             - traefik.enable=true
             - traefik.http.routers.deviceconfig.entrypoints=https
-            - traefik.http.routers.deviceconfig.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/deviceconfig`)
+            - traefik.http.routers.deviceconfig.rule=PathPrefix(`/api/devices/{ver:v[0-9]+}/deviceconfig`)
             - traefik.http.routers.deviceconfig.tls=true
             - traefik.http.routers.deviceconfig.service=deviceconfig
             - traefik.http.routers.deviceconfig.middlewares=devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.services.deviceconfig.loadbalancer.server.port=8080
             - traefik.http.routers.deviceconfigMgmt.entrypoints=https
             - traefik.http.routers.deviceconfigMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder4
-            - traefik.http.routers.deviceconfigMgmt.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/deviceconfig`)
+            - traefik.http.routers.deviceconfigMgmt.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/deviceconfig`)
             - traefik.http.routers.deviceconfigMgmt.tls=true
             - traefik.http.routers.deviceconfigMgmt.service=deviceconfig
             - traefik.http.services.deviceconfigMgmt.loadbalancer.server.port=8080

--- a/docker-compose.config.yml
+++ b/docker-compose.config.yml
@@ -17,14 +17,14 @@ services:
         labels:
             - traefik.enable=true
             - traefik.http.routers.deviceconfig.entrypoints=https
-            - traefik.http.routers.deviceconfig.rule=PathPrefix(`/api/devices/{(v[0-9]+)}/deviceconfig`)
+            - traefik.http.routers.deviceconfig.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/deviceconfig`)
             - traefik.http.routers.deviceconfig.tls=true
             - traefik.http.routers.deviceconfig.service=deviceconfig
             - traefik.http.routers.deviceconfig.middlewares=devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.services.deviceconfig.loadbalancer.server.port=8080
             - traefik.http.routers.deviceconfigMgmt.entrypoints=https
             - traefik.http.routers.deviceconfigMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder4
-            - traefik.http.routers.deviceconfigMgmt.rule=PathPrefix(`/api/management/{(v[0-9]+)}/deviceconfig`)
+            - traefik.http.routers.deviceconfigMgmt.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/deviceconfig`)
             - traefik.http.routers.deviceconfigMgmt.tls=true
             - traefik.http.routers.deviceconfigMgmt.service=deviceconfig
             - traefik.http.services.deviceconfigMgmt.loadbalancer.server.port=8080

--- a/docker-compose.connect.yml
+++ b/docker-compose.connect.yml
@@ -21,13 +21,13 @@ services:
         labels:
             - traefik.enable=true
             - traefik.http.routers.deviceconnect.entrypoints=https
-            - traefik.http.routers.deviceconnect.rule=PathPrefix(`/api/devices/{(v[0-9]+)}/deviceconnect`)
+            - traefik.http.routers.deviceconnect.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/deviceconnect`)
             - traefik.http.routers.deviceconnect.tls=true
             - traefik.http.routers.deviceconnect.service=deviceconnect
             - traefik.http.routers.deviceconnect.middlewares=devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.services.deviceconnect.loadbalancer.server.port=8080
             - traefik.http.routers.deviceconnectMgmt.entrypoints=https
-            - traefik.http.routers.deviceconnectMgmt.rule=PathPrefix(`/api/management/{(v[0-9]+)}/deviceconnect`)
+            - traefik.http.routers.deviceconnectMgmt.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/deviceconnect`)
             - traefik.http.routers.deviceconnectMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deviceconnectMgmt.tls=true
             - traefik.http.routers.deviceconnectMgmt.service=deviceconnectMgmt

--- a/docker-compose.connect.yml
+++ b/docker-compose.connect.yml
@@ -21,13 +21,13 @@ services:
         labels:
             - traefik.enable=true
             - traefik.http.routers.deviceconnect.entrypoints=https
-            - traefik.http.routers.deviceconnect.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/deviceconnect`)
+            - traefik.http.routers.deviceconnect.rule=PathPrefix(`/api/devices/{ver:v[0-9]+}/deviceconnect`)
             - traefik.http.routers.deviceconnect.tls=true
             - traefik.http.routers.deviceconnect.service=deviceconnect
             - traefik.http.routers.deviceconnect.middlewares=devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.services.deviceconnect.loadbalancer.server.port=8080
             - traefik.http.routers.deviceconnectMgmt.entrypoints=https
-            - traefik.http.routers.deviceconnectMgmt.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/deviceconnect`)
+            - traefik.http.routers.deviceconnectMgmt.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/deviceconnect`)
             - traefik.http.routers.deviceconnectMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deviceconnectMgmt.tls=true
             - traefik.http.routers.deviceconnectMgmt.service=deviceconnectMgmt

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -26,14 +26,14 @@ services:
             - traefik.enable=true
             - traefik.http.routers.tenantadm.entrypoints=https
             - traefik.http.routers.tenantadm.middlewares=userauth,sec-headers,compression
-            - traefik.http.routers.tenantadm.rule=PathPrefix(`/api/management/{(v[0-9]+)}/tenantadm`)
+            - traefik.http.routers.tenantadm.rule=PathPrefix(`/api/management/{v[0-9]+}/tenantadm`)
             - traefik.http.routers.tenantadm.tls=true
             - traefik.http.routers.tenantadm.service=tenantadm
             - traefik.http.services.tenantadm.loadbalancer.server.port=8080
 
             - traefik.http.routers.tenantadmMgmt.entrypoints=https
             - traefik.http.routers.tenantadmMgmt.middlewares=sec-headers,compression
-            - traefik.http.routers.tenantadmMgmt.rule=PathPrefix(`/api/management/{(v[0-9]+)}/tenantadm/tenants`) && Method(`OPTIONS`,`POST`,`PUT`,`DELETE`)
+            - traefik.http.routers.tenantadmMgmt.rule=PathPrefix(`/api/management/{v[0-9]+}/tenantadm/tenants`) && Method(`OPTIONS`,`POST`,`PUT`,`DELETE`)
             - traefik.http.routers.tenantadmMgmt.tls=true
             - traefik.http.routers.tenantadmMgmt.service=tenantadmMgmt
             - traefik.http.services.tenantadmMgmt.loadbalancer.server.port=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,13 +233,13 @@ services:
             - traefik.enable=true
             - traefik.http.routers.useradm.entrypoints=https
             - traefik.http.routers.useradm.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
-            - traefik.http.routers.useradm.rule=PathPrefix(`/api/management/{(v[0-9]+)}/useradm`)
+            - traefik.http.routers.useradm.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/useradm`)
             - traefik.http.routers.useradm.tls=true
             - traefik.http.routers.useradm.service=useradm
             - traefik.http.services.useradm.loadbalancer.server.port=8080
 
             - traefik.http.routers.useradmLogin.entrypoints=https
-            - traefik.http.routers.useradmLogin.rule=Path(`/api/management/{(v[0-9]+)}/useradm/auth/login`)||PathPrefix(`/api/management/{(v[0-9]+)}/useradm/{(oauth2|auth\/password-reset)}`)
+            - traefik.http.routers.useradmLogin.rule=Path(`/api/management/{ver:(v[0-9]+)}/useradm/auth/login`)||PathPrefix(`/api/management/{ver:(v[0-9]+)}/useradm/{ep:(oauth2|auth\/password-reset)}`)
             # traefik should automatically forward the x-forwarded-host header
             - traefik.http.routers.useradmLogin.middlewares=sec-headers,compression,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.useradmLogin.tls=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - traefik.enable=true
             # Devices API
             - traefik.http.routers.deployments.entrypoints=https
-            - traefik.http.routers.deployments.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/deployments`)
+            - traefik.http.routers.deployments.rule=PathPrefix(`/api/devices/{ver:v[0-9]+}/deployments`)
             - traefik.http.routers.deployments.middlewares=devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deployments.tls=true
             - traefik.http.routers.deployments.service=deployments
@@ -24,7 +24,7 @@ services:
             - traefik.http.services.deployments.loadbalancer.healthcheck.timeout=5s
             # Devices API download endpoint - we won't use compression here
             - traefik.http.routers.deploymentsDL.entrypoints=https
-            - traefik.http.routers.deploymentsDL.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/deployments/download`)
+            - traefik.http.routers.deploymentsDL.rule=PathPrefix(`/api/devices/{ver:v[0-9]+}/deployments/download`)
             - traefik.http.routers.deploymentsDL.middlewares=sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deploymentsDL.tls=true
             - traefik.http.routers.deploymentsDL.service=deploymentsDL
@@ -35,7 +35,7 @@ services:
             - traefik.http.services.deploymentsDL.loadbalancer.healthcheck.timeout=3s
             # Management API
             - traefik.http.routers.deploymentsMgmt.entrypoints=https
-            - traefik.http.routers.deploymentsMgmt.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/deployments`)
+            - traefik.http.routers.deploymentsMgmt.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/deployments`)
             - traefik.http.routers.deploymentsMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deploymentsMgmt.tls=true
             - traefik.http.routers.deploymentsMgmt.service=deploymentsMgmt
@@ -161,13 +161,13 @@ services:
         labels:
             - traefik.enable=true
             - traefik.http.routers.deviceauth.entrypoints=https
-            - traefik.http.routers.deviceauth.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/authentication`)
+            - traefik.http.routers.deviceauth.rule=PathPrefix(`/api/devices/{ver:v[0-9]+}/authentication`)
             - traefik.http.routers.deviceauth.tls=true
             - traefik.http.routers.deviceauth.service=deviceauth
             - traefik.http.services.deviceauth.loadbalancer.server.port=8080
             
             - traefik.http.routers.deviceauthMgmt.entrypoints=https
-            - traefik.http.routers.deviceauthMgmt.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/devauth`)
+            - traefik.http.routers.deviceauthMgmt.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/devauth`)
             - traefik.http.routers.deviceauthMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deviceauthMgmt.tls=true
             - traefik.http.routers.deviceauthMgmt.service=deviceauthMgmt
@@ -233,13 +233,13 @@ services:
             - traefik.enable=true
             - traefik.http.routers.useradm.entrypoints=https
             - traefik.http.routers.useradm.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
-            - traefik.http.routers.useradm.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/useradm`)
+            - traefik.http.routers.useradm.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/useradm`)
             - traefik.http.routers.useradm.tls=true
             - traefik.http.routers.useradm.service=useradm
             - traefik.http.services.useradm.loadbalancer.server.port=8080
 
             - traefik.http.routers.useradmLogin.entrypoints=https
-            - traefik.http.routers.useradmLogin.rule=Path(`/api/management/{ver:(v[0-9]+)}/useradm/auth/login`)||PathPrefix(`/api/management/{ver:(v[0-9]+)}/useradm/{ep:(oauth2|auth\/password-reset)}`)
+            - traefik.http.routers.useradmLogin.rule=Path(`/api/management/{ver:v[0-9]+}/useradm/auth/login`)||PathPrefix(`/api/management/{ver:v[0-9]+}/useradm/{ep:oauth2|auth\/password-reset}`)
             # traefik should automatically forward the x-forwarded-host header
             - traefik.http.routers.useradmLogin.middlewares=sec-headers,compression,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.useradmLogin.tls=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - traefik.enable=true
             # Devices API
             - traefik.http.routers.deployments.entrypoints=https
-            - traefik.http.routers.deployments.rule=PathPrefix(`/api/devices/{(v[0-9]+)}/deployments`)
+            - traefik.http.routers.deployments.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/deployments`)
             - traefik.http.routers.deployments.middlewares=devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deployments.tls=true
             - traefik.http.routers.deployments.service=deployments
@@ -24,7 +24,7 @@ services:
             - traefik.http.services.deployments.loadbalancer.healthcheck.timeout=5s
             # Devices API download endpoint - we won't use compression here
             - traefik.http.routers.deploymentsDL.entrypoints=https
-            - traefik.http.routers.deploymentsDL.rule=PathPrefix(`/api/devices/{(v[0-9]+)}/deployments/download`)
+            - traefik.http.routers.deploymentsDL.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/deployments/download`)
             - traefik.http.routers.deploymentsDL.middlewares=sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deploymentsDL.tls=true
             - traefik.http.routers.deploymentsDL.service=deploymentsDL
@@ -35,7 +35,7 @@ services:
             - traefik.http.services.deploymentsDL.loadbalancer.healthcheck.timeout=3s
             # Management API
             - traefik.http.routers.deploymentsMgmt.entrypoints=https
-            - traefik.http.routers.deploymentsMgmt.rule=PathPrefix(`/api/management/{(v[0-9]+)}/deployments`)
+            - traefik.http.routers.deploymentsMgmt.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/deployments`)
             - traefik.http.routers.deploymentsMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deploymentsMgmt.tls=true
             - traefik.http.routers.deploymentsMgmt.service=deploymentsMgmt
@@ -161,13 +161,13 @@ services:
         labels:
             - traefik.enable=true
             - traefik.http.routers.deviceauth.entrypoints=https
-            - traefik.http.routers.deviceauth.rule=PathPrefix(`/api/devices/{(v[0-9]+)}/authentication`)
+            - traefik.http.routers.deviceauth.rule=PathPrefix(`/api/devices/{ver:(v[0-9]+)}/authentication`)
             - traefik.http.routers.deviceauth.tls=true
             - traefik.http.routers.deviceauth.service=deviceauth
             - traefik.http.services.deviceauth.loadbalancer.server.port=8080
             
             - traefik.http.routers.deviceauthMgmt.entrypoints=https
-            - traefik.http.routers.deviceauthMgmt.rule=PathPrefix(`/api/management/{(v[0-9]+)}/devauth`)
+            - traefik.http.routers.deviceauthMgmt.rule=PathPrefix(`/api/management/{ver:(v[0-9]+)}/devauth`)
             - traefik.http.routers.deviceauthMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deviceauthMgmt.tls=true
             - traefik.http.routers.deviceauthMgmt.service=deviceauthMgmt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,13 +238,13 @@ services:
             - traefik.http.routers.useradm.service=useradm
             - traefik.http.services.useradm.loadbalancer.server.port=8080
 
-            - traefik.http.routers.useradmLogin.entrypoints=https
-            - traefik.http.routers.useradmLogin.rule=Path(`/api/management/{ver:v[0-9]+}/useradm/auth/login`)||PathPrefix(`/api/management/{ver:v[0-9]+}/useradm/{ep:oauth2|auth\/password-reset}`)
+            - traefik.http.routers.useradmNoAuth.entrypoints=https
+            - traefik.http.routers.useradmNoAuth.rule=Path(`/api/management/{ver:v[0-9]+}/useradm/auth/login`)||PathPrefix(`/api/management/{ver:v[0-9]+}/useradm/{ep:oauth2|auth\/password-reset|auth\/verify-email}`)
             # traefik should automatically forward the x-forwarded-host header
-            - traefik.http.routers.useradmLogin.middlewares=sec-headers,compression,json-error-responder2,json-error-responder3,json-error-responder4
-            - traefik.http.routers.useradmLogin.tls=true
-            - traefik.http.routers.useradmLogin.service=useradmLogin
-            - traefik.http.services.useradmLogin.loadbalancer.server.port=8080
+            - traefik.http.routers.useradmNoAuth.middlewares=sec-headers,compression,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.useradmNoAuth.tls=true
+            - traefik.http.routers.useradmNoAuth.service=useradmNoAuth
+            - traefik.http.services.useradmNoAuth.loadbalancer.server.port=8080
             - mender.testprefix=${MENDER_TESTPREFIX:-""}
         networks:
             - mender

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -337,7 +337,7 @@ def wait_for_traefik(gateway_host, routers=[]):
             "inventoryMgmt@docker",
             "inventoryMgmtV1@docker",
             "useradm@docker",
-            "useradmLogin@docker",
+            "useradmNoAuth@docker",
             "deviceauth@docker",
             "deviceauthMgmt@docker",
             "inventoryV1@docker",


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-4623

useradm's /verify is not called for its own mgmt endpoints.
useradmLogin 'hijacks' all mgmt requests. that router doesn't enforce verification
of course; we intended to use the 'useradm' router instead.

the reason is malformed regex paths. traefik wants regex expressions
formatted in a very specific way:

... to use regular expressions with Host and Path expressions, you
must declare an arbitrarily named variable followed by the
colon-separated regular expression, all enclosed in curly braces. Any
pattern supported by Go's regexp package may be used (example:
`/posts/{id:[0-9]+}`).

iow the var name is mandatory. without it, the regex is not even parsed,
and the captured path segment can be anything.

that's why the useradmLogin router path means in fact:
`/api/management/{something}/useradm/{something}`

so it happily captures `/api/management/v1/useradm/users`, etc.
our regexes our understood as just var names/path segments.

changelog: fix auth verification on useradm APIs

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>


---

for reference: 
https://doc.traefik.io/traefik/routing/routers/ (Regexp Syntax section)