### PR TITLE
[requirements.txt]: Downgrade idna to < 3.0

### DIFF
--- a/tests/requirements/python-requirements.txt
+++ b/tests/requirements/python-requirements.txt
@@ -20,7 +20,7 @@ execnet==1.8.0
 fabric==2.6.0
 filelock==3.0.12
 html5lib==1.1
-idna==3.1
+idna==2.10
 iniconfig==1.1.1
 invoke==1.5.0
 jsonschema==3.2.0


### PR DESCRIPTION
This is needed, since the requests library does not yet support `idna > 2.x`.

See this for information:

https://github.com/psf/requests/issues/5710

This shows up in Alpine containers during install as:

```
ERROR: Cannot install -r tests/integration/mender_integration/tests/requirements/python-requirements.txt (line 54) and idna==3.1 because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested idna==3.1
    requests 2.25.1 depends on idna<3 and >=2.5
```

But not in containers with these dependencies already installed.

Like this is from a `mender-qa` pipeline from a container running on the
`docker` image:

```
Requirement already satisfied: idna==3.1 in /usr/lib/python3.8/site-packages (from -r /builds/Northern.tech/Mender/integration/tests/requirements/python-requirements.txt (line 23)) (3.1)
Requirement already satisfied: requests==2.25.1 in /usr/lib/python3.8/site-packages (from -r /builds/Northern.tech/Mender/integration/tests/requirements/python-requirements.txt (line 54)) (2.25.1)
```

This is due to the installation in the `requirements/apk-requirements.txt` file,
already installing this, in some cases:

```
[32;1m$ apk add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)[0;m
(1/73) Installing readline (8.1.0-r0)
  .
  .
  .
(55/73) Installing py3-idna (3.1-r0)
```

Never the less, the requirements file is still wrong.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>