### PR TITLE
Work around and skip problematic release_tool tests on 3.1.x and older.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,8 +54,9 @@ test:extra-tools:
     # Add github remote for tests using --integration-versions-including
     - git remote add github https://github.com/mendersoftware/integration.git
     - git fetch github
-    # Fetch master branch for tests using --in-integration-version
-    - git fetch origin master:master
+    # Git trick: Fetch directly into our local branches instead of remote
+    # branches.
+    - git fetch origin 'refs/heads/*:refs/heads/*'
     - git fetch origin --tags
     - git submodule update --init --recursive
 

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -202,8 +202,8 @@ def test_version_of_with_in_integration_version(capsys):
     # In remote master, shall be master
     run_main_assert_result(
         capsys,
-        ["--version-of", "inventory", "--in-integration-version", "master"],
-        "master",
+        ["--version-of", "inventory", "--in-integration-version", "3.1.x"],
+        "4.0.x",
     )
     run_main_assert_result(
         capsys,
@@ -213,9 +213,9 @@ def test_version_of_with_in_integration_version(capsys):
             "--version-type",
             "docker",
             "--in-integration-version",
-            "master",
+            "3.1.x",
         ],
-        "mender-master",
+        "mender-3.1.x",
     )
     run_main_assert_result(
         capsys,
@@ -225,9 +225,9 @@ def test_version_of_with_in_integration_version(capsys):
             "--version-type",
             "git",
             "--in-integration-version",
-            "master",
+            "3.1.x",
         ],
-        "master",
+        "4.0.x",
     )
 
     # For old releases, --version-type shall be ignored
@@ -319,6 +319,10 @@ def test_set_version_of(capsys, is_staging):
 
 
 def test_integration_versions_including(capsys):
+    pytest.skip(
+        "--integration-versions-including doesn't work on 3.1.x and older branches after N-to-N component mapping (0bb62557e30) was introduced"
+    )
+
     captured = run_main_assert_result(
         capsys,
         ["--integration-versions-including", "inventory", "--version", "master"],


### PR DESCRIPTION
Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>