### PR TITLE
MEN-4790: fix ad improve the the production template

### DIFF
--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -16,7 +16,7 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.minio.entrypoints=https"
-            - "traefik.http.routers.minio.rule=Host(`${STORAGE_URL:-s3.docker.mender.io}`)||Headers(`X-Forwarded-Host`,`${STORAGE_URL:-s3.docker.mender.io}`)||PathPrefix(`/mender-artifact-storage`)"
+            - "traefik.http.routers.minio.rule=PathPrefix(`/mender-artifact-storage`)||HeadersRegexp(`X-Amz-Date`, `.+`)"
             - "traefik.http.routers.minio.tls=true"
             - "traefik.http.services.minio.loadbalancer.server.port=9000"
             - mender.testprefix=${MENDER_TESTPREFIX:-""}

--- a/production/config/prod.yml.template
+++ b/production/config/prod.yml.template
@@ -27,6 +27,8 @@ services:
 
     mender-create-artifact-worker:
         command: --automigrate
+        environment:
+            - CREATE_ARTIFACT_GATEWAY_URL=https://set-my-alias-here.com
 
     mender-useradm:
         command: server --automigrate
@@ -61,12 +63,9 @@ services:
             mender:
                 aliases:
                     # mender-api-gateway is a proxy to storage
-                    # and has to use exactly the same name as devices
-                    # and the deployments service will;
-                    #
-                    # if devices and deployments will access storage
-                    # using https://s3.acme.org:9000, then
-                    # set this to https://s3.acme.org:9000
+                    # and you have to expose it using a DNS name
+                    # that both devices and the deployments service
+                    # can use
                     - set-my-alias-here.com
         command:
             - --accesslog=true
@@ -104,8 +103,8 @@ services:
             # secret, the same valie as MINIO_SECRET_KEY
             DEPLOYMENTS_AWS_AUTH_SECRET:
 
-            # deployments service uses signed URLs, hence it needs to access
-            # storage-proxy using exactly the same name as devices will; if
+            # deployments service generates signed URLs, hence it needs to access
+            # the storage layer using exactly the same name as devices will; if
             # devices will access storage using https://s3.acme.org:9000, then
             # set this to https://s3.acme.org:9000
             DEPLOYMENTS_AWS_URI: https://set-my-alias-here.com


### PR DESCRIPTION
Improve the comments to make it clear the deployments service must
contact the storage layer using the same DNS name the devices will use.
Set the correct value for the CREATE_ARTIFACT_GATEWAY_URL env variable.

We cannot use the domain name in the rule to route requests to minio,
because you can use the same domain name for both APIs/UI and minio. The
X-Amz-Date header is always present when performing AWS S3 requests.