### PR TITLE
[tests] Add client version fixture and mark File Transfer limits tests

### DIFF
--- a/tests/tests/test_filetransfer.py
+++ b/tests/tests/test_filetransfer.py
@@ -667,6 +667,7 @@ class TestFileTransfer(_TestFileTransferBase):
         rsp = download_file("/foo/bar", devid, authtoken)
         assert rsp.status_code == 502
 
+    @pytest.mark.min_mender_client_version("2.7.0")
     def test_filetransfer_limits_upload(self, standard_setup_one_client):
         """Tests the file transfer upload limits"""
         devid, _, auth, = self.prepare_env()
@@ -674,6 +675,7 @@ class TestFileTransfer(_TestFileTransferBase):
             standard_setup_one_client.device, devid, auth
         )
 
+    @pytest.mark.min_mender_client_version("2.7.0")
     @pytest.mark.xfail(raises=NotImplementedError, reason="MEN-4659")
     def test_filetransfer_limits_download(self, standard_setup_one_client):
         """Tests the file transfer download limits"""
@@ -734,11 +736,13 @@ class TestFileTransferEnterprise(_TestFileTransferBase):
         devid, authtoken, _, _ = self.prepare_env(enterprise_no_client)
         super().test_filetransfer(devid, authtoken, content_assertion="ServerURL")
 
+    @pytest.mark.min_mender_client_version("2.7.0")
     def test_filetransfer_limits_upload(self, enterprise_no_client):
         """Tests the file transfer upload limits"""
         devid, _, auth, mender_device = self.prepare_env(enterprise_no_client)
         super().test_filetransfer_limits_upload(mender_device, devid, auth)
 
+    @pytest.mark.min_mender_client_version("2.7.0")
     @pytest.mark.xfail(raises=NotImplementedError, reason="MEN-4659")
     def test_filetransfer_limits_download(self, enterprise_no_client):
         """Tests the file transfer download limits"""


### PR DESCRIPTION
The fixture uses release_tool to figure out which mender client is
being used. Tests marked with min_version higher that the one being used
will be skip.

This fixture is specifically designed for staging branch, for which we
use the "latest stable" mender client and some tests might be at times
incompatible. For the rest of the branches it won't really have any
effect, as the client version will be a branch and validate as more
recent that the required minimum version.

Mark File Transfer limits tests to be skip on current client version.