### PR TITLE
test_image_download_retry_timeout: Rework update start detection

### DIFF
--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -224,7 +224,19 @@ class TestFaultTolerance(MenderTesting):
             if test_set["blockAfterStart"]:
                 # Block after we start the download.
                 deployment_id, new_yocto_id = common_update_procedure(valid_image)
-                mender_device.run("fuser -mv %s" % (inactive_part))
+                mender_device.run(
+                    "start=$(date -u +%s);"
+                    + 'output="";'
+                    + 'while [ -z "$output" ]; do '
+                    + "sleep 0.1;"
+                    + 'output="$(fuser -mv %s)";' % inactive_part
+                    + "now=$(date -u +%s);"
+                    + "if [ $(($now - $start)) -gt 600 ]; then "
+                    + "exit 1;"
+                    + "fi;"
+                    + "done",
+                    wait=10 * 60,
+                )
 
                 # storage must be blocked by ip to kill an ongoing connection
                 # so block the whole gateway

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -116,7 +116,7 @@ class TestFaultTolerance(MenderTesting):
                 hide=True,
             )
             time.sleep(2)
-            if int(output) >= 2:  # check that some retries have occured
+            if int(output) >= 2:  # check that some retries have occurred
                 logger.info(
                     "Looks like the download was retried 2 times, restoring download functionality"
                 )
@@ -195,7 +195,7 @@ class TestFaultTolerance(MenderTesting):
     ):
         """
             Install an update, and block storage connection when we detect it's
-            being copied over to the inactive parition.
+            being copied over to the inactive partition.
 
             The test should result in a successful download retry.
             

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -76,7 +76,7 @@ class MenderDevice:
         """Run given cmd in remote SSH host
 
         Argument:
-        cmd - sring with the command to execute remotely
+        cmd - string with the command to execute remotely
 
         Recognized keyword arguments:
         hide - do not print stdout nor stderr, and do not fail on errors


### PR DESCRIPTION
    Previous code relied on a single call to MenderDevice.run, with retries
    the command until it succeeds using an exponential back-off time between
    tries. This test is test time sensitive, it needs to break the
    connectivity after it starts the download but before it completes, and
    sometimes it is missed between different SSH connection attempts.

    The new code basically tries with a while loop in a single SSH
    connection, which should be much more accurate.