### PR TITLE
tests: Introduce helper new_tenant_client between tests and env managers

### DIFF
--- a/backend-tests/requirements-py3.txt
+++ b/backend-tests/requirements-py3.txt
@@ -4,6 +4,7 @@ cffi==1.15.0
 chardet==4.0.0
 cryptography==36.0.0
 docker==5.0.3
+fabric==2.6.0
 filelock==3.4.0
 idna==3.3
 iniconfig==1.1.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,10 +193,21 @@ def pytest_exception_interact(node, call, report):
         if device is None:
             logger.info("Could not find device in test environment, no printing logs")
         else:
+
+            def print_device_output(instance, output):
+                """Log command output of either a MenderDevice or a MenderDeviceGroup."""
+                if isinstance(instance, MenderDevice):
+                    logger.info(output)
+                else:
+                    for dev, log in output.items():
+                        logger.info("Printing log of device %s", dev)
+                        logger.info(log)
+
             try:
                 logger.info("Printing client deployment log, if possible:")
                 output = device.run("cat /data/mender/deployment*.log || true", wait=60)
-                logger.info(output)
+                print_device_output(device, output)
+
             except:
                 logger.info("Not able to print client deployment log")
 
@@ -208,7 +219,7 @@ def pytest_exception_interact(node, call, report):
                 try:
                     logger.info("Printing %s systemd log, if possible:" % service)
                     output = device.run("journalctl -u %s || true" % service, wait=60,)
-                    logger.info(output)
+                    print_device_output(device, output)
                 except:
                     logger.info("Not able to print %s systemd log" % service)
 

--- a/tests/tests/test_access.py
+++ b/tests/tests/test_access.py
@@ -15,7 +15,7 @@ import json
 import pytest
 import uuid
 
-from testutils.common import Tenant, User, update_tenant
+from testutils.common import Tenant, User, update_tenant, new_tenant_client
 from testutils.infra.cli import CliTenantadm
 from testutils.infra.container_manager.kubernetes_manager import isK8S
 from testutils.api.client import ApiClient
@@ -25,7 +25,6 @@ import testutils.api.auditlogs as auditlogs
 import testutils.api.useradm as useradm
 import testutils.api.tenantadm as tenantadm
 import testutils.api.tenantadm_v2 as tenantadm_v2
