### PR TITLE
QA-321: Add all components to the release tool

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -6,6 +6,28 @@
 
 git:
 
+  mender-convert:
+    docker_image: []
+    docker_container: []
+    release_component: true
+    independent_component: true
+    non_core_component: true
+
+  mender-binary-delta:
+    docker_image: []
+    docker_container: []
+    release_component: true
+    independent_component: true
+    non_core_component: true
+
+  mender-configure-module:
+    docker_image:
+    - mender-client-docker-addons
+    docker_container: []
+    release_component: true
+    independent_component: true
+    non_core_component: true
+
   iot-manager:
     docker_image:
     - iot-manager
@@ -304,6 +326,7 @@ docker_image:
     - integration
     - mender
     - mender-connect
+    - mender-configure-module
     docker_container:
     - mender-client
     release_component: true

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -153,6 +153,7 @@ class Component:
         only_non_release=False,
         only_independent_component=False,
         only_non_independent_component=False,
+        only_core_components=True,
     ):
         Component._initialize_component_maps()
         if only_release is None:
@@ -172,6 +173,11 @@ class Component:
             is_release_component = Component.COMPONENT_MAPS[type][comp][
                 "release_component"
             ]
+            is_non_core_component = (
+                Component.COMPONENT_MAPS.get(type, {})
+                .get(comp, {})
+                .get("is_non_core_component", False)
+            )
             if is_independent_component and only_non_independent_component:
                 continue
             if not is_independent_component and only_independent_component:
@@ -179,6 +185,8 @@ class Component:
             if is_release_component and only_non_release:
                 continue
             if not is_release_component and only_release:
+                continue
+            if is_non_core_component and only_core_components:
                 continue
             components.append(Component(comp, type))
         return components
@@ -673,6 +681,7 @@ def do_list_repos(args, optional_too, only_backend, only_client):
         only_release=(not optional_too),
         only_non_independent_component=(only_backend),
         only_independent_component=(only_client),
+        only_core_components=(not optional_too),
     )
     repos.sort(key=lambda x: x.name)
 
