### PR TITLE
release_tool: Repeat reporting fix for 3.2.1.

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -528,6 +528,18 @@ def version_specific_docker_compose_data_patching(data, rev):
             "version": "master",
         }
 
+    if rev == "3.2.1":
+        for comp in [
+            ("mender-artifact", ".0"),
+            ("mender-cli", ".0"),
+            ("mender-binary-delta", ".0"),
+            ("mender-convert", ".2"),
+        ]:
+            if data.get(comp[0]) is not None and data[comp[0]]["version"].endswith(
+                ".x"
+            ):
+                data[comp[0]]["version"] = data[comp[0]]["version"][:-2] + comp[1]
+
     return data
 
 

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -504,7 +504,7 @@ def version_specific_docker_compose_data_patching(data, rev):
 
     Therefore, we patch in this modification below, since we cannot fix the
     tags. Yes, this is ugly, but at least it's confined to versions below
-    3.2.0."""
+    3.3.0."""
 
     last_comp = rev.split("/")[-1]
     if re.match(r"^[0-9]+\.[0-9]\.", last_comp) is None:
@@ -534,7 +534,7 @@ def version_specific_docker_compose_data_patching(data, rev):
             "version": "1.0.%s" % patch,
         }
 
-    if rev == "3.2.0" and data.get("reporting") is None:
+    if (rev == "3.2.0" or rev == "3.2.1") and data.get("reporting") is None:
         data["reporting"] = {
             "containers": ["mender-reporting"],
             "image_prefix": "mendersoftware/",

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -388,6 +388,10 @@ def test_set_version_of(capsys, is_staging):
                 "extra/failover-testing/docker-compose.failover-server.yml.bkp",
             ),
         )
+        shutil.copyfile(
+            os.path.join(INTEGRATION_DIR, "other-components.yml"),
+            os.path.join(INTEGRATION_DIR, "other-components.yml.bkp"),
+        )
 
         # Using --set-version-of modifies both versions, regardless of using the repo name
         run_main_assert_result(
@@ -498,6 +502,80 @@ def test_set_version_of(capsys, is_staging):
             capsys, ["--version-of", "gui", "--version-type", "git"], "4.5.6-test"
         )
 
+        with pytest.raises(Exception):
+            # No docker version of mender-cli.
+            run_main_assert_result(
+                capsys,
+                [
+                    "--set-version-of",
+                    "mender-cli",
+                    "--version-type",
+                    "docker",
+                    "--version",
+                    "1.2.3-docker",
+                ],
+            )
+        run_main_assert_result(
+            capsys,
+            [
+                "--set-version-of",
+                "mender-cli",
+                "--version-type",
+                "git",
+                "--version",
+                "1.2.3-git",
+            ],
+        )
+        run_main_assert_result(capsys, ["--version-of", "mender-cli"], "1.2.3-git")
+        with pytest.raises(Exception):
+            # No docker version of mender-cli.
+            run_main_assert_result(
+                capsys,
+                ["--version-of", "mender-cli", "--version-type", "docker"],
+                "1.2.3-git",
+            )
+        run_main_assert_result(
+            capsys, ["--version-of", "mender-cli", "--version-type", "git"], "1.2.3-git"
+        )
+
+        with pytest.raises(Exception):
+            # No docker version of mender-artifact.
+            run_main_assert_result(
+                capsys,
+                [
+                    "--set-version-of",
+                    "mender-artifact",
+                    "--version-type",
+                    "docker",
+                    "--version",
+                    "1.2.3-docker",
+                ],
+            )
+        run_main_assert_result(
+            capsys,
+            [
+                "--set-version-of",
+                "mender-artifact",
+                "--version-type",
+                "git",
+                "--version",
+                "1.2.3-git",
+            ],
+        )
+        run_main_assert_result(capsys, ["--version-of", "mender-artifact"], "1.2.3-git")
+        with pytest.raises(Exception):
+            # No docker version of mender-artifact.
+            run_main_assert_result(
+                capsys,
+                ["--version-of", "mender-artifact", "--version-type", "docker"],
+                "1.2.3-git",
+            )
+        run_main_assert_result(
+            capsys,
+            ["--version-of", "mender-artifact", "--version-type", "git"],
+            "1.2.3-git",
+        )
+
     finally:
         os.rename(
             os.path.join(INTEGRATION_DIR, "git-versions.yml.bkp"),
@@ -524,6 +602,10 @@ def test_set_version_of(capsys, is_staging):
                 INTEGRATION_DIR,
                 "extra/failover-testing/docker-compose.failover-server.yml",
             ),
