### PR TITLE
component-maps.yml: empty docker properties for mender-auth-azure-iot

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -7,10 +7,8 @@
 git:
 
   mender-auth-azure-iot:
-    docker_image:
-    - mender-client-qemu
-    docker_container:
-    - mender-client
+    docker_image: []
+    docker_container: []
     release_component: true
     independent_component: true
 
@@ -505,7 +503,6 @@ docker_container:
     git:
     - mender
     - monitor-client
-    - mender-auth-azure-iot
     docker_image:
     - mender-client-docker
     - mender-client-docker-addons


### PR DESCRIPTION
The release tool (today) does not play nice with two git repos having
the same docker_image. Set for now mender-auth-azure-iot with the same
setup as other device components (namely mender-connect).

We are planning on reworking the design to allow this, so one Docker
image can relate to more than one git repositories.