### PR TITLE
release_tool.py: Extend the handling of reporting service for 3.2.x

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -534,7 +534,7 @@ def version_specific_docker_compose_data_patching(data, rev):
             "version": "1.0.%s" % patch,
         }
 
-    if rev == "3.2.0" and data.get("reporting") is None:
+    if rev.startswith("3.2.") and data.get("reporting") is None:
         data["reporting"] = {
             "containers": ["mender-reporting"],
             "image_prefix": "mendersoftware/",


### PR DESCRIPTION
Latest tag 3.2.1 has the same problem as 3.2.0 because it came from the
same release branch.