### PR TITLE
release_tool: Update extra files also from CLI call

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -2749,6 +2749,20 @@ def do_set_version_to(args):
         integration_dir(), repo, args.version, git_tag=args.version
     )
 
+    # Update extra files used in integration tests
+    set_docker_compose_version_to(
+        os.path.join(integration_dir(), "extra", "mtls"),
+        repo,
+        args.version,
+        git_tag=args.version,
+    )
+    set_docker_compose_version_to(
+        os.path.join(integration_dir(), "extra", "failover-testing"),
+        repo,
+        args.version,
+        git_tag=args.version,
+    )
+
 
 def is_marked_as_releaseable_in_integration_version(
     integration_version, repo_git, repo_git_version


### PR DESCRIPTION
This is an amend to commit c68e632, which correctly sets the versions of
the extra docker compose files when releasing, but missed them when
using the --set-version-of CLI argument.

Fixes test failures from 3.1.x release branch, where these files are set
to a non-existing version (iow not set to "pr" by CI script).