### PR TITLE
3.0.x: release_tool.py: Add docker-compose.reporting.yml

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -427,6 +427,7 @@ def filter_docker_compose_files_list(list, version):
         "docker-compose.connect.yml",
         "docker-compose.config.yml",
         "docker-compose.monitor.yml",
+        "docker-compose.reporting.yml",
         "other-components-docker.yml",
     ]
     _GIT_ONLY_YML = ["git-versions.yml", "git-versions-enterprise.yml"]


### PR DESCRIPTION
The tool needs to know about this new file that might be found in more
recent remote branches.