### PR TITLE
restored gui knowledge of now default config + connect features

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
             - MENDER_ARTIFACT_VERSION
             - MENDER_VERSION
             - MENDER_DEB_PACKAGE_VERSION
-            - HAVE_DEVICECONNECT
-            - HAVE_DEVICECONFIG
+            - HAVE_DEVICECONNECT=1
+            - HAVE_DEVICECONFIG=1
 
     #
     # mender-api-gateway


### PR DESCRIPTION
    this is just bringing back [this](https://github.com/mendersoftware/integration/commit/f6b1683718966fa132aae47889f1ab6277236b48#diff-81c3984ed252c36e7fdd96bbe99512361c084944dca6736924fe0835096a97b7L31) and [this](https://github.com/mendersoftware/integration/commit/f6b1683718966fa132aae47889f1ab6277236b48#diff-c93fabfc78ed66d1775dde2c6831f5417f0b7362ab8351ad6ad11a1e4480c79bL35)