### PR TITLE
Fix: mtls tests, mount the CA certificate in the right location:

### DIFF
--- a/extra/mtls/mtls-ambassador-test.yml
+++ b/extra/mtls/mtls-ambassador-test.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ${MTLS_CERT:-./extra/mtls/certs/server/server.crt}:/etc/mtls/certs/server/server.crt:ro
       - ${MTLS_KEY:-./extra/mtls/certs/server/server.key}:/etc/mtls/certs/server/server.key:ro
-      - ${MTLS_TENANT_CA:-./extra/mtls/certs/tenant-ca/tenant.ca.crt}:/etc/mtls/certs/tenant-ca/tenant.ca.pem:ro
+      - ${MTLS_TENANT_CA:-./extra/mtls/certs/tenant-ca/tenant.ca.crt}:/etc/mtls/certs/tenant-ca/tenant.ca.crt:ro
     environment:
       MTLS_MENDER_USER: "mtls@mender.io"
       MTLS_MENDER_PASS: "correcthorsebatterystaple"


### PR DESCRIPTION
Adapt the CA certificate mount point to the new location in the
mtls-ambassador updated in the commit
7c1429946266ef12113c9dc2d61e6b2f59599dfb.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>