### PR TITLE
README: update backend diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,27 +44,37 @@ A provided `docker-compose.yml` file will provision the following set of
 services:
 
 ```
-       |
-  port |        +-----------------------+         +------------------------+
-   443 | <----> |  API Gateway          |    +--->|  Device Authentication |
-       |        |  (mender-api-gateway) |<---|    |  (mender-device-auth)  | <---+
-       |        +-----------------------+    |    +------------------------+     |
-       |                                     +--->|  Inventory             |     |
-       |                                     |    |  (mender-inventory)    | <---+
-       |                                     |    +------------------------+     |     +----------------------------------+
-       |                                     +--->|  User Administration   |     +---> |  Workflows Engine                |
-       |                                     |    |  (mender-useradm)      | <---+     |  (mender-workflows-server)       |
-       |                                     |    +------------------------+     |     |  (mender-workflows-worker)       |
-       |                                     +--->|  Deployments           |     |     |  (mender-create-artifact-worker) |
-       |                 +----------------------->|  (mender-deployments)  | <---+     +----------------------------------+
-       |                 |                        +------------------------+
-       |                 |
-       |                 v
-  port |        +------------------+              +----------+
-  9000 | <----> |  Storage Proxy   |<------------>|  Minio   |
-       |        |  (storage-proxy) |              |  (minio) |
-       |        +------------------+              +----------+
-       |
+        |
+        |                                            +-------------------------+
+        |                                            |                         |
+        |                                       +--->|  Device Authentication  |<---+
+        |                                       |    |  (mender-device-auth)   |    |
+        |                                       |    +-------------------------+    |
+        |        +-----------------------+      |    |                         |    |
+   port |        |                       |      +--->|  Inventory              |<---+     +----------------------------------+
+    443 | <----> |  API Gateway          |      |    |  (mender-inventory)     |    +---> |  Workflows Engine                |
+        |        |  (traefik)            |<-----+    +-------------------------+    |     |  (mender-workflows-server)       |
+        |        +-----------------------+      |    |                         |    |     |  (mender-workflows-worker)       |
+        |                                       +--->|  User Administration    |    |     |  (mender-create-artifact-worker) |
+        |                                       |    |  (mender-useradm)       |<---+     +----------------------------------+
+        |                                       |    +-------------------------+    |
+        |                                       +--->|                         |    |
+        |                                       |    |  Device Config          |<---+
+        |                                       |    |  (mender-deviceconfig)  |    |
+        |                                       |    +-------------------------+    |
+        |                                       +--->|                         |    |
+        |                                       |    |  Deployments            |<---+
+        |                                       |    |  (mender-deployments)   |    |
+        |                                       |    +-------------------------+    |
+        |                                       +--->|                         |<---+
+        |                                       |    |  Device Connect         |          +--------+
+        |                                       |    |  (mender-deviceconnect) |<-------->|        |
+        |                                       |    +-------------------------+          |  Nats  |
+        |                                       +--->|                         |          |        |
+        |                                            |  Minio                  |          +--------+
+        |                                            |                         |
+        |                                            +-------------------------+
+        |
 ```
 
 It is customary to provide deployment specific overrides in a separate compose


### PR DESCRIPTION
I was originally thinking about replacing the diagram with the link to the docs, but the relation between docs and integration is, let's say, complicated (maybe the docs should have a link to this diagram, since we are referencing to the integration repo there?).
There is ongoing discussion about the server installation docs. We have tasks to restructure this part of the documentation, so I decided that having the diagram updated is enough for now. 