### PR TITLE
test_release_tool.py: Disable test_generate_release_notes_from_master

### DIFF
--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -764,6 +764,9 @@ def test_generate_release_notes(request, capsys):
         del os.environ["TEST_RELEASE_TOOL_LIST_OPEN_SOURCE_ONLY"]
 
 
+@pytest.mark.skip(
+    reason="reporting has no git version in 3.2.0 tag. To be fixed with QA-310"
+)
 def test_generate_release_notes_from_master(request, capsys):
     try:
         subprocess.check_call("rm -f release_notes*.txt", shell=True)


### PR DESCRIPTION
To be fixed with QA-310.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit 42bf938d5641bfec24a1a56f8a0f478fd9b0735a)