### PR TITLE
statistics-generator: Skip missing repositories.

### DIFF
--- a/extra/statistics-generator
+++ b/extra/statistics-generator
@@ -79,6 +79,9 @@ collect_changes() {
             pushd .
         else
             CHANGES="$("$RELEASE_TOOL" --version-of $repo --in-integration-version "$given_range")"
+            if [ -z "$CHANGES" ]; then
+                continue
+            fi
             pushd "$BASE_DIR/$repo"
             case "$repo" in
                 *-enterprise)


### PR DESCRIPTION
This makes it possible to run the generator on an old release, but
using a newer branch of integration. Normally this isn't necessary,
but it helps with the transition from mender-docs to
mender-docs-changelogs. We need to use a more recent branch of
integration in order to omit client components from the changelog, but
still need to be able to include those components in the legacy
changelog, by using the old branch of integration.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>