### PR TITLE
Moving to newer dind with explicit alpine version for staging integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,7 +138,7 @@ test:staging:backend-tests:
 test:staging:integration-tests:
   # Integration tests depends on running ssh to containers, we're forced to
   # run dockerd on the same host.
-  image: docker:19.03.5-dind
+  image: docker:19.03.15-dind-alpine3.13
   stage: test
   timeout: 4h
   only:


### PR DESCRIPTION
…taging integration.

we need something similar to 2d8acc35e0f33320857ecf782ddbf0c997c32892
to fix this:
`error: Rust 1.39.0 does not match extension requirement >=1.41.0'
https://gitlab.com/Northern.tech/Mender/integration/-/jobs/1690800935

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>