### PR TITLE
license-overview-generator: Add monitor-client as a non-go repo

### DIFF
--- a/extra/license-overview-generator
+++ b/extra/license-overview-generator
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 # Only do basic checks on these.
-OTHER_REPOS = [ 'mender-api-gateway-docker', 'integration' ]
+OTHER_REPOS = [ 'mender-api-gateway-docker', 'integration', 'monitor-client' ]
 # We don't currently care about these.
 IGNORE_REPOS = [ ]
 


### PR DESCRIPTION
It is written in bash, has not vendored dependencies (nor licenses).