### PR TITLE
[backend-tests] Add six to requirements-py3.txt

### DIFF
--- a/backend-tests/requirements-py3.txt
+++ b/backend-tests/requirements-py3.txt
@@ -20,6 +20,7 @@ pytest-metadata==1.11.0
 pyzbar==0.1.8
 redo==2.0.4
 requests==2.25.1
+six==1.15.0
 stripe==2.56.0
 toml==0.10.2
 urllib3==1.26.4


### PR DESCRIPTION
It seems to have been installed in the past via OS package but not
anymore.