@@ -1015,7 +1024,7 @@ def refresh_repos(state):
 
     git_list = []
 
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         remote = find_upstream_remote(state, repo.git())
         git_list.append(
             (
@@ -1044,7 +1053,7 @@ def check_tag_availability(state):
     tag_avail = {}
     highest_overall = -1
     all_released = True
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         tag_avail[repo.git()] = {}
         missing_repos = False
         try:
@@ -1133,7 +1142,10 @@ def report_release_state(state, tag_avail):
     fmt_str = "%-27s %-10s %-16s %-20s"
     print(fmt_str % ("REPOSITORY", "VERSION", "PICK NEXT BUILD", "BUILD TAG"))
     print(fmt_str % ("", "", "TAG FROM", ""))
-    for repo in sorted(Component.get_components_of_type("git"), key=repo_sort_key):
+    for repo in sorted(
+        Component.get_components_of_type("git", only_core_components=False),
+        key=repo_sort_key,
+    ):
         if tag_avail[repo.git()]["already_released"]:
             tag = state[repo.git()]["version"]
             # Report released tags as following themselves, even though behind
@@ -1272,7 +1284,7 @@ def generate_new_tags(state, tag_avail, final):
 
     # Find highest of all build tags in all repos.
     highest = 0
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         if (
             not tag_avail[repo.git()]["already_released"]
             and tag_avail[repo.git()].get("build_tag") is not None
@@ -1283,7 +1295,7 @@ def generate_new_tags(state, tag_avail, final):
 
     # Assign new build tags to each repo based on our previous findings.
     next_tag_avail = copy.deepcopy(tag_avail)
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         if not tag_avail[repo.git()]["already_released"]:
             if final:
                 # For final tag, point to the previous build tag, not the
@@ -1368,7 +1380,10 @@ def tag_and_push(state, tag_avail, next_tag_avail, final):
         changelogs = []
 
         # Modify docker tags in docker-compose file.
-        for repo in sorted(Component.get_components_of_type("git"), key=repo_sort_key):
+        for repo in sorted(
+            Component.get_components_of_type("git", only_core_components=False),
+            key=repo_sort_key,
+        ):
             if repo.is_independent_component():
                 set_docker_compose_version_to(
                     tmpdir, repo, next_tag_avail[repo.git()]["build_tag"]
@@ -1447,7 +1462,7 @@ def tag_and_push(state, tag_avail, next_tag_avail, final):
     # Prepare Git tag and push commands.
     git_tag_list = []
     git_push_list = []
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         if not next_tag_avail[repo.git()]["already_released"]:
             git_tag_list.append(
                 (
@@ -1476,7 +1491,7 @@ def tag_and_push(state, tag_avail, next_tag_avail, final):
         return tag_avail
 
     # If this was the final tag, reflect that in our data.
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         if not next_tag_avail[repo.git()]["already_released"] and final:
             next_tag_avail[repo.git()]["already_released"] = True
 
@@ -1544,7 +1559,7 @@ def get_extra_buildparams_from_jenkins():
     # as extra build parameters.
     extra_buildparams = {}
     in_versioned_repos = {}
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_compoments=False):
         in_versioned_repos[git_to_buildparam(repo.git())] = True
 
     for key, type, value in [jenkinsParamToDefaultMap(param) for param in parameters]:
@@ -1577,7 +1592,7 @@ def get_extra_buildparams_from_yaml():
     # as extra build parameters.
     extra_buildparams = {}
     in_versioned_repos = {}
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         in_versioned_repos[git_to_buildparam(repo.git())] = True
 
     for key, value in build_variables.items():
@@ -1619,7 +1634,8 @@ def trigger_build(state, tag_avail):
 
             # Populate parameters with build tags for each repository.
             for repo in sorted(
-                Component.get_components_of_type("git"), key=repo_sort_key
+                Component.get_components_of_type("git", only_core_components=False),
+                key=repo_sort_key,
             ):
                 if tag_avail[repo.git()].get("build_tag") is None:
                     print("%s doesn't have a build tag yet!" % repo.git())
@@ -1870,13 +1886,17 @@ def do_license_generation(state, tag_avail):
             return tag_avail[repo_git]["build_tag"]
 
     tmpdirs = []
-    for repo in Component.get_components_of_type("git", only_release=True):
+    for repo in Component.get_components_of_type(
+        "git", only_release=True, only_core_components=False
+    ):
         tmpdirs.append(
             setup_temp_git_checkout(
                 state, repo.git(), tag_or_followed_branch(repo.git())
             )
         )
-    for repo in Component.get_components_of_type("git", only_non_release=True):
+    for repo in Component.get_components_of_type(
+        "git", only_non_release=True, only_core_components=False
+    ):
         remote = find_upstream_remote(state, repo.git())
         tmpdirs.append(setup_temp_git_checkout(state, repo.git(), remote + "/master"))
 
@@ -1999,7 +2019,7 @@ def purge_build_tags(state, tag_avail):
     upstream as well."""
 
     git_list = []
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         remote = find_upstream_remote(state, repo.git())
         tag_list = execute_git(state, repo.git(), ["tag"], capture=True).split("\n")
         to_purge = []
@@ -2210,7 +2230,7 @@ def create_release_branches(state, tag_avail):
 
     any_repo_needs_branch = False
 
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         if tag_avail[repo.git()]["already_released"]:
             continue
 
@@ -2266,7 +2286,7 @@ def create_release_branches(state, tag_avail):
 
 
 def do_beta_to_final_transition(state):
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         version = state[repo.git()]["version"]
         version = re.sub("b[0-9]+$", "", version)
         update_state(state, [repo.git(), "version"], version)
@@ -2404,7 +2424,7 @@ def do_build(args):
         tag_avail = check_tag_availability(state)
     else:
         update_state(state, ["version"], args.build)
-        for repo in Component.get_components_of_type("git"):
+        for repo in Component.get_components_of_type("git", only_core_components=False):
             if repo.git() == "integration":
                 update_state(state, [repo.git(), "version"], args.build)
             else:
@@ -2640,6 +2660,7 @@ def do_generate_release_notes(state):
         only_release=True,
         only_non_independent_component=False,
         only_independent_component=True,
+        only_core_components=False,
     )
     for repo in repos:
         if repo.git() == "integration":
@@ -2705,7 +2726,10 @@ def do_release(release_state_file):
     if input.startswith("Y") or input.startswith("y"):
         refresh_repos(state)
 
-    repos = sorted(Component.get_components_of_type("git"), key=repo_sort_key)
+    repos = sorted(
+        Component.get_components_of_type("git", only_core_components=False),
+        key=repo_sort_key,
+    )
     while len(repos) > 0:
         repo = repos.pop(0)
         if not determine_version_to_include_in_release(state, repo):
@@ -2714,7 +2738,7 @@ def do_release(release_state_file):
     # Fill data about available tags.
     tag_avail = check_tag_availability(state)
 
-    for repo in Component.get_components_of_type("git"):
+    for repo in Component.get_components_of_type("git", only_core_components=False):
         if state_value(state, [repo.git(), "following"]) is None:
             # Follow "1.0.x" style branches by default.
             assign_default_following_branch(state, repo)
@@ -2798,7 +2822,9 @@ def do_release(release_state_file):
             push_latest_docker_tags(state, tag_avail)
         elif reply.lower() == "p":
             git_list = []
-            for repo in Component.get_components_of_type("git"):
+            for repo in Component.get_components_of_type(
+                "git", only_core_components=False
+            ):
                 remote = find_upstream_remote(state, repo.git())
                 git_list.append(
                     (

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -467,6 +467,21 @@ def test_list_repos(capsys, is_staging):
     else:
         assert all([r in repos_list for r in SAMPLE_REPOS_BACKEND_OS])
 
+    # release_tool.py --list --all
+    captured = run_main_assert_result(capsys, ["--list", "--all"], None)
+    repos_list = captured.split("\n")
+    assert all([r in repos_list for r in SAMPLE_REPOS_BACKEND_BASE])
+    assert all([r in repos_list for r in SAMPLE_REPOS_BACKEND_ENT])
+    assert all([r in repos_list for r in SAMPLE_REPOS_NON_BACKEND])
+    assert all([r in repos_list for r in SAMPLE_REPOS_DEPRECATED])
+    if is_staging:
+        assert not any([r in repos_list for r in SAMPLE_REPOS_BACKEND_OS])
+    else:
+        assert all([r in repos_list for r in SAMPLE_REPOS_BACKEND_OS])
+    assert "mender-binary-delta" in repos_list
+    assert "mender-convert" in repos_list
+    assert "mender-configure-module" in repos_list
+
 
 def test_list_repos_old_releases(capsys):
 

--- a/other-components.yml
+++ b/other-components.yml
@@ -12,3 +12,12 @@ services:
 
     mender-connect:
         image: mendersoftware/mender-connect:master
+
+    mender-binary-delta:
+        image: mendersoftware/mender-binary-delta:master
+
+    mender-convert:
+        image: mendersoftware/mender-convert:master
+
+    mender-configure-module:
+        image: mendersoftware/mender-configure-module:master


### PR DESCRIPTION
This includes support for:

* mender-binary-delta
* mender-convert
* mender-configure-module

Which are independent components, as well as `non-core`.

List them with `relase_tool --list --all`

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>