### PR TITLE
3.2.x: Set mender-client-docker version to mender-3.2.x

### DIFF
--- a/docker-compose.docker-client.yml
+++ b/docker-compose.docker-client.yml
@@ -3,7 +3,7 @@ services:
 
     mender-client:
         # Needs to be built in mender client's test directory.
-        image: mendersoftware/mender-client-docker:3.2.x
+        image: mendersoftware/mender-client-docker:mender-3.2.x
         networks:
             - mender
 


### PR DESCRIPTION
Missing from be8b274.

See https://github.com/mendersoftware/integration/pull/1857#discussion_r786051581

Changelog: None