### PR TITLE
smtp.mock.yml: Correctly set network and not expose port

### DIFF
--- a/extra/smtp-testing/smtp.mock.yml
+++ b/extra/smtp-testing/smtp.mock.yml
@@ -7,8 +7,8 @@ services:
             - PYTHONUNBUFFERED=1
         command: bash -c "mkdir -p /var/spool/mail; stdbuf -oL python -m smtpd -n -c DebuggingServer 0.0.0.0:1025 > /var/spool/mail/local"
         ports:
-            - 1025:1025
+            - "1025"
         networks:
-            mender:
+            - mender
 networks:
     mender:

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -247,14 +247,3 @@ def enterprise_no_client_class(request):
     reset_mender_api(env)
 
     return env
-
-
-@pytest.fixture(scope="function")
-def enterprise_no_client_smtp(request):
-    env = container_factory.getEnterpriseSMTPSetup()
-    request.addfinalizer(env.teardown)
-
-    env.setup()
-    reset_mender_api(env)
-
-    return env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,11 @@ def pytest_exception_interact(node, call, report):
             except:
                 logger.info("Not able to print client deployment log")
 
-            for service in [device.get_client_service_name(), "mender-connect"]:
+            for service in [
+                device.get_client_service_name(),
+                "mender-connect",
+                "mender-monitor",
+            ]:
                 try:
                     logger.info("Printing %s systemd log, if possible:" % service)
                     output = device.run("journalctl -u %s || true" % service, wait=60,)

--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -186,7 +186,7 @@ class TestMonitorClientEnterprise:
         expected_from = "alert@mender.io"
         service_name = "crond"
         user_name = "bugs.bunny@acme.org"
-        devid, authtoken, auth, mender_device = self.prepare_env(
+        devid, _, _, mender_device = self.prepare_env(
             monitor_commercial_setup_no_client, user_name
         )
         logger.info("test_monitorclient_alert_email: env ready.")
@@ -290,10 +290,9 @@ class TestMonitorClientEnterprise:
         """Tests the monitor client flapping support"""
         mailbox_path = "/var/spool/mail/local"
         wait_for_alert_interval_s = 120
-        expected_from = "alert@mender.io"
         service_name = "crond"
         user_name = "bugs.bunny@monitoring.acme.org"
-        devid, authtoken, auth, mender_device = self.prepare_env(
+        devid, _, _, mender_device = self.prepare_env(
             monitor_commercial_setup_no_client, user_name
         )
         logger.info("test_monitorclient_flapping: env ready.")
@@ -368,7 +367,7 @@ class TestMonitorClientEnterprise:
         expected_from = "alert@mender.io"
         service_name = "crond"
         user_name = "bugs.bunny@acme.org"
-        devid, authtoken, auth, mender_device = self.prepare_env(
+        devid, _, auth, mender_device = self.prepare_env(
             monitor_commercial_setup_no_client, user_name
         )
         logger.info("test_monitorclient_alert_email_rbac: env ready.")

--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -159,7 +159,7 @@ class TestMonitorClientEnterprise:
         devauth_tenant = DeviceAuthV2(auth)
 
         env.new_tenant_client("configuration-test-container", tenant["tenant_token"])
-        mender_device = MenderDevice(env.get_mender_clients()[0])
+        env.device = mender_device = MenderDevice(env.get_mender_clients()[0])
         mender_device.ssh_is_opened()
 
         devauth_tenant.accept_devices(1)

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -100,11 +100,6 @@ class DockerComposeNamespace(DockerNamespace):
         COMPOSE_FILES_PATH + "/docker-compose.client.yml",
         COMPOSE_FILES_PATH + "/docker-compose.mt.client.yml",
     ]
-    SMTP_FILES = [
-        COMPOSE_FILES_PATH + "/extra/smtp-testing/workflows-worker-smtp-test.yml",
-        COMPOSE_FILES_PATH
-        + "/extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml",
-    ]
     SMTP_MOCK_FILES = [
         COMPOSE_FILES_PATH + "/extra/smtp-testing/workflows-worker-smtp-mock.yml",
         COMPOSE_FILES_PATH
@@ -457,18 +452,6 @@ class DockerComposeEnterpriseSetup(DockerComposeNamespace):
             env={"TENANT_TOKEN": "%s" % tenant},
         )
         time.sleep(5)
-
-
-class DockerComposeEnterpriseSMTPSetup(DockerComposeNamespace):
-    def __init__(self, name):
-        DockerComposeNamespace.__init__(
-            self, name, self.ENTERPRISE_FILES + self.SMTP_FILES
-        )
-
-    def setup(self):
-        host_ip = socket.gethostbyname(socket.gethostname())
-        self._docker_compose_cmd("up -d", env={"HOST_IP": host_ip})
-        self._wait_for_containers(self.NUM_SERVICES_ENTERPRISE)
 
 
 class DockerComposeCompatibilitySetup(DockerComposeNamespace):

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -336,8 +336,6 @@ class DockerComposeStandardSetup(DockerComposeNamespace):
 class DockerComposeMonitorCommercialSetup(DockerComposeNamespace):
     def __init__(self, name, num_clients=0):
         self.num_clients = num_clients
-        # Lock to avoid concurrent tests using SMTP mock (port 1025)
-        self.smtp_mock_lock = filelock.FileLock("smtp_mock_lock")
         if self.num_clients > 0:
             raise NotImplementedError(
                 "Clients not implemented on setup time, use new_tenant_client"
@@ -348,16 +346,11 @@ class DockerComposeMonitorCommercialSetup(DockerComposeNamespace):
             )
 
     def setup(self, recreate=True, env=None):
-        self.smtp_mock_lock.acquire(timeout=20 * 60)
         cmd = "up -d"
         if not recreate:
             cmd += " --no-recreate"
         self._docker_compose_cmd(cmd, env=env)
         self._wait_for_containers(self.NUM_SERVICES_ENTERPRISE + 1)
-
-    def teardown(self):
-        super().teardown()
-        self.smtp_mock_lock.release()
 
     def new_tenant_client(self, name, tenant):
         if not self.MONITOR_CLIENT_COMMERCIAL_FILES[0] in self.docker_compose_files:

--- a/testutils/infra/container_manager/factory.py
+++ b/testutils/infra/container_manager/factory.py
@@ -23,7 +23,6 @@ from .docker_compose_manager import (
     DockerComposeShortLivedTokenSetup,
     DockerComposeFailoverServerSetup,
     DockerComposeEnterpriseSetup,
-    DockerComposeEnterpriseSMTPSetup,
     DockerComposeCustomSetup,
     DockerComposeCompatibilitySetup,
     DockerComposeMTLSSetup,
@@ -118,9 +117,6 @@ class DockerComposeManagerFactory(ContainerManagerFactory):
 
     def getEnterpriseSetup(self, name=None, num_clients=0):
         return DockerComposeEnterpriseSetup(name, num_clients)
-
-    def getEnterpriseSMTPSetup(self, name=None):
-        return DockerComposeEnterpriseSMTPSetup(name)
 
     def getCompatibilitySetup(self, name=None, **kwargs):
         return DockerComposeCompatibilitySetup(name, **kwargs)


### PR DESCRIPTION
    The port does not need to be exposed out of the Docker network. The
    problem was a typo in the `networks` key for `local-smtp` which made the
    container not connected to the Docker network. This was hidden by the
    fact that the port was exposed outside, and the tests used this outside
    interface.
    
    This fix allows for multiple tests using smtp mock to run in parallel.

And few minor clean-ups and improvements.