### PR TITLE
Bump versions for Mender saas-v2021.11.02.

### DIFF
--- a/docker-compose.auditlogs.yml
+++ b/docker-compose.auditlogs.yml
@@ -5,7 +5,7 @@ services:
     # auditlogs
     #
     mender-auditlogs:
-        image: registry.mender.io/mendersoftware/auditlogs:staging
+        image: registry.mender.io/mendersoftware/auditlogs:saas-v2021.11.02
         extends:
             file: common.yml
             service: mender-base

--- a/docker-compose.config.yml
+++ b/docker-compose.config.yml
@@ -5,7 +5,7 @@ services:
     # mender-deviceconfig
     #
     mender-deviceconfig:
-        image: mendersoftware/deviceconfig:staging
+        image: mendersoftware/deviceconfig:saas-v2021.11.02
         extends:
             file: common.yml
             service: mender-base

--- a/docker-compose.connect.yml
+++ b/docker-compose.connect.yml
@@ -5,7 +5,7 @@ services:
     # mender-deviceconnect
     #
     mender-deviceconnect:
-        image: mendersoftware/deviceconnect:staging
+        image: mendersoftware/deviceconnect:saas-v2021.11.02
         command: server --automigrate
         extends:
             file: common.yml

--- a/docker-compose.docker-client.addons.yml
+++ b/docker-compose.docker-client.addons.yml
@@ -3,7 +3,7 @@ services:
 
     mender-client:
         # Needs to be built in extra/mender-client-docker-addons
-        image: mendersoftware/mender-client-docker-addons:master
+        image: mendersoftware/mender-client-docker-addons:origin/staging
         networks:
             - mender
 

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -12,7 +12,7 @@ services:
 
     # add services
     mender-tenantadm:
-        image: registry.mender.io/mendersoftware/tenantadm:staging
+        image: registry.mender.io/mendersoftware/tenantadm:saas-v2021.11.02
         environment:
             TENANTADM_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
         extends:
@@ -25,7 +25,7 @@ services:
 
     # configure the rest
     mender-device-auth:
-        image: registry.mender.io/mendersoftware/deviceauth-enterprise:mender-master
+        image: registry.mender.io/mendersoftware/deviceauth-enterprise:saas-v2021.11.02
         environment:
             DEVICEAUTH_REDIS_ADDR: "mender-redis:6379"
             DEVICEAUTH_REDIS_USERNAME: ""

--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -5,7 +5,7 @@ services:
     # mender-devicemonitor
     #
     mender-devicemonitor:
-        image: registry.mender.io/mendersoftware/devicemonitor:mender-master
+        image: registry.mender.io/mendersoftware/devicemonitor:saas-v2021.11.02
         command: server --automigrate
         extends:
             file: common.yml

--- a/docker-compose.reporting.yml
+++ b/docker-compose.reporting.yml
@@ -4,7 +4,7 @@ services:
     # mender-reporting
     #
     mender-reporting:
-        image: mendersoftware/reporting:mender-master
+        image: mendersoftware/reporting:saas-v2021.11.02
         command: server --automigrate
         extends:
             file: common.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # mender-azure-iot-manager
     #
     mender-azure-iot-manager:
-        image: mendersoftware/azure-iot-manager:mender-master
+        image: mendersoftware/azure-iot-manager:saas-v2021.11.02
         extends:
             file: common.yml
             service: mender-base
@@ -20,7 +20,7 @@ services:
     # mender-deployments
     #
     mender-deployments:
-        image: registry.mender.io/mendersoftware/deployments-enterprise:staging
+        image: registry.mender.io/mendersoftware/deployments-enterprise:saas-v2021.11.02
         extends:
             file: common.yml
             service: mender-base
@@ -35,7 +35,7 @@ services:
     # mender-gui
     #
     mender-gui:
