### PR TITLE
update RBAC tests for configuration deployments

### DIFF
--- a/backend-tests/tests/test_rbac.py
+++ b/backend-tests/tests/test_rbac.py
@@ -329,9 +329,7 @@ class TestRBACDeploymentsToGroupEnterprise:
             {
                 "name": "Test RBAC deploy configuration to device belonging to a given group",
                 "user": {"name": "test1-UUID@example.com", "pwd": "password"},
-                "permissions": [
-                    UserPermission("CREATE_DEPLOYMENT", "DEVICE_GROUP", "test")
-                ],
+                "permissions": [UserPermission("VIEW_DEVICE", "DEVICE_GROUP", "test")],
                 "device_groups": {"test": 1, "production": 1},
                 "deploy_group": "test",
                 "set_configuration_status_code": 204,
@@ -340,9 +338,7 @@ class TestRBACDeploymentsToGroupEnterprise:
             {
                 "name": "Test RBAC configuration deployment forbidden",
                 "user": {"name": "test2-UUID@example.com", "pwd": "password"},
-                "permissions": [
-                    UserPermission("CREATE_DEPLOYMENT", "DEVICE_GROUP", "test")
-                ],
+                "permissions": [UserPermission("VIEW_DEVICE", "DEVICE_GROUP", "test")],
                 "device_groups": {"test": 1, "production": 1},
                 "deploy_group": "production",
                 "set_configuration_status_code": 403,


### PR DESCRIPTION
With new, simplified RBAC we do not support any other actions than
VIEW_DEVICE when it comes to group permissions.
If user can view the device then user is allowed to deploy to the
device too.