### PR TITLE
MEN-3420: Remove the cached auth token upon a tenant token change

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -133,7 +133,7 @@ fi
 # Extract file system images from Docker images
 mkdir -p output
 docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
-       mendersoftware/mender-client-qemu:$(../extra/release_tool.py --version-of mender-client-qemu --version-type docker) || ret=$?
+       mendersoftware/mender-client-qemu:$(../extra/release_tool.py --version-of mender-client-qemu --version-type docker)
 docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
         mendersoftware/mender-client-qemu-rofs:$(../extra/release_tool.py --version-of mender-client-qemu-rofs --version-type docker)
 mv output/* .

--- a/tests/tests/test_00_multi_tenancy.py
+++ b/tests/tests/test_00_multi_tenancy.py
@@ -61,9 +61,11 @@ class TestMultiTenancyEnterprise(MenderTesting):
 
         devauth.get_devices(expected_devices=1)
 
-    def test_multi_tenancy_deployment(self, enterprise_no_client, valid_image):
-        """ Simply make sure we are able to run the multi tenancy setup and
-           bootstrap 2 different devices to different tenants """
+    def test_multi_tenancy_deployment(
+        self, enterprise_no_client, valid_image_with_mender_conf
+    ):
+        """Simply make sure we are able to run the multi tenancy setup and
+           bootstrap 2 different devices to different tenants"""
 
         auth.reset_auth_token()
 
@@ -98,7 +100,19 @@ class TestMultiTenancyEnterprise(MenderTesting):
                     user["container"]
                 )
             )
+
+            # By default the valid_image has a tenant_token=dummy in the mender.conf
+            # Therefore, replace the 'mender.conf' in the image with the one from the
+            # currently running image, which has a valid 'mender.conf'.
+            mender_conf = mender_device.run("cat /etc/mender/mender.conf")
+            logger.info(
+                "Injecting the mender.conf into the update image:\n{conf}\n".format(
+                    conf=mender_conf
+                )
+            )
+            update_image_name = valid_image_with_mender_conf(mender_conf)
+
             host_ip = enterprise_no_client.get_virtual_network_host_ip()
             update_image(
-                mender_device, host_ip, install_image=valid_image,
+                mender_device, host_ip, install_image=update_image_name,
             )

--- a/tests/tests/test_update_control.py
+++ b/tests/tests/test_update_control.py
@@ -29,7 +29,7 @@ from .common_connect import wait_for_connect
 
 class TestUpdateControlEnterprise:
     def test_update_control(
-        self, enterprise_no_client, valid_image,
+        self, enterprise_no_client, valid_image_with_mender_conf,
     ):
         """
         Schedule an update with a pause in ArtifactInstall_Enter,
@@ -61,9 +61,11 @@ class TestUpdateControlEnterprise:
         )
         assert 1 == len(devices)
 
+        mender_conf = device.run("cat /etc/mender/mender.conf")
+
         with tempfile.NamedTemporaryFile() as artifact_file:
             created_artifact = image.make_rootfs_artifact(
-                valid_image,
+                valid_image_with_mender_conf(mender_conf),
                 conftest.machine_name,
                 "test-update-control",
                 artifact_file.name,


### PR DESCRIPTION
Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>