### PR TITLE
[MEN-4852] Fix demo script user creation race condition

### DIFF
--- a/demo
+++ b/demo
@@ -19,7 +19,7 @@ RUN_UP=0
 UPLOAD_ARTIFACT=1
 PRINT_LOGIN_INFO=0
 PRINT_USER_EXISTS=0
-RETRY_LIMIT=5
+RETRY_LIMIT=30
 
 declare -a ARGS
 
@@ -228,26 +228,45 @@ start_server() {
         exit $retval
     fi
 
-    # Block until the useradm service returns an HTTP 4xx response
+    # Probe healthcheck endpoints until all services are ready
     local RETRIES=0
-    while :
-    do
-        curl --silent -k -X POST -u ${USER}:${PASSWORD} \
-                --fail \
-                --connect-timeout 5 \
-                $MENDER_SERVER_URI/api/management/v1/useradm/auth/login
-        retval=$?
-        case $retval in
-            0)  break ;; # User exists - continue.
-            22) break ;; # Server 400 error, ie, server is up - continue.
-            *) echo "It does not seem the useradm service is up and running yet. Retrying..." ;;
-        esac
-        if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
-            echo "Retried $RETRIES times without success. Giving up."
+    echo "Waiting for services to become ready..."
+    # For each container in docker-compose project with a healthcheck docker label
+    IFS= docker ps -a \
+        --filter "label=com.docker.compose.project=${DOCKER_COMPOSE_PROJECT_NAME}" \
+        --filter "label=mender.healthcheck.path" \
+        --format '{{.ID}} {{.Names}} {{.Label "mender.healthcheck.path"}}' | \
+    while read -r container_id container_name health_path; do
+        local container_ip
+        # Get container ip and status
+        container_ip=$(docker container inspect $container_id \
+            --format "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}")
+        # At this point all containers should be running, if ip is empty
+        # that means the container exited.
+        if [ $? != 0 ] || [ -z "$container_ip" ]; then
+            echo "Failed to obtain address of container ${container_name}."
             exit 1
+        elif [ -n "$container_ip" ]; then
+            break
         fi
-        RETRIES=$((RETRIES+1))
-        sleep 5
+
+        while :
+        do
+            curl --silent -k -X GET \
+                    --fail \
+                    --connect-timeout 5 \
+                    "http://$container_ip:8080/${health_path#/}"
+            case $retval in
+                0)  break ;;
+                *) ;;
+            esac
+            if [[ $RETRIES -ge $RETRY_LIMIT ]]; then
+                echo "Retried $RETRIES times without success. Giving up."
+                exit 1
+            fi
+            RETRIES=$((RETRIES+1))
+            sleep 1
+        done
     done
 }
 

--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -14,6 +14,8 @@ services:
         depends_on:
             - mender-mongo
         command: server --automigrate
+        labels:
+            mender.healthcheck.path: "/api/internal/v1/auditlogs/health"
 
     mender-api-gateway:
       volumes:

--- a/docker-compose.config.yml
+++ b/docker-compose.config.yml
@@ -14,6 +14,8 @@ services:
         depends_on:
             - mender-mongo
         command: server --automigrate
+        labels:
+            mender.healthcheck.path: "/api/internal/v1/deviceconfig/health"
 
     mender-api-gateway:
       volumes:

--- a/docker-compose.connect.yml
+++ b/docker-compose.connect.yml
@@ -18,6 +18,8 @@ services:
         environment:
             DEVICECONNECT_MONGO_URL: "mongodb://mender-mongo"
             DEVICECONNECT_NATS_URI: "nats://mender-nats:4222"
+        labels:
+            mender.healthcheck.path: "/api/internal/v1/deviceconnect/health"
 
     mender-nats:
         image: nats:2.1.9-alpine3.12

--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -14,6 +14,8 @@ services:
             - mender
         depends_on:
             - mender-mongo
+        labels:
+            mender.healthcheck.path: "/api/internal/v1/devicemonitor/health"
 
     mender-api-gateway:
       volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
             - mender
         depends_on:
             - mender-mongo
+        labels:
+            mender.healthcheck.path: "/api/internal/v1/deployments/health"
 
     #
     # mender-gui
@@ -82,6 +84,8 @@ services:
         depends_on:
             - mender-mongo
             - mender-workflows-server
+        labels:
+            mender.healthcheck.path: "/api/internal/v1/devauth/health"
 
     #
     # mender-inventory
@@ -95,6 +99,8 @@ services:
             - mender
         depends_on:
             - mender-mongo
+        labels:
+            mender.healthcheck.path: "/api/internal/v1/inventory/health"
 
     #
     # mender-useradm
@@ -108,6 +114,8 @@ services:
             - mender
         depends_on:
             - mender-mongo
+        labels:
+            mender.healthcheck.path: "/api/internal/v1/useradm/health"
 
     #
     # mender-workflows-server
@@ -123,6 +131,8 @@ services:
             - mender
         depends_on:
             - mender-mongo
+        labels:
+            mender.healthcheck.path: "/health"
 
     #
     # mender-workflows-worker


### PR DESCRIPTION
The demo script will now probe all healthcheck endpoints assigned to
docker-compose services using labels until all services becomes ready to
accept traffic.