### PR TITLE
3.1.x: test_monitorclient_logs_and_patterns: Add missing import

### DIFF
--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -19,6 +19,7 @@ import os.path
 import shutil
 import tempfile
 import time
+import uuid
 
 from email.parser import Parser
 from email.policy import default


### PR DESCRIPTION
Amends cherry-pick 7c25e18, which was done from a more recent master
where all tests use uuid to create random usernames.