### PR TITLE
Fix spurious failure in test_rootfs_image_rejected (and maybe others).

### DIFF
--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -167,11 +167,34 @@ class Deployments:
                 time.sleep(polling_frequency)
                 continue
 
-        if time.time() > timeout:
-            pytest.fail(
-                "Never found status: %s for %s after %d seconds"
-                % (expected_status, deployment_id, max_wait)
-            )
+        pytest.fail(
+            "Never found status: %s for %s after %d seconds"
+            % (expected_status, deployment_id, max_wait)
+        )
+
+    def check_not_in_status(
+        self, expected_status, deployment_id, max_wait=60 * 60, polling_frequency=0.2
+    ):
+        timeout = time.time() + max_wait
+
+        while time.time() <= timeout:
+            data = self.get_status(status=expected_status)
+
+            for deployment in data:
+                if deployment["id"] == deployment_id:
+                    time.sleep(polling_frequency)
+                    continue
+            else:
+                logger.info(
+                    "left deployment status (%s) as expected for: %s"
+                    % (expected_status, deployment_id)
+                )
+                return
+
+        pytest.fail(
+            "Never left status: %s for %s after %d seconds"
+            % (expected_status, deployment_id, max_wait)
+        )
 
     def check_expected_statistics(
         self,

--- a/tests/tests/common_update.py
+++ b/tests/tests/common_update.py
@@ -88,7 +88,7 @@ def common_update_procedure(
     deployment_triggered_callback()
     # wait until deployment is in correct state
     if verify_status:
-        deploy.check_expected_status("inprogress", deployment_id)
+        deploy.check_not_in_status("pending", deployment_id)
 
     return deployment_id, artifact_name
 


### PR DESCRIPTION
The test fails if the client is too quick, because it looks for the
"inprogress" deployment status. However, by the time it gets to do
that check, the client may already be past that and the deployment is
"finished".

What we really want to look for is whether the deployment has left the
"pending" status, which is before any clients have picked it up.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>