### PR TITLE
added circuitbreaker middleware to prevent accumulating buffered requests

### DIFF
--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -17,7 +17,7 @@ services:
         labels:
             - traefik.enable=true
             - traefik.http.routers.auditlogs.entrypoints=https
-            - traefik.http.routers.auditlogs.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder4
+            - traefik.http.routers.auditlogs.middlewares=circuitbreaker,userauth,sec-headers,compression,json-error-responder1,json-error-responder4
             - traefik.http.routers.auditlogs.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/auditlogs`)
             - traefik.http.routers.auditlogs.tls=true
             - traefik.http.routers.auditlogs.service=auditlogs

--- a/docker-compose.config.yml
+++ b/docker-compose.config.yml
@@ -20,10 +20,10 @@ services:
             - traefik.http.routers.deviceconfig.rule=PathPrefix(`/api/devices/{ver:v[0-9]+}/deviceconfig`)
             - traefik.http.routers.deviceconfig.tls=true
             - traefik.http.routers.deviceconfig.service=deviceconfig
-            - traefik.http.routers.deviceconfig.middlewares=devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deviceconfig.middlewares=circuitbreaker,devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.services.deviceconfig.loadbalancer.server.port=8080
             - traefik.http.routers.deviceconfigMgmt.entrypoints=https
-            - traefik.http.routers.deviceconfigMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder4
+            - traefik.http.routers.deviceconfigMgmt.middlewares=circuitbreaker,userauth,sec-headers,compression,json-error-responder1,json-error-responder4
             - traefik.http.routers.deviceconfigMgmt.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/deviceconfig`)
             - traefik.http.routers.deviceconfigMgmt.tls=true
             - traefik.http.routers.deviceconfigMgmt.service=deviceconfig

--- a/docker-compose.connect.yml
+++ b/docker-compose.connect.yml
@@ -24,11 +24,11 @@ services:
             - traefik.http.routers.deviceconnect.rule=PathPrefix(`/api/devices/{ver:v[0-9]+}/deviceconnect`)
             - traefik.http.routers.deviceconnect.tls=true
             - traefik.http.routers.deviceconnect.service=deviceconnect
-            - traefik.http.routers.deviceconnect.middlewares=devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deviceconnect.middlewares=circuitbreaker,devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.services.deviceconnect.loadbalancer.server.port=8080
             - traefik.http.routers.deviceconnectMgmt.entrypoints=https
             - traefik.http.routers.deviceconnectMgmt.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/deviceconnect`)
-            - traefik.http.routers.deviceconnectMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deviceconnectMgmt.middlewares=circuitbreaker,userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deviceconnectMgmt.tls=true
             - traefik.http.routers.deviceconnectMgmt.service=deviceconnectMgmt
             - traefik.http.services.deviceconnectMgmt.loadbalancer.server.port=8080

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -25,14 +25,14 @@ services:
         labels:
             - traefik.enable=true
             - traefik.http.routers.tenantadm.entrypoints=https
-            - traefik.http.routers.tenantadm.middlewares=userauth,sec-headers,compression
+            - traefik.http.routers.tenantadm.middlewares=circuitbreaker,userauth,sec-headers,compression
             - traefik.http.routers.tenantadm.rule=PathPrefix(`/api/management/{v[0-9]+}/tenantadm`)
             - traefik.http.routers.tenantadm.tls=true
             - traefik.http.routers.tenantadm.service=tenantadm
             - traefik.http.services.tenantadm.loadbalancer.server.port=8080
 
             - traefik.http.routers.tenantadmMgmt.entrypoints=https
-            - traefik.http.routers.tenantadmMgmt.middlewares=sec-headers,compression
+            - traefik.http.routers.tenantadmMgmt.middlewares=circuitbreaker,sec-headers,compression
             - traefik.http.routers.tenantadmMgmt.rule=PathPrefix(`/api/management/{v[0-9]+}/tenantadm/tenants`) && Method(`OPTIONS`,`POST`,`PUT`,`DELETE`)
             - traefik.http.routers.tenantadmMgmt.tls=true
             - traefik.http.routers.tenantadmMgmt.service=tenantadmMgmt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
             # Devices API
             - traefik.http.routers.deployments.entrypoints=https
             - traefik.http.routers.deployments.rule=PathPrefix(`/api/devices/{ver:v[0-9]+}/deployments`)
-            - traefik.http.routers.deployments.middlewares=devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deployments.middlewares=circuitbreaker,devauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deployments.tls=true
             - traefik.http.routers.deployments.service=deployments
             - traefik.http.services.deployments.loadbalancer.server.port=8080
@@ -25,7 +25,7 @@ services:
             # Devices API download endpoint - we won't use compression here
             - traefik.http.routers.deploymentsDL.entrypoints=https
             - traefik.http.routers.deploymentsDL.rule=PathPrefix(`/api/devices/{ver:v[0-9]+}/deployments/download`)
-            - traefik.http.routers.deploymentsDL.middlewares=sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deploymentsDL.middlewares=circuitbreaker,sec-headers,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deploymentsDL.tls=true
             - traefik.http.routers.deploymentsDL.service=deploymentsDL
             - traefik.http.services.deploymentsDL.loadbalancer.server.port=8080
@@ -36,7 +36,7 @@ services:
             # Management API
             - traefik.http.routers.deploymentsMgmt.entrypoints=https
             - traefik.http.routers.deploymentsMgmt.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/deployments`)