-        image: mendersoftware/gui:staging
+        image: mendersoftware/gui:saas-v2021.11.02
         extends:
             file: common.yml
             service: mender-base
@@ -88,7 +88,7 @@ services:
     # mender-device-auth
     #
     mender-device-auth:
-        image: mendersoftware/deviceauth:staging
+        image: mendersoftware/deviceauth:saas-v2021.11.02
         environment:
             DEVICEAUTH_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
         extends:
@@ -106,7 +106,7 @@ services:
     # mender-inventory
     #
     mender-inventory:
-        image: registry.mender.io/mendersoftware/inventory-enterprise:staging
+        image: registry.mender.io/mendersoftware/inventory-enterprise:saas-v2021.11.02
         extends:
             file: common.yml
             service: mender-base
@@ -121,7 +121,7 @@ services:
     # mender-useradm
     #
     mender-useradm:
-        image: registry.mender.io/mendersoftware/useradm-enterprise:staging
+        image: registry.mender.io/mendersoftware/useradm-enterprise:saas-v2021.11.02
         extends:
             file: common.yml
             service: mender-base
@@ -136,7 +136,7 @@ services:
     # mender-workflows-server
     #
     mender-workflows-server:
-        image: registry.mender.io/mendersoftware/workflows-enterprise:staging
+        image: registry.mender.io/mendersoftware/workflows-enterprise:saas-v2021.11.02
         environment:
             WORKFLOWS_MONGO_URL: mongodb://mender-mongo:27017
         extends:
@@ -153,7 +153,7 @@ services:
     # mender-workflows-worker
     #
     mender-workflows-worker:
-        image: registry.mender.io/mendersoftware/workflows-enterprise-worker:staging
+        image: registry.mender.io/mendersoftware/workflows-enterprise-worker:saas-v2021.11.02
         command: worker --excluded-workflows generate_artifact
         environment:
             WORKFLOWS_MONGO_URL: mongodb://mender-mongo:27017
@@ -169,7 +169,7 @@ services:
     # mender-create-artifact-worker
     #
     mender-create-artifact-worker:
-        image: mendersoftware/create-artifact-worker:staging
+        image: mendersoftware/create-artifact-worker:saas-v2021.11.02
         extends:
             file: common.yml
             service: mender-base

--- a/git-versions-enterprise.yml
+++ b/git-versions-enterprise.yml
@@ -8,31 +8,31 @@ services:
     # backend enterprise services
     #
     mender-deployments:
-        image: registry.mender.io/mendersoftware/deployments-enterprise:staging
+        image: registry.mender.io/mendersoftware/deployments-enterprise:saas-v2021.11.02
 
     mender-inventory:
-        image: registry.mender.io/mendersoftware/inventory-enterprise:staging
+        image: registry.mender.io/mendersoftware/inventory-enterprise:saas-v2021.11.02
 
     mender-workflows-server:
-        image: registry.mender.io/mendersoftware/workflows-enterprise:staging
+        image: registry.mender.io/mendersoftware/workflows-enterprise:saas-v2021.11.02
 
     mender-workflows-worker:
-        image: registry.mender.io/mendersoftware/workflows-enterprise-worker:staging
+        image: registry.mender.io/mendersoftware/workflows-enterprise-worker:saas-v2021.11.02
 
     mender-tenantadm:
-        image: registry.mender.io/mendersoftware/tenantadm:staging
+        image: registry.mender.io/mendersoftware/tenantadm:saas-v2021.11.02
 
     mender-useradm:
-        image: registry.mender.io/mendersoftware/useradm-enterprise:staging
+        image: registry.mender.io/mendersoftware/useradm-enterprise:saas-v2021.11.02
 
     mender-auditlogs:
-        image: registry.mender.io/mendersoftware/auditlogs:staging
+        image: registry.mender.io/mendersoftware/auditlogs:saas-v2021.11.02
 
     mtls-ambassador:
