### PR TITLE
release_tool: Make --list-format json output easier to use

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -698,7 +698,16 @@ def do_list_repos(args, optional_too, only_backend):
             )
         )
     elif args.list_format == "json":
-        print(json.dumps(repos_versions_dict))
+        json_object = {
+            "release": repos_versions_dict["integration"],
+            "repos": list(
+                map(
+                    lambda item: {"name": item[0], "version": item[1]},
+                    repos_versions_dict.items(),
+                )
+            ),
+        }
+        print(json.dumps(json_object))
 
 
 def version_sort_key(version):


### PR DESCRIPTION
Produces something like:

```
$ release_tool --list --list-format json -i 3.0.x | jq
{
  "release": "3.0.x",
  "repos": [
    {
      "name": "auditlogs",
      "version": "1.2.x"
    },
    {
      "name": "create-artifact-worker",
      "version": "1.0.x"
    },
...
```

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>