### PR TITLE
mender-client-docker-addons entry point: mender-connect in background

### DIFF
--- a/extra/mender-client-docker-addons/entrypoint.sh
+++ b/extra/mender-client-docker-addons/entrypoint.sh
@@ -15,4 +15,5 @@ dbus-daemon --nofork --nopidfile --system &
 sleep 8
 mender --no-syslog daemon &
 sleep 8
-mender-connect daemon
+mender-connect daemon &
+while true; do sleep 10; done


### PR DESCRIPTION
Previously the container will terminate when killing mender-connect.
On a interactive session, one might want to restart the mender-connect
for debugging purposes.