### PR TITLE
test: run integrations tests in both OS and ENT where possible

### DIFF
--- a/extra/integration-testing/docker-compose.mender.2.5.yml
+++ b/extra/integration-testing/docker-compose.mender.2.5.yml
@@ -12,7 +12,8 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - SERVER_URL=$SERVER_URL
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       # Provision demo certificate
       - ./cert/cert.crt:/mnt/config/server.crt

--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -282,9 +282,7 @@ class TestMonitorClientEnterprise:
         auth.reset_auth_token()
         devauth_tenant = DeviceAuthV2(auth)
 
-        mender_device = new_tenant_client(
-            env, "configuration-test-container", tenant["tenant_token"]
-        )
+        mender_device = new_tenant_client(env, "test-container", tenant["tenant_token"])
         mender_device.ssh_is_opened()
 
         devauth_tenant.accept_devices(1)

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -379,6 +379,14 @@ class DockerComposeMenderClient_2_5(DockerComposeCompatibilitySetup):
         super(DockerComposeCompatibilitySetup, self).__init__(
             name, extra_files=extra_files
         )
+
+    def new_tenant_client(self, name, tenant):
+        logger.info("creating client connected to tenant: " + tenant)
+        self._docker_compose_cmd(
+            "run -d --name=%s_%s mender-client-2-5" % (self.name, name),
+            env={"TENANT_TOKEN": "%s" % tenant},
+        )
+        time.sleep(45)
 
 
 class DockerComposeCustomSetup(DockerComposeNamespace):


### PR DESCRIPTION
Rework tests in the following files to run both in open-source and
enterprise:

- test_filetransfer.py
- test_filetransfer_cli.py
- test_mender_connect.py
- test_portforward.py
- test_remote_terminal.py

Changelog: none
Ticket: QA-332

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>