### PR TITLE
Fix: Traefik is proxying minio requests on (80,443) ports, not on 9000

### DIFF
--- a/docker-compose.no-ssl.yml
+++ b/docker-compose.no-ssl.yml
@@ -16,4 +16,4 @@ services:
 
     mender-deployments:
         environment:
-            DEPLOYMENTS_AWS_URI: http://s3.docker.mender.io:9000
+            DEPLOYMENTS_AWS_URI: http://s3.docker.mender.io

--- a/extra/failover-testing/docker-compose.failover-server.yml
+++ b/extra/failover-testing/docker-compose.failover-server.yml
@@ -20,7 +20,7 @@ services:
             STORAGE_BACKEND_CERT: /etc/ssl/certs/s3.docker.mender.io.crt
             DEPLOYMENTS_AWS_AUTH_KEY: minio
             DEPLOYMENTS_AWS_AUTH_SECRET: minio123
-            DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io:9000
+            DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io
 
     #
     # mender-gui

--- a/production/config/prod.yml.template
+++ b/production/config/prod.yml.template
@@ -65,8 +65,8 @@ services:
                     # and the deployments service will;
                     #
                     # if devices and deployments will access storage
-                    # using https://s3.acme.org:9000, then
-                    # set this to https://s3.acme.org:9000
+                    # using https://s3.acme.org, then
+                    # set this to s3.acme.org
                     - set-my-alias-here.com
         command:
             - --accesslog=true
@@ -106,8 +106,8 @@ services:
 
             # deployments service uses signed URLs, hence it needs to access
             # storage-proxy using exactly the same name as devices will; if
-            # devices will access storage using https://s3.acme.org:9000, then
-            # set this to https://s3.acme.org:9000
+            # devices will access storage using https://s3.acme.org, then
+            # set this to https://s3.acme.org
             DEPLOYMENTS_AWS_URI: https://set-my-alias-here.com
         logging:
             options:


### PR DESCRIPTION
Remove left-over references to port 9000, which is not used anymore to
access the minio storage layer. Update the production template's
comments to meention the correct configuration settings.

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>