### PR TITLE
[backend-tests/run] Do not override exit code when running twice

### DIFF
--- a/backend-tests/run
+++ b/backend-tests/run
@@ -203,7 +203,7 @@ cleanup(){
 parse_args "$@"
 build_backend_tests_runner
 
-script_failed=1
+script_failed=0
 
 for suite in "${TEST_SUITES[@]}"; do
     case "$suite" in
@@ -225,7 +225,10 @@ for suite in "${TEST_SUITES[@]}"; do
 
     prepare_pytest_args
     run_tests
-    script_failed=$?
+    run_tests_retcode=$?
+    if [ $script_failed -eq 0 ]; then
+        script_failed=$run_tests_retcode
+    fi
 
     if [ $? != 0 ]; then
         tmppath=$(mktemp ${HERE}/acceptance.XXXXXX)


### PR DESCRIPTION
The previous code, when running two tests suites, would always exit with
the retcode of the second one - potentially masking an error in the
first test suite.

Indirectly, this fixes an issue in staging branch, where skipping the OS
test suite would make the script exit with code 1.