### PR TITLE
components-maps.yml: Amend monitor-client Docker image name

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -197,7 +197,7 @@ git:
     docker_image:
     - mender-monitor-qemu-commercial
     docker_container:
-    - monitor-client
+    - mender-client
     release_component: true
     independent_component: true
 
@@ -409,7 +409,7 @@ docker_image:
     git:
     - monitor-client
     docker_container:
-    - monitor-client
+    - mender-client
     release_component: true
 
   reporting:
@@ -455,11 +455,13 @@ docker_container:
   mender-client:
     git:
     - mender
+    - monitor-client
     docker_image:
     - mender-client-docker
     - mender-client-docker-addons
     - mender-client-qemu
     - mender-client-qemu-rofs
+    - mender-monitor-qemu-commercial
     release_component: true
 
   mender-api-gateway:
@@ -566,13 +568,6 @@ docker_container:
     - deviceconfig
     docker_image:
     - deviceconfig
-    release_component: true
-
-  monitor-client:
-    git:
-    - monitor-client
-    docker_image:
-    - mender-monitor-qemu-commercial
     release_component: true
 
   mender-reporting:


### PR DESCRIPTION
During integration tests development we changed it to use the same name
as for the regular yocto images build from mender repo. Align the maps
accordingly.