-            - traefik.http.routers.deploymentsMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deploymentsMgmt.middlewares=circuitbreaker,userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deploymentsMgmt.tls=true
             - traefik.http.routers.deploymentsMgmt.service=deploymentsMgmt
             - traefik.http.services.deploymentsMgmt.loadbalancer.server.port=8080
@@ -88,6 +88,7 @@ services:
             - traefik.http.middlewares.sec-headers.headers.browserXssFilter=true
             - traefik.http.middlewares.sec-headers.headers.customRequestHeaders.X-Forwarded-Proto=https
             - traefik.http.middlewares.compression.compress=true
+            - traefik.http.middlewares.circuitbreaker.circuitbreaker.expression=ResponseCodeRatio(500, 600, 0, 600) > 0.25 || NetworkErrorRatio() > 0.10
             - traefik.http.middlewares.devauth.forwardAuth.address=http://mender-device-auth:8080/api/internal/v1/devauth/tokens/verify
             - traefik.http.middlewares.devauth.forwardAuth.authResponseHeaders=X-MEN-RequestID
             - traefik.http.middlewares.userauth.forwardAuth.address=http://mender-useradm:8080/api/internal/v1/useradm/auth/verify
@@ -168,7 +169,7 @@ services:
             
             - traefik.http.routers.deviceauthMgmt.entrypoints=https
             - traefik.http.routers.deviceauthMgmt.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/devauth`)
-            - traefik.http.routers.deviceauthMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.deviceauthMgmt.middlewares=circuitbreaker,userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.deviceauthMgmt.tls=true
             - traefik.http.routers.deviceauthMgmt.service=deviceauthMgmt
             - traefik.http.services.deviceauthMgmt.loadbalancer.server.port=8080
@@ -194,14 +195,14 @@ services:
             - traefik.http.routers.inventoryMgmt.entrypoints=https
             - traefik.http.routers.inventoryMgmt.rule=PathPrefix(`/api/management/v2/inventory`)
             - traefik.http.routers.inventoryMgmt.service=inventoryMgmt
-            - traefik.http.routers.inventoryMgmt.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.inventoryMgmt.middlewares=circuitbreaker,userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.inventoryMgmt.tls=true
             - traefik.http.services.inventoryMgmt.loadbalancer.server.port=8080
 
             - traefik.http.middlewares.inventoryMgmtV1-replacepathregex.replacepathregex.regex=^/api/management/v1/inventory/(.*)
             - traefik.http.middlewares.inventoryMgmtV1-replacepathregex.replacepathregex.replacement=/api/0.1.0/$$1
             - traefik.http.routers.inventoryMgmtV1.entrypoints=https
-            - traefik.http.routers.inventoryMgmtV1.middlewares=userauth,inventoryMgmtV1-replacepathregex,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.inventoryMgmtV1.middlewares=circuitbreaker,userauth,inventoryMgmtV1-replacepathregex,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.inventoryMgmtV1.rule=PathPrefix(`/api/management/v1/inventory`)
             - traefik.http.routers.inventoryMgmtV1.service=inventoryMgmtV1
             - traefik.http.routers.inventoryMgmtV1.tls=true
@@ -210,7 +211,7 @@ services:
             - traefik.http.middlewares.inventoryV1-replacepathregex.replacepathregex.regex=^/api/devices/v1/inventory/(.*)
             - traefik.http.middlewares.inventoryV1-replacepathregex.replacepathregex.replacement=/api/0.1.0/attributes
             - traefik.http.routers.inventoryV1.entrypoints=https
-            - traefik.http.routers.inventoryV1.middlewares=devauth,inventoryV1-replacepathregex,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.inventoryV1.middlewares=circuitbreaker,devauth,inventoryV1-replacepathregex,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.inventoryV1.rule=PathPrefix(`/api/devices/v1/inventory`)
             - traefik.http.routers.inventoryV1.service=inventoryV1
             - traefik.http.routers.inventoryV1.tls=true
@@ -232,7 +233,7 @@ services:
         labels:
             - traefik.enable=true
             - traefik.http.routers.useradm.entrypoints=https
-            - traefik.http.routers.useradm.middlewares=userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.useradm.middlewares=circuitbreaker,userauth,sec-headers,compression,json-error-responder1,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.useradm.rule=PathPrefix(`/api/management/{ver:v[0-9]+}/useradm`)
             - traefik.http.routers.useradm.tls=true
             - traefik.http.routers.useradm.service=useradm
@@ -241,7 +242,7 @@ services:
             - traefik.http.routers.useradmNoAuth.entrypoints=https
             - traefik.http.routers.useradmNoAuth.rule=Path(`/api/management/{ver:v[0-9]+}/useradm/auth/login`)||PathPrefix(`/api/management/{ver:v[0-9]+}/useradm/{ep:oauth2|auth\/password-reset|auth\/verify-email}`)
             # traefik should automatically forward the x-forwarded-host header
-            - traefik.http.routers.useradmNoAuth.middlewares=sec-headers,compression,json-error-responder2,json-error-responder3,json-error-responder4
+            - traefik.http.routers.useradmNoAuth.middlewares=circuitbreaker,sec-headers,compression,json-error-responder2,json-error-responder3,json-error-responder4
             - traefik.http.routers.useradmNoAuth.tls=true
             - traefik.http.routers.useradmNoAuth.service=useradmNoAuth
             - traefik.http.services.useradmNoAuth.loadbalancer.server.port=8080


### PR DESCRIPTION
- this is in light of the behaviour we saw during the scale testing
=> https://doc.traefik.io/traefik/middlewares/circuitbreaker/ for reference

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>