### PR TITLE
Fix: Unset variable ENTERPRISE_CLIENT_FILES

### DIFF
--- a/demo
+++ b/demo
@@ -274,7 +274,7 @@ maybe_launch_enterprise_client() {
                     --id $TENANT_ID \
                     | jq -r .tenant_token)
             # Now that we have the tenant token we can enable the client.
-            EXTRA_FILES="$EXTRA_FILES $ENTERPRISE_CLIENT_FILES"
+            EXTRA_FILES="$EXTRA_FILES $CLIENT_FILES"
             TENANT_TOKEN=$TENANT_TOKEN run_compose_command "${ARGS[@]}" -d mender-client
         else
             echo "WARNING: Ignoring request to launch the Mender client."


### PR DESCRIPTION
This variable does not exist in 3.0.x

Changelog: None
(cherry picked from commit 421fd04e75ef59ffe90a217de66b521e57395aca)
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>