### PR TITLE
[release tools] MEN-4513: Changelog and statistics for Mender server

### DIFF
--- a/extra/changelog-generator/changelog-generator
+++ b/extra/changelog-generator/changelog-generator
@@ -114,12 +114,17 @@ else:
 if args.all:
     repo_list = (
         subprocess.check_output(
-            [os.path.join(base_dir, "integration/extra/release_tool.py"), "--list"]
+            [
+                os.path.join(base_dir, "integration/extra/release_tool.py"),
+                "--list",
+                "--only-backend",
+            ]
         )
         .decode()
         .strip()
     )
     repos += [os.path.join(base_dir, repo) for repo in repo_list.split()]
+    repos.append(os.path.join(base_dir, "integration"))
 else:
     repos.append(".")
 

--- a/extra/statistics-generator
+++ b/extra/statistics-generator
@@ -63,7 +63,8 @@ collect_changes() {
     else
         # Sorting is important because we need "*-enterprise" repositories to
         # come after their Open Source counterparts (see below).
-        REPO_LIST="$("$RELEASE_TOOL" --list git | sort)"
+        REPO_LIST="$("$RELEASE_TOOL" --list git --only-backend | sort)"
+        REPO_LIST="$REPO_LIST integration"
     fi
 
     declare -A os_commits

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -16,12 +16,14 @@ import os
 import sys
 import shutil
 import re
+import pathlib
 from unittest.mock import patch
 
 import pytest
 
 from release_tool import main
 from release_tool import docker_compose_files_list
+from release_tool import Component
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 RELEASE_TOOL = os.path.join(THIS_DIR, "release_tool.py")
@@ -353,3 +355,198 @@ def test_docker_compose_files_list():
     assert "git-versions-enterprise.yml" not in list_docker_filenames
     assert "docker-compose.yml" in list_docker_filenames
     assert "docker-compose.enterprise.yml" in list_docker_filenames
+
+
+@patch("release_tool.integration_dir")
+def test_get_components_of_type(integration_dir_func):
+    integration_dir_func.return_value = pathlib.Path(__file__).parent.parent.absolute()
+
+    # standard query (only_release=None)
+    repos_comp = Component.get_components_of_type("git")
+    repos_name = [r.name for r in repos_comp]
+    assert "deployments" in repos_name
+    assert "deployments-enterprise" in repos_name
+    assert "deviceauth" in repos_name
+    assert "gui" in repos_name
+    assert "integration" in repos_name
+    assert "inventory" in repos_name
+    assert "inventory-enterprise" in repos_name
+    assert "mender" in repos_name
+    assert "mender-artifact" in repos_name
+    assert "mender-cli" in repos_name
+    assert "tenantadm" in repos_name
+    assert "useradm" in repos_name
+    assert "useradm-enterprise" in repos_name
+    assert "workflows" in repos_name
+    assert "workflows-enterprise" in repos_name
+    assert "create-artifact-worker" in repos_name
+    assert "auditlogs" in repos_name
+    assert "mtls-ambassador" in repos_name
+    assert "deviceconnect" in repos_name
+    assert "mender-connect" in repos_name
+    assert "deviceconfig" in repos_name
+
+    # only_release=False
+    repos_comp = Component.get_components_of_type("git", only_release=False)
+    repos_name = [r.name for r in repos_comp]
+    assert "deployments" in repos_name
+    assert "deployments-enterprise" in repos_name
+    assert "deviceauth" in repos_name
+    assert "gui" in repos_name
+    assert "integration" in repos_name
+    assert "inventory" in repos_name
+    assert "inventory-enterprise" in repos_name
+    assert "mender" in repos_name
+    assert "mender-artifact" in repos_name
+    assert "mender-cli" in repos_name
+    assert "tenantadm" in repos_name
+    assert "useradm" in repos_name
+    assert "useradm-enterprise" in repos_name
+    assert "workflows" in repos_name
+    assert "workflows-enterprise" in repos_name
+    assert "create-artifact-worker" in repos_name
+    assert "auditlogs" in repos_name
+    assert "mtls-ambassador" in repos_name
+    assert "deviceconnect" in repos_name
+    assert "mender-connect" in repos_name
+    assert "deviceconfig" in repos_name
+    # should also include deprecated repos
+    assert "deviceadm" in repos_name
+    assert "mender-api-gateway-docker" in repos_name
+    assert "mender-conductor" in repos_name
+    assert "mender-conductor-enterprise" in repos_name
+
+    # only_non_release=True
+    repos_comp = Component.get_components_of_type("git", only_non_release=True)
+    repos_name = [r.name for r in repos_comp]
+    assert "deployments" not in repos_name
+    assert "deployments-enterprise" not in repos_name
+    assert "deviceauth" not in repos_name
+    assert "gui" not in repos_name
+    assert "integration" not in repos_name
+    assert "inventory" not in repos_name
+    assert "inventory-enterprise" not in repos_name
+    assert "mender" not in repos_name
+    assert "mender-artifact" not in repos_name
+    assert "mender-cli" not in repos_name
+    assert "tenantadm" not in repos_name
+    assert "useradm" not in repos_name
+    assert "useradm-enterprise" not in repos_name
+    assert "workflows" not in repos_name
+    assert "workflows-enterprise" not in repos_name
+    assert "create-artifact-worker" not in repos_name
+    assert "auditlogs" not in repos_name
+    assert "mtls-ambassador" not in repos_name
+    assert "deviceconnect" not in repos_name
+    assert "mender-connect" not in repos_name
+    assert "deviceconfig" not in repos_name
+    # should only include deprecated repos
+    assert "deviceadm" in repos_name
+    assert "mender-api-gateway-docker" in repos_name
+    assert "mender-conductor" in repos_name
+    assert "mender-conductor-enterprise" in repos_name
+
+    # only_independent_component=True
+    repos_comp = Component.get_components_of_type(
+        "git", only_independent_component=True
+    )
+    repos_name = [r.name for r in repos_comp]
+    assert "deployments" not in repos_name
+    assert "deployments-enterprise" not in repos_name
+    assert "deviceauth" not in repos_name
+    assert "gui" not in repos_name
+    assert "inventory" not in repos_name
+    assert "inventory-enterprise" not in repos_name
+    assert "tenantadm" not in repos_name
+    assert "useradm" not in repos_name
+    assert "useradm-enterprise" not in repos_name
+    assert "workflows" not in repos_name
+    assert "workflows-enterprise" not in repos_name
+    assert "create-artifact-worker" not in repos_name
+    assert "auditlogs" not in repos_name
+    assert "mtls-ambassador" not in repos_name
+    assert "deviceconnect" not in repos_name
+    assert "deviceconfig" not in repos_name
+    # should only include non backend repos
+    assert "integration" in repos_name
+    assert "mender" in repos_name
+    assert "mender-artifact" in repos_name
+    assert "mender-cli" in repos_name
+    assert "mender-connect" in repos_name
+
+    # only_non_independent_component=True
+    repos_comp = Component.get_components_of_type(
+        "git", only_non_independent_component=True
+    )
+    repos_name = [r.name for r in repos_comp]
+    assert "integration" not in repos_name
+    assert "mender" not in repos_name
+    assert "mender-artifact" not in repos_name
+    assert "mender-cli" not in repos_name
+    assert "mender-connect" not in repos_name
+    # should only include backend repos
+    assert "deployments" in repos_name
+    assert "deployments-enterprise" in repos_name
+    assert "deviceauth" in repos_name
+    assert "gui" in repos_name
+    assert "inventory" in repos_name
+    assert "inventory-enterprise" in repos_name
+    assert "tenantadm" in repos_name
+    assert "useradm" in repos_name
+    assert "useradm-enterprise" in repos_name
+    assert "workflows" in repos_name
+    assert "workflows-enterprise" in repos_name
+    assert "create-artifact-worker" in repos_name
+    assert "auditlogs" in repos_name
+    assert "mtls-ambassador" in repos_name
+    assert "deviceconnect" in repos_name
+    assert "deviceconfig" in repos_name
+
+
+def test_list_repos(capsys):
+    run_main_assert_result(
+        capsys,
+        ["--list"],
+        """auditlogs
+create-artifact-worker
+deployments
+deployments-enterprise
+deviceauth
+deviceconfig
+deviceconnect
+gui
+integration
+inventory
+inventory-enterprise
+mender
+mender-artifact
+mender-cli
+mender-connect
+mtls-ambassador
+tenantadm
+useradm
+useradm-enterprise
+workflows
+workflows-enterprise""",
+    )
+
+    run_main_assert_result(
+        capsys,
+        ["--list", "--only-backend"],
+        """auditlogs
+create-artifact-worker
+deployments
+deployments-enterprise
+deviceauth
+deviceconfig
+deviceconnect
+gui
+inventory
+inventory-enterprise
+mtls-ambassador
+tenantadm
+useradm
+useradm-enterprise
+workflows
+workflows-enterprise""",
+    )


### PR DESCRIPTION
From now on we need to group the "Mender server" for changelog and
statistics, leaving everything else as independent repos.

`release_tool` supports now a new flag `--only-backend` that, when used
in combination with `--list` skips the independent components. The other
tools `changelog-generator` and `statistics-generator` are updated to
use this tool (note that they need to add `integration` repo).

Added unit tests to verify backwards compatibility.