### PR TITLE
[tests] Clear two DeprecationWarning

### DIFF
--- a/tests/MenderAPI/requests_helpers.py
+++ b/tests/MenderAPI/requests_helpers.py
@@ -23,7 +23,7 @@ def requests_retry(status_forcelist=[500, 502]):
         total=5,
         backoff_factor=1,
         status_forcelist=status_forcelist,
-        method_whitelist=["HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS", "TRACE"],
+        allowed_methods=["HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS", "TRACE"],
     )
     s.mount("https://", HTTPAdapter(max_retries=retries))
     return s

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -117,7 +117,7 @@ class MenderDevice:
         return output
 
     def get_active_partition(self):
-        cmd = "mount | awk '/on \/ / { print $1}'"
+        cmd = r"mount | awk '/on \/ / { print $1}'"
         active = self.run(cmd, hide=True)
         return active.strip()
 


### PR DESCRIPTION
Specifically:

```
DeprecationWarning: invalid escape sequence \/
DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
```