### PR TITLE
tests: Bump the Debian version to Bullseye

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ test:docs:
     - ./run-tests.sh
 
 test:staging:backend-tests:
-  image: debian:buster
+  image: debian:bullseye
   stage: test
   timeout: 4h
   only:


### PR DESCRIPTION
This will give us a recent enough version of Rust, and make cryptography happy.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>