### PR TITLE
[2.6.x] Cherry websocket bump

### DIFF
--- a/tests/requirements/python-requirements.txt
+++ b/tests/requirements/python-requirements.txt
@@ -17,6 +17,6 @@ fabric==2.5.0              ; python_version >= "3.0"
 pycrypto                   ; python_version >= "3.0"
 paramiko==2.7.2            ; python_version >= "3.0"
 msgpack>=1.0.0             ; python_version >= "3.0"
-websockets>=8.1            ; python_version >= "3.0"
+websockets>=9.0            ; python_version >= "3.0"
 cryptography==3.3.2        ; python_version >= "3.0"
 flaky==3.7.0

--- a/testutils/util/websockets.py
+++ b/testutils/util/websockets.py
@@ -35,7 +35,7 @@ class Websocket:
             ssl_context.verify_mode = ssl.CERT_NONE
 
         async def connect():
-            self.ws = await websockets.client.connect(
+            self.ws = await websockets.connect(
                 self.url, extra_headers=self.headers, ssl=ssl_context
             )
 
@@ -44,7 +44,7 @@ class Websocket:
             try:
                 asyncio.get_event_loop().run_until_complete(connect())
                 break
-            except websockets.exceptions.InvalidStatusCode:
+            except websockets.InvalidStatusCode:
                 if self.retry_connect and attempts > 0:
                     attempts -= 1
                     time.sleep(5)


### PR DESCRIPTION
Make sure we use min `9.0` of websockets, and apply the needed fix from: https://github.com/mendersoftware/integration/pull/1360/commits/9777719e8abc8736608da8a739631c54b3e2d792