+        )
+        os.rename(
+            os.path.join(INTEGRATION_DIR, "other-components.yml.bkp"),
+            os.path.join(INTEGRATION_DIR, "other-components.yml"),
         )
 
 
@@ -582,29 +664,28 @@ def test_integration_versions_including(capsys):
 def test_docker_compose_files_list():
     list_git = docker_compose_files_list(INTEGRATION_DIR, version="git")
     list_git_filenames = [os.path.basename(file) for file in list_git]
-    assert "docker-compose.client.demo.yml" in list_git_filenames
-    assert "docker-compose.no-ssl.yml" in list_git_filenames
-    assert "docker-compose.testing.enterprise.yml" in list_git_filenames
-    assert "other-components.yml" in list_git_filenames
-    assert "docker-compose.storage.minio.yml" in list_git_filenames
-    assert "docker-compose.client.rofs.yml" in list_git_filenames
-    assert "docker-compose.client-dev.yml" in list_git_filenames
-    assert "docker-compose.mt.client.yml" in list_git_filenames
-    assert "docker-compose.demo.yml" in list_git_filenames
-    assert "docker-compose.client.yml" in list_git_filenames
-    assert "docker-compose.docker-client.yml" in list_git_filenames
+    assert "docker-compose.client.demo.yml" not in list_git_filenames
+    assert "docker-compose.no-ssl.yml" not in list_git_filenames
+    assert "docker-compose.testing.enterprise.yml" not in list_git_filenames
+    assert "docker-compose.storage.minio.yml" not in list_git_filenames
+    assert "docker-compose.client.rofs.yml" not in list_git_filenames
+    assert "docker-compose.client-dev.yml" not in list_git_filenames
+    assert "docker-compose.mt.client.yml" not in list_git_filenames
+    assert "docker-compose.demo.yml" not in list_git_filenames
+    assert "docker-compose.client.yml" not in list_git_filenames
+    assert "docker-compose.docker-client.yml" not in list_git_filenames
+    assert "docker-compose.yml" not in list_git_filenames
+    assert "docker-compose.enterprise.yml" not in list_git_filenames
 
     assert "git-versions.yml" in list_git_filenames
     assert "git-versions-enterprise.yml" in list_git_filenames
-    assert "docker-compose.yml" not in list_git_filenames
-    assert "docker-compose.enterprise.yml" not in list_git_filenames
+    assert "other-components.yml" in list_git_filenames
 
     list_docker = docker_compose_files_list(INTEGRATION_DIR, version="docker")
     list_docker_filenames = [os.path.basename(file) for file in list_docker]
     assert "docker-compose.client.demo.yml" in list_docker_filenames
     assert "docker-compose.no-ssl.yml" in list_docker_filenames
     assert "docker-compose.testing.enterprise.yml" in list_docker_filenames
-    assert "other-components.yml" in list_docker_filenames
     assert "docker-compose.storage.minio.yml" in list_docker_filenames
     assert "docker-compose.client.rofs.yml" in list_docker_filenames
     assert "docker-compose.client-dev.yml" in list_docker_filenames
@@ -612,11 +693,12 @@ def test_docker_compose_files_list():
     assert "docker-compose.demo.yml" in list_docker_filenames
     assert "docker-compose.client.yml" in list_docker_filenames
     assert "docker-compose.docker-client.yml" in list_docker_filenames
+    assert "docker-compose.yml" in list_docker_filenames
+    assert "docker-compose.enterprise.yml" in list_docker_filenames
 
     assert "git-versions.yml" not in list_docker_filenames
     assert "git-versions-enterprise.yml" not in list_docker_filenames
-    assert "docker-compose.yml" in list_docker_filenames
-    assert "docker-compose.enterprise.yml" in list_docker_filenames
+    assert "other-components.yml" not in list_docker_filenames
 
 
 @patch("release_tool.integration_dir")

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -220,6 +220,28 @@ def test_version_of(capsys):
         "mender-master",
     )
 
+    # Some known hardcodings for these.
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "mender-artifact", "--in-integration-version", "3.2.1"],
+        "3.7.0",
+    )
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "mender-cli", "--in-integration-version", "3.2.1"],
+        "1.7.0",
+    )
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "mender-binary-delta", "--in-integration-version", "3.2.1"],
+        "1.3.0",
+    )
+    run_main_assert_result(
+        capsys,
+        ["--version-of", "mender-convert", "--in-integration-version", "3.2.1"],
+        "2.6.2",
+    )
+
 
 def test_version_of_with_in_integration_version(capsys):
     # In remote master, shall be master


### PR DESCRIPTION
The underlying problem, which is that reporting is missing in
`git-versions.yml`, has also been fixed on the 3.2.x branch, so it
should not happen again.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>