-        image: registry.mender.io/mendersoftware/mtls-ambassador:1.0.0
+        image: registry.mender.io/mendersoftware/mtls-ambassador:saas-v2021.11.02
 
     mender-devicemonitor:
-        image: registry.mender.io/mendersoftware/devicemonitor:master
+        image: registry.mender.io/mendersoftware/devicemonitor:saas-v2021.11.02
 
     mender-device-auth:
-        image: registry.mender.io/mendersoftware/deviceauth-enterprise:master
+        image: registry.mender.io/mendersoftware/deviceauth-enterprise:saas-v2021.11.02

--- a/git-versions.yml
+++ b/git-versions.yml
@@ -8,13 +8,13 @@ services:
     # backend open source services
     #
     mender-azure-iot-manager:
-        image: mendersoftware/azure-iot-manager:master
+        image: mendersoftware/azure-iot-manager:saas-v2021.11.02
 
     mender-gui:
-        image: mendersoftware/gui:staging
+        image: mendersoftware/gui:saas-v2021.11.02
 
     mender-device-auth:
-        image: mendersoftware/deviceauth:staging
+        image: mendersoftware/deviceauth:saas-v2021.11.02
 
     #mender-inventory:
         #image: mendersoftware/inventory:master
@@ -23,13 +23,13 @@ services:
         #image: mendersoftware/useradm:master
 
     mender-deviceconnect:
-        image: mendersoftware/deviceconnect:staging
+        image: mendersoftware/deviceconnect:saas-v2021.11.02
 
     mender-deviceconfig:
-        image: mendersoftware/deviceconfig:staging
+        image: mendersoftware/deviceconfig:saas-v2021.11.02
 
     mender-reporting:
-        image: mendersoftware/reporting:staging
+        image: mendersoftware/reporting:saas-v2021.11.02
 
     #mender-workflows-server:
         #image: mendersoftware/workflows:master
@@ -38,4 +38,4 @@ services:
         #image: mendersoftware/workflows-worker:master
 
     mender-create-artifact-worker:
-        image: mendersoftware/create-artifact-worker:staging
+        image: mendersoftware/create-artifact-worker:saas-v2021.11.02

--- a/other-components-docker.yml
+++ b/other-components-docker.yml
@@ -3,4 +3,4 @@
 # installation (have no docker-compose file).
 services:
     mtls-ambassador:
-        image: registry.mender.io/mendersoftware/mtls-ambassador:mender-3.0.0
+        image: registry.mender.io/mendersoftware/mtls-ambassador:saas-v2021.11.02


### PR DESCRIPTION
Changelog: Add auditlogs saas-v2021.11.02.
Changelog: Add azure-iot-manager saas-v2021.11.02.
Changelog: Add create-artifact-worker saas-v2021.11.02.
Changelog: Add deployments-enterprise saas-v2021.11.02.
Changelog: Add deviceauth-enterprise saas-v2021.11.02.
Changelog: Add deviceauth saas-v2021.11.02.
Changelog: Add deviceconfig saas-v2021.11.02.
Changelog: Add deviceconnect saas-v2021.11.02.
Changelog: Add devicemonitor saas-v2021.11.02.
Changelog: Add gui saas-v2021.11.02.
Changelog: Add integration saas-v2021.11.02.
Changelog: Add inventory-enterprise saas-v2021.11.02.
Changelog: Add mender-artifact 3.6.1.
Changelog: Add mender-cli 1.7.0.
Changelog: Add mender-connect 1.2.0.
Changelog: Add mender 3.1.0.
Changelog: Add monitor-client 1.0.0.
Changelog: Add mtls-ambassador saas-v2021.11.02.
Changelog: Add reporting saas-v2021.11.02.
Changelog: Add tenantadm saas-v2021.11.02.
Changelog: Add useradm-enterprise saas-v2021.11.02.
Changelog: Add workflows-enterprise saas-v2021.11.02.
Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>