### PR TITLE
release_tool: Set remote integration version for `--list` option

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -696,6 +696,7 @@ def do_list_repos(args, optional_too, only_backend, only_client):
         "%s is not a valid name list format!" % args.list_format
     )
 
+    Component.set_integration_version(args.in_integration_version)
     repos = Component.get_components_of_type(
         type,
         only_release=(not optional_too),

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -121,6 +121,9 @@ def run_main_assert_result(capsys, args, expect=None):
     with patch.object(sys, "argv", testargs):
         main()
 
+    # Reset to avoid cache for further calls
+    Component.COMPONENT_MAPS = None
+
     captured = capsys.readouterr().out.strip()
     if expect is not None:
         assert captured == expect
@@ -462,3 +465,15 @@ def test_list_repos(capsys, is_staging):
         assert not any([r in repos_list for r in SAMPLE_REPOS_BACKEND_OS])
     else:
         assert all([r in repos_list for r in SAMPLE_REPOS_BACKEND_OS])
+
+
+def test_list_repos_old_releases(capsys):
+
+    # release_tool.py --list --in-integration-version 3.0.0
+    captured = run_main_assert_result(capsys, ["--list", "-i", "3.0.0"], None)
+    repos_list = captured.split("\n")
+    assert "monitor-client" not in repos_list
+    assert "deviceauth-enterprise" not in repos_list
+    assert "azure-iot-manager" not in repos_list
+    assert "mender" in repos_list
+    assert "deviceauth" in repos_list


### PR DESCRIPTION
Extend implementation from 2ae692c to also cover `--list`