### PR TITLE
introduce mender-reporting

### DIFF
--- a/config/traefik/traefik.middlewares.yaml
+++ b/config/traefik/traefik.middlewares.yaml
@@ -83,3 +83,8 @@ http:
       replacepathregex:
         regex: "^/api/management/v1/inventory/(.*)"
         replacement: "/api/0.1.0/$1"
+
+    reportingMgmtSearch-replacepathregex:
+      replacepathregex:
+        regex: "^/api/management/v2/inventory/filters/search(.*)"
+        replacement: "/api/management/v1/reporting/inventory/search"

--- a/config/traefik/traefik.reporting.yaml
+++ b/config/traefik/traefik.reporting.yaml
@@ -1,0 +1,27 @@
+http:
+  routers:
+    #
+    # reporting
+    #
+    reporting:
+      entrypoints: https
+      middlewares: #{{- if not (env "TESTING") }}
+      - circuit-breaker #{{- end}}
+      - userauth
+      - reportingMgmtSearch-replacepathregex
+      - sec-headers
+      - compression
+      - json-error-responder1
+      - json-error-responder2
+      - json-error-responder3
+      - json-error-responder4
+      rule: "PathPrefix(`/api/management/v2/inventory/filters/search`)"
+      service: reporting
+      tls: true
+
+  services:
+
+    reporting:
+      loadBalancer:
+        servers:
+        - url: "http://mender-reporting:8080"

--- a/config/traefik/traefik.yaml
+++ b/config/traefik/traefik.yaml
@@ -147,6 +147,19 @@ http:
       service: inventory
       tls: true
 
+    # POC - reroute v2 inventory search to mender-reporting
+    reportingInventorySearch:
+      entrypoints: https
+      middlewares: #{{- template "circuit-breaker"}}
+      - userauth
+      - sec-headers
+      - compression
+      - json-error-responder1
+      - json-error-responder4
+      rule: "PathPrefix(`/api/management/v2/inventory/filters/search`)"
+      service: reporting
+      tls: true
+
     #
     # useradm
     #

--- a/docker-compose.reporting.yml
+++ b/docker-compose.reporting.yml
@@ -1,0 +1,32 @@
+version: '2.1'
+services:
+    #
+    # mender-reporting
+    #
+    mender-reporting:
+        image: mendersoftware/mender-reporting:mender-master
+        command: server
+        extends:
+            file: common.yml
+            service: mender-base
+        networks:
+            - mender
+        depends_on:
+            - mender-elasticsearch
+        environment:
+            REPORTING_ELASTICSEARCH_ADDRESSES: "http://mender-elasticsearch:9200"
+
+    #
+    # elasticsearch
+    #
+    mender-elasticsearch:
+        image: elasticsearch:7.13.1
+        environment:
+          - "network.host=0.0.0.0"
+          - "discovery.type=single-node"
+          - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        ports:
+            - 9200:9200
+            - 9300:9300
+        networks:
+            - mender

--- a/docker-compose.reporting.yml
+++ b/docker-compose.reporting.yml
@@ -17,6 +17,13 @@ services:
             REPORTING_ELASTICSEARCH_ADDRESSES: "http://mender-elasticsearch:9200"
 
     #
+    # mender-api-gateway
+    #
+    mender-api-gateway:
+      volumes:
+        - ./config/traefik/traefik.reporting.yaml:/etc/traefik/config/traefik.reporting.yaml:ro
+
+    #
     # elasticsearch
     #
     mender-elasticsearch:

--- a/docker-compose.reporting.yml
+++ b/docker-compose.reporting.yml
@@ -30,3 +30,11 @@ services:
             - 9300:9300
         networks:
             - mender
+
+    #
+    # mender-inventory
+    #
+    mender-inventory:
+        environment:
+            INVENTORY_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
+            INVENTORY_ENABLE_REPORTING: 1


### PR DESCRIPTION
currently used for development and manual testing of the work for https://tracker.mender.io/browse/MEN-4844.

- introduce `mender-reporting` and elasticsearch
- tell `inventory` to emit reindexing workflows on every device change
- tell traefik to reroute inventory v2 queries into mender-reporting endpoint reimplementation

TODO:
- make the rerouting conditional on e.g. `REPORTING_ENABLED` - we don't want to break searches in master
- (use sprig templates I guess?)