### PR TITLE
[test_state_scripts] Support builds with systemctl service "mender"

### DIFF
--- a/tests/module-state-scripts-test
+++ b/tests/module-state-scripts-test
@@ -18,7 +18,7 @@ case "$STATE" in
         ;;
 
     ArtifactReboot|ArtifactRollbackReboot)
-        systemctl restart mender-client
+        systemctl restart mender-client || systemctl restart mender
         ;;
 
 esac


### PR DESCRIPTION
By falling back to `systemctl restart mender` when the default service
name does not exist. This is the case for meta-mender/warrior.