### PR TITLE
QA-303: install curl in the mender-client-docker-addons

### DIFF
--- a/extra/mender-client-docker-addons/Dockerfile
+++ b/extra/mender-client-docker-addons/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:20.04 AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y make git build-essential golang liblzma-dev \
-    jq libssl-dev libglib2.0-dev
+    jq libssl-dev libglib2.0-dev curl
 
 ARG MENDER_CLIENT_REV=master
 ARG MENDER_CONNECT_REV=master


### PR DESCRIPTION
curl is needed to report the device configuration to the backend
in the device configuration add-on.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>