### PR TITLE
Monitoring: alert email sending test stabilization.

### DIFF
--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -290,6 +290,8 @@ class TestMonitorClientEnterprise:
             "test_monitorclient_alert_email: email alert a pattern found in the journalctl output scenario."
         )
         service_name = "mender-client"
+        mender_device.run("systemctl stop mender-monitor")
+        time.sleep(wait_for_alert_interval_s)
         prepare_log_monitoring(
             mender_device,
             service_name,


### PR DESCRIPTION

The test_monitorclient_alert_email started failing
There is no apparent reason, but this makes it stable.

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>