### PR TITLE
[tests requirements] Lock idna version to 2.10

### DIFF
--- a/tests/requirements/python-requirements.txt
+++ b/tests/requirements/python-requirements.txt
@@ -20,7 +20,7 @@ execnet==1.8.0
 fabric==2.6.0
 filelock==3.0.12
 html5lib==1.1
-idna==3.1
+idna==2.10
 iniconfig==1.1.1
 invoke==1.5.0
 jsonschema==3.2.0


### PR DESCRIPTION
As `requests` require idna<3.0 which cannot be satisfied with the
current requirements.txt list.

The issue seems to be side tracked from our CI due to some previously
installed packages (I honestly don't know exactly what).

Introduced by mistake at 099539ab6.