### PR TITLE
MEN-4790: rely on the X-Amz-Date header to route requests to minio

### DIFF
--- a/config/traefik/traefik.minio.yaml
+++ b/config/traefik/traefik.minio.yaml
@@ -6,6 +6,7 @@ http:
       rule: >-
         {{with env "STORAGE_URL" | default "s3.docker.mender.io" -}}
         Host(`{{.}}`)||Headers(`X-Forwarded-Host`,`{{.}}`) ||
+        HeadersRegexp(`X-Amz-Date`, `.+`) ||
         PathPrefix(`/mender-artifact-storage`)
         {{- end}}
       tls: true


### PR DESCRIPTION
We cannot use the domain name in the rule to route requests to minio,
because you can use the same domain name for both APIs/UI and minio. The
X-Amz-Date header is always present when performing AWS S3 requests.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>