### PR TITLE
chore: missing backlink to mender-workflows-server docker container

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -416,7 +416,7 @@ docker_image:
     git:
     - workflows-enterprise
     docker_container:
-    - mender-workflows
+    - mender-workflows-server
     release_component: true
 
   workflows-worker:


### PR DESCRIPTION
The name was changed at some point, and this was forgotten.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>