-from testutils.infra.device import MenderDevice
 import testutils.integration.stripe as stripeutils
 
 from ..common_setup import (
@@ -367,8 +366,7 @@ class TestAccessEnterprise(_TestAccessBase):
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        env.new_tenant_client("test-container-{}".format(plan), ttoken)
-        device = MenderDevice(env.get_mender_clients()[0])
+        new_tenant_client(env, "test-container-{}".format(plan), ttoken)
         devauth.accept_devices(1)
 
         devices = list(
@@ -380,7 +378,6 @@ class TestAccessEnterprise(_TestAccessBase):
         u = User("", email, "correcthorse")
 
         tenant.users.append(u)
-        tenant.device = device
         tenant.device_id = devices[0]
         tenant.auth = auth
         tenant.devauth = devauth
@@ -440,8 +437,7 @@ class TestAccessEnterprise(_TestAccessBase):
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        env.new_tenant_client("test-container-trial", ttoken)
-        device = MenderDevice(env.get_mender_clients()[0])
+        new_tenant_client(env, "test-container-trial", ttoken)
         devauth.accept_devices(1)
 
         devices = list(
@@ -453,7 +449,6 @@ class TestAccessEnterprise(_TestAccessBase):
         u = User("", email, "correcthorse")
 
         tenant.users.append(u)
-        tenant.device = device
         tenant.device_id = devices[0]
         tenant.auth = auth
         tenant.devauth = devauth

--- a/tests/tests/test_configuration.py
+++ b/tests/tests/test_configuration.py
@@ -20,8 +20,7 @@ import time
 import uuid
 
 from testutils.infra.cli import CliTenantadm
-from testutils.infra.device import MenderDevice
-from testutils.common import Tenant, User, update_tenant
+from testutils.common import Tenant, User, update_tenant, new_tenant_client
 
 from ..common_setup import standard_setup_one_client, enterprise_no_client
 from ..MenderAPI import (
@@ -116,13 +115,10 @@ class TestConfigurationEnterprise(MenderTesting):
         devauth_tenant = DeviceAuthV2(auth)
 
         # Add a client to the tenant
-        enterprise_no_client.new_tenant_client(
-            "configuration-test-container", tenant.tenant_token
+        mender_device = new_tenant_client(
+            enterprise_no_client, "configuration-test-container", tenant.tenant_token
         )
-        mender_device = MenderDevice(enterprise_no_client.get_mender_clients()[0])
         mender_device.ssh_is_opened()
-
-        enterprise_no_client.device = mender_device
 
         devauth_tenant.accept_devices(1)
 

--- a/tests/tests/test_deployment_retry.py
+++ b/tests/tests/test_deployment_retry.py
@@ -20,9 +20,8 @@ import uuid
 from .. import conftest
 from ..common_setup import enterprise_no_client
 from ..MenderAPI import logger, Authentication, DeviceAuthV2, Deployments
-from testutils.infra.device import MenderDevice
 from testutils.infra.cli import CliTenantadm
-from testutils.common import Tenant, User
+from testutils.common import Tenant, User, new_tenant_client
 from .common_artifact import get_script_artifact
 from .mendertesting import MenderTesting
 
@@ -94,11 +93,10 @@ class TestDeploymentRetryEnterprise(MenderTesting):
         deploy = Deployments(auth, devauth)
 
         # Add a client to the tenant
-        enterprise_no_client.new_tenant_client(
-            "retry-test-container", tenant.tenant_token
+        device = new_tenant_client(
+            enterprise_no_client, "retry-test-container", tenant.tenant_token
         )
         devauth.accept_devices(1)
-        device = MenderDevice(env.get_mender_clients()[0])
 
         with tempfile.NamedTemporaryFile() as tf:
 

--- a/tests/tests/test_filetransfer.py
+++ b/tests/tests/test_filetransfer.py
@@ -43,7 +43,7 @@ from .common import md5sum
 from .mendertesting import MenderTesting
 from testutils.infra.container_manager import factory
 from testutils.infra.device import MenderDevice
-from testutils.common import User, update_tenant
+from testutils.common import User, update_tenant, new_tenant_client
 from testutils.infra.cli import CliTenantadm
 
 container_factory = factory.get_factory()
@@ -713,8 +713,9 @@ class TestFileTransferEnterprise(_TestFileTransferBase):
         auth.reset_auth_token()
         devauth_tenant = DeviceAuthV2(auth)
 
-        env.new_tenant_client("configuration-test-container", tenant["tenant_token"])
-        mender_device = MenderDevice(env.get_mender_clients()[0])
+        mender_device = new_tenant_client(
+            env, "configuration-test-container", tenant["tenant_token"]
+        )
         mender_device.ssh_is_opened()
 
         devauth_tenant.accept_devices(1)

--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -40,8 +40,7 @@ from testutils.api import useradm
 from testutils.api.client import ApiClient
 from testutils.infra.container_manager import factory
 from testutils.infra.container_manager.kubernetes_manager import isK8S
-from testutils.infra.device import MenderDevice
-from testutils.common import User
+from testutils.common import User, new_tenant_client
 from testutils.infra.cli import CliTenantadm
 
 container_factory = factory.get_factory()
@@ -259,8 +258,9 @@ class TestMonitorClientEnterprise:
         auth.reset_auth_token()
         devauth_tenant = DeviceAuthV2(auth)
 
-        env.new_tenant_client("configuration-test-container", tenant["tenant_token"])
-        env.device = mender_device = MenderDevice(env.get_mender_clients()[0])
+        mender_device = new_tenant_client(
+            env, "configuration-test-container", tenant["tenant_token"]
+        )
         mender_device.ssh_is_opened()
 
         devauth_tenant.accept_devices(1)

--- a/tests/tests/test_update_control.py
+++ b/tests/tests/test_update_control.py
@@ -17,14 +17,12 @@ import json
 import tempfile
 import uuid
 
-from testutils.common import User
+from testutils.common import User, new_tenant_client
 from testutils.infra.cli import CliTenantadm
-from testutils.infra.device import MenderDevice
 
 from .. import conftest
 from ..common_setup import enterprise_no_client
 from ..MenderAPI import Authentication, Deployments, DeviceAuthV2, image
-from .common_connect import wait_for_connect
 
 
 class TestUpdateControlEnterprise:
@@ -53,8 +51,9 @@ class TestUpdateControlEnterprise:
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        enterprise_no_client.new_tenant_client("control-map-test-container", ttoken)
-        device = MenderDevice(enterprise_no_client.get_mender_clients()[0])
+        device = new_tenant_client(
+            enterprise_no_client, "control-map-test-container", ttoken
+        )
         devauth.accept_devices(1)
 
         deploy = Deployments(auth, devauth)
@@ -154,10 +153,7 @@ class TestUpdateControlEnterprise:
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        enterprise_no_client.new_tenant_client("control-map-test-container", ttoken)
-        enterprise_no_client.device = MenderDevice(
-            enterprise_no_client.get_mender_clients()[0]
-        )
+        new_tenant_client(enterprise_no_client, "control-map-test-container", ttoken)
         devauth.accept_devices(1)
 
         deploy = Deployments(auth, devauth)

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -18,6 +18,7 @@ import traceback
 import os
 import socket
 import subprocess
+from typing import Dict
 
 from fabric import Connection
 from paramiko import SSHException
@@ -72,7 +73,7 @@ class MenderDevice:
     def host_string(self):
         return "%s:%s" % (self.host, self.port)
 
-    def run(self, cmd, **kw):
+    def run(self, cmd, **kw) -> str:
         """Run given cmd in remote SSH host
 
         Argument:
@@ -265,7 +266,12 @@ class MenderDeviceGroup:
     def __getitem__(self, idx):
         return self._devices[idx]
 
-    def run(self, cmd, **kw):
+    def append(self, new_device: MenderDevice):
+        """Append new_device to the group."""
+        assert isinstance(new_device, MenderDevice)
+        self._devices.append(new_device)
+
+    def run(self, cmd, **kw) -> Dict:
         """Run command for all devices in group sequentially
 
         see MenderDevice.run


### PR DESCRIPTION
The story behind this is that we have a hook in conftest to inspect test
environment in search for MenderDevice/MenderDeviceGroup instances. When
found, then we can print systemd logs from the Mender client(s).

This works fine for all OS setups, as common_setup fixtures uses this
convention of attaching the device to the environment. But on Enterprise
setups this is test specific, so it was forgotten most of the times.

Now this common.py level helper sits in the middle of the tests and the
env managers, so that it can create the Mender client container and
attach the MenderDevice instance to the test env (so that, yey, the logs
can be printed).