### PR TITLE
mender-client-docker-addons: Update base image to latest Ubuntu

### DIFF
--- a/extra/mender-client-docker-addons/Dockerfile
+++ b/extra/mender-client-docker-addons/Dockerfile
@@ -1,6 +1,6 @@
 # Creates a container which acts as a bare bones non-VM based Mender
 # installation, for use in tests.
-FROM ubuntu:20.04 AS build
+FROM ubuntu:21.10 AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y make git build-essential golang liblzma-dev \
@@ -37,7 +37,7 @@ RUN make DESTDIR=/mender-install install
 
 RUN mkdir -p /mender-install/var/lib/mender && echo device_type=docker-client > /mender-install/var/lib/mender/device_type
 
-FROM ubuntu:20.04
+FROM ubuntu:21.10
 
 RUN mkdir -p /run/dbus && apt-get update && apt-get install -y liblzma5 dbus openssh-server
 


### PR DESCRIPTION
Ubuntu 20.04 LTS has golang 1.13, which is getting outdated. One of the
problems using it is that the vendor folder is ignored and the
dependencies are being downloaded from upstream. Ubuntu 21.10 comes with
golang 1.17 and respects the vendor folder.