### PR TITLE
MEN-5344: adjust Azure integration tests to the new implementation

### DIFF
--- a/testutils/api/iot_manager.py
+++ b/testutils/api/iot_manager.py
@@ -15,5 +15,6 @@
 HOST = "mender-iot-manager:8080"
 
 URL_MGMT = "/api/management/v1/iot-manager"
-URL_SETTINGS = "/settings"
+URL_INTEGRATIONS = "/integrations"
 URL_DEVICE = lambda id: f"/devices/{id}"
+URL_DEVICE_STATE = lambda id: f"/devices/{id}/state"


### PR DESCRIPTION
Update the implementation of the backend integration tests for the Azure
integration. Also, add new tests for the device state management (Device
Twin in IoT Hub).

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>

Depends on: https://github.com/mendersoftware/iot-manager/pull/13