### PR TITLE
component-maps.yml: Move "device" images to integration repo

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -7,8 +7,7 @@
 git:
 
   mender-auth-azure-iot:
-    docker_image:
-    - mender-client-qemu
+    docker_image: []
     docker_container:
     - mender-client
     release_component: true
@@ -63,6 +62,9 @@ git:
 
   integration:
     docker_image:
+    - mender-client-qemu
+    - mender-client-qemu-rofs
+    - mender-monitor-qemu-commercial
     - mender-client-docker-addons
     docker_container:
     - mender-client
@@ -86,8 +88,6 @@ git:
   mender:
     docker_image:
     - mender-client-docker
-    - mender-client-qemu
-    - mender-client-qemu-rofs
     docker_container:
     - mender-client
     release_component: true
@@ -206,7 +206,8 @@ git:
 
   mender-connect:
     docker_image: []
-    docker_container: []
+    docker_container:
+    - mender-client
     release_component: true
     independent_component: true
 
@@ -218,8 +219,7 @@ git:
     release_component: true
 
   monitor-client:
-    docker_image:
-    - mender-monitor-qemu-commercial
+    docker_image: []
     docker_container:
     - mender-client
     release_component: true
@@ -306,14 +306,14 @@ docker_image:
 
   mender-client-qemu:
     git:
-    - mender
+    - integration
     docker_container:
     - mender-client
     release_component: true
 
   mender-client-qemu-rofs:
     git:
-    - mender
+    - integration
     docker_container:
     - mender-client
     release_component: true
@@ -446,7 +446,7 @@ docker_image:
 
   mender-monitor-qemu-commercial:
     git:
-    - monitor-client
+    - integration
     docker_container:
     - mender-client
     release_component: true
@@ -503,7 +503,9 @@ docker_container:
 
   mender-client:
     git:
+    - integration
     - mender
+    - mender-connect
     - monitor-client
     - mender-auth-azure-iot
     docker_image:


### PR DESCRIPTION
Since we have introduced add-ons, the QEMU images no longer represent a
single version (mender client) but rather a combination of components,
and it makes more sense to track them following integration repo
versioning.

This commit moves all QEMU images to integration and corrects the
inconsistency across add-ons repos (mender-connect had no container,
mender-auth-azure-iot had both conainer and image).

Some sample release_tool commands:

```
$ release_tool --map-name git integration docker
mender-client-qemu
mender-client-qemu-rofs
mender-monitor-qemu-commercial
mender-client-docker-addons

$ release_tool --map-name container mender-client docker_url
mendersoftware/mender-client-docker
mendersoftware/mender-client-docker-addons
mendersoftware/mender-client-qemu
mendersoftware/mender-client-qemu-rofs
registry.mender.io/mendersoftware/mender-monitor-qemu-commercial

$ release_tool --map-name container mender-client git
integration
mender
mender-connect
monitor-client
mender-auth-azure-iot

$ release_tool --map-name git mender docker
mender-client-docker
```

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>