### PR TITLE
test: run integrations tests in both OS and ENT where possible

### DIFF
--- a/tests/MenderAPI/devauth.py
+++ b/tests/MenderAPI/devauth.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ class DeviceAuthV2:
             )
             if (
                 devices.status_code == requests.status_codes.codes.ok
-                and len(devices.json()) == expected_devices
+                and len(devices.json()) >= expected_devices
             ):
                 got_devices = True
                 break

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -12,11 +12,16 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import json
 import pytest
+import uuid
+
 from . import conftest
 
-from .MenderAPI import auth, devauth, reset_mender_api
+from .MenderAPI import authentication, auth, devauth, reset_mender_api, DeviceAuthV2
 
+from testutils.common import User, new_tenant_client
+from testutils.infra.cli import CliTenantadm
 from testutils.infra.device import MenderDevice, MenderDeviceGroup
 from testutils.infra.container_manager import factory
 
@@ -35,6 +40,7 @@ def standard_setup_one_client(request):
 
     reset_mender_api(env)
 
+    env.auth = auth
     return env
 
 
@@ -61,6 +67,7 @@ def standard_setup_one_client_bootstrapped_impl(request):
     reset_mender_api(env)
     devauth.accept_devices(1)
 
+    env.auth = auth
     return env
 
 
@@ -87,6 +94,7 @@ def standard_setup_one_rofs_client_bootstrapped(request):
     reset_mender_api(env)
     devauth.accept_devices(1)
 
+    env.auth = auth
     return env
 
 
@@ -103,6 +111,7 @@ def standard_setup_one_docker_client_bootstrapped(request):
     reset_mender_api(env)
     devauth.accept_devices(1)
 
+    env.auth = auth
     return env
 
 
@@ -119,6 +128,7 @@ def standard_setup_two_clients_bootstrapped(request):
     reset_mender_api(env)
     devauth.accept_devices(2)
 
+    env.auth = auth
     return env
 
 
@@ -231,6 +241,115 @@ def enterprise_no_client(request):
 
     env.setup()
     reset_mender_api(env)
+
+    return env
+
+
+@pytest.fixture(scope="function")
+def enterprise_one_client(request):
+    env = container_factory.getEnterpriseSetup(num_clients=0)
+    request.addfinalizer(env.teardown)
+
+    env.setup()
+    reset_mender_api(env)
+
+    uuidv4 = str(uuid.uuid4())
+    tname = "test.mender.io-{}".format(uuidv4)
+    email = "some.user+{}@example.com".format(uuidv4)
+    u = User("", email, "whatsupdoc")
+    cli = CliTenantadm(containers_namespace=env.name)
+    tid = cli.create_org(tname, u.name, u.pwd, plan="os")
+
+    tenant = cli.get_tenant(tid)
+    tenant = json.loads(tenant)
+    env.tenant = tenant
+
+    auth = authentication.Authentication(
+        name="os-tenant", username=u.name, password=u.pwd
+    )
+    auth.create_org = False
+    auth.reset_auth_token()
+    env.auth = auth
+
+    mender_device = new_tenant_client(env, "test-container", tenant["tenant_token"])
+    mender_device.ssh_is_opened()
+    env.device = mender_device
+
+    return env
+
+
+@pytest.fixture(scope="function")
+def enterprise_one_client_bootstrapped(request):
+    env = container_factory.getEnterpriseSetup(num_clients=0)
+    request.addfinalizer(env.teardown)
+
+    env.setup()
+    reset_mender_api(env)
+
+    uuidv4 = str(uuid.uuid4())
+    tname = "test.mender.io-{}".format(uuidv4)
+    email = "some.user+{}@example.com".format(uuidv4)
+    u = User("", email, "whatsupdoc")
+    cli = CliTenantadm(containers_namespace=env.name)
+    tid = cli.create_org(tname, u.name, u.pwd, plan="os")
+
+    tenant = cli.get_tenant(tid)
+    tenant = json.loads(tenant)
+    env.tenant = tenant
+
+    auth = authentication.Authentication(
+        name="os-tenant", username=u.name, password=u.pwd
+    )
+    auth.create_org = False
+    auth.reset_auth_token()
+    env.auth = auth
+
+    mender_device = new_tenant_client(env, "test-container", tenant["tenant_token"])
+    mender_device.ssh_is_opened()
+    env.device = mender_device
+
+    devauth_tenant = DeviceAuthV2(auth)
+    devauth_tenant.accept_devices(1)
+    devices = devauth_tenant.get_devices_status("accepted")
+    assert 1 == len(devices)
+
+    return env
+
+
+@pytest.fixture(scope="function")
+def enterprise_two_clients_bootstrapped(request):
+    env = container_factory.getEnterpriseSetup(num_clients=0)
+    request.addfinalizer(env.teardown)
+
+    env.setup()
+    reset_mender_api(env)
+
+    uuidv4 = str(uuid.uuid4())
+    tname = "test.mender.io-{}".format(uuidv4)
+    email = "some.user+{}@example.com".format(uuidv4)
+    u = User("", email, "whatsupdoc")
+    cli = CliTenantadm(containers_namespace=env.name)
+    tid = cli.create_org(tname, u.name, u.pwd, plan="os")
+
+    tenant = cli.get_tenant(tid)
+    tenant = json.loads(tenant)
+    env.tenant = tenant
+
+    auth = authentication.Authentication(
+        name="os-tenant", username=u.name, password=u.pwd
+    )
+    auth.create_org = False
+    auth.reset_auth_token()
+    env.auth = auth
+
+    new_tenant_client(env, "test-container-1", tenant["tenant_token"])
+    new_tenant_client(env, "test-container-2", tenant["tenant_token"])
+    env.device_group.ssh_is_opened()
+
+    devauth_tenant = DeviceAuthV2(auth)
+    devauth_tenant.accept_devices(2)
+    devices = devauth_tenant.get_devices_status("accepted", expected_devices=2)
+    assert 2 == len(devices)
 
     return env
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -117,8 +117,19 @@ def valid_image_with_mender_conf(request, valid_image):
 
 
 @pytest.fixture(scope="session")
-def valid_image_rofs(request):
-    return "mender-image-full-cmdline-rofs-%s.ext4" % machine_name
+def valid_image_rofs_with_mender_conf(request):
+    valid_image = "mender-image-full-cmdline-rofs-%s.ext4" % machine_name
+    if not os.path.exists(valid_image):
+        yield None
+        return
+
+    with tempfile.TemporaryDirectory() as d:
+
+        def cleanup():
+            shutil.rmtree(d, ignore_errors=True)
+
+        request.addfinalizer(cleanup)
+        yield lambda conf: add_mender_conf_to_image(valid_image, d, conf)
 
 
 def pytest_configure(config):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class Helpers:
         return json.dumps(data_dict, separators=(",", ":"))
 
     @staticmethod
-    def ip_to_device_id_map(device_group):
+    def ip_to_device_id_map(device_group, devauth=devauth):
         # Get deviceauth data, which includes device identity.
         devauth_devices = devauth.get_devices(expected_devices=len(device_group))
 

--- a/tests/tests/common_connect.py
+++ b/tests/tests/common_connect.py
@@ -54,7 +54,7 @@ def prepare_env_for_connect(env):
     auth.reset_auth_token()
     devauth_tenant = DeviceAuthV2(auth)
 
-    mender_device = new_tenant_client(env, "test-container", tenant["tenant_token"])
+    mender_device = new_tenant_client(env, "mender-client", tenant["tenant_token"])
     mender_device.ssh_is_opened()
 
     devauth_tenant.accept_devices(1)

--- a/tests/tests/common_update.py
+++ b/tests/tests/common_update.py
@@ -109,6 +109,8 @@ def update_image(
     make_artifact=None,
     compression_type="gzip",
     version=None,
+    devauth=devauth,
+    deploy=deploy,
 ):
     """
         Perform a successful upgrade, and assert that deployment status/logs are correct.
@@ -131,6 +133,8 @@ def update_image(
             make_artifact=make_artifact,
             compression_type=compression_type,
             version=version,
+            devauth=devauth,
+            deploy=deploy,
         )
         reboot.verify_reboot_performed()
 
@@ -175,6 +179,8 @@ def update_image_failed(
     install_image="broken_update.ext4",
     make_artifact=None,
     expected_number_of_reboots=2,
+    devauth=devauth,
+    deploy=deploy,
 ):
     """
         Perform a upgrade using a broken image (random data)
@@ -187,7 +193,7 @@ def update_image_failed(
     previous_active_part = device.get_active_partition()
     with device.get_reboot_detector(host_ip) as reboot:
         deployment_id, _ = common_update_procedure(
-            install_image, make_artifact=make_artifact
+            install_image, make_artifact=make_artifact, devauth=devauth, deploy=deploy,
         )
         # It will reboot twice. Once into the failed update, which the
         # bootloader will roll back, and therefore we will end up on the

--- a/tests/tests/common_update.py
+++ b/tests/tests/common_update.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ def common_update_procedure(
     make_artifact=None,
     compression_type="gzip",
     version=None,
+    devauth=devauth,
+    deploy=deploy,
 ):
 
     with artifact_lock:

--- a/tests/tests/test_access.py
+++ b/tests/tests/test_access.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -371,7 +371,7 @@ class TestAccessEnterprise(_TestAccessBase):
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        new_tenant_client(env, "test-container-{}".format(plan), ttoken)
+        new_tenant_client(env, "mender-client-{}".format(plan), ttoken)
         devauth.accept_devices(1)
 
         devices = list(
@@ -442,7 +442,7 @@ class TestAccessEnterprise(_TestAccessBase):
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        new_tenant_client(env, "test-container-trial", ttoken)
+        new_tenant_client(env, "mender-client-trial", ttoken)
         devauth.accept_devices(1)
 
         devices = list(

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -24,9 +24,19 @@ from ..common_setup import (
     standard_setup_with_short_lived_token,
     setup_failover,
     standard_setup_one_client_bootstrapped,
+    enterprise_one_client_bootstrapped,
+    enterprise_with_short_lived_token,
 )
 from .common_update import update_image, update_image_failed
-from ..MenderAPI import image, inv, logger, devauth, DeviceAuthV2, get_container_manager
+from ..MenderAPI import (
+    image,
+    logger,
+    devauth,
+    DeviceAuthV2,
+    Deployments,
+    Inventory,
+    get_container_manager,
+)
 from .mendertesting import MenderTesting
 
 
@@ -40,7 +50,168 @@ class DeviceAuthFailover(DeviceAuthV2):
         )
 
 
-class TestBasicIntegration(MenderTesting):
+class BaseTestBasicIntegration(MenderTesting):
+    def do_test_update_jwt_expired(self, env, valid_image_with_mender_conf):
+        """Update a device with a short lived JWT token"""
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
+
+        mender_conf = env.device.run("cat /etc/mender/mender.conf")
+        update_image(
+            env.device,
+            env.get_virtual_network_host_ip(),
+            install_image=valid_image_with_mender_conf(mender_conf),
+            devauth=devauth,
+            deploy=deploy,
+        )
+
+    def do_test_failed_updated_and_valid_update(
+        self, env, valid_image_with_mender_conf
+    ):
+        """Upload a device with a broken image, followed by a valid image"""
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
+
+        mender_device = env.device
+        host_ip = env.get_virtual_network_host_ip()
+
+        update_image_failed(mender_device, host_ip, devauth=devauth, deploy=deploy)
+        mender_conf = mender_device.run("cat /etc/mender/mender.conf")
+        update_image(
+            mender_device,
+            host_ip,
+            install_image=valid_image_with_mender_conf(mender_conf),
+            devauth=devauth,
+            deploy=deploy,
+        )
+
+    def do_test_update_no_compression(self, env, valid_image_with_mender_conf):
+        """Uploads an uncompressed artifact, and runs the whole udpate process."""
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
+
+        mender_device = env.device
+        mender_conf = mender_device.run("cat /etc/mender/mender.conf")
+        update_image(
+            env.device,
+            env.get_virtual_network_host_ip(),
+            install_image=valid_image_with_mender_conf(mender_conf),
+            compression_type="none",
+            devauth=devauth,
+            deploy=deploy,
+        )
+
+    def do_test_forced_update_check_from_client(
+        self, env, valid_image_with_mender_conf
+    ):
+        """Upload a device with a broken image, followed by a valid image"""
+
+        mender_device = env.device
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
+
+        # Give the image a really large wait interval.
+        sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % (
+            r"\(.*PollInter.*:\)\( *[0-9]*\)",
+            "\\1 1800",
+        )
+        mender_device.run(sedcmd)
+        client_service_name = mender_device.get_client_service_name()
+        mender_device.run("systemctl restart %s" % client_service_name)
+
+        def deployment_callback():
+            logger.info("Running pre deployment callback function")
+            wait_count = 0
+            # Match the log template six times to make sure the client is truly sleeping.
+            catcmd = "journalctl -u %s --output=cat" % client_service_name
+            template = mender_device.run(catcmd)
+            while True:
+                logger.info("sleeping...")
+                logger.info("wait_count: %d" % wait_count)
+                time.sleep(10)
+                out = mender_device.run(catcmd)
+                if out == template:
+                    wait_count += 1
+                    # Only return if the client has been idling in check-wait for a minute.
+                    if wait_count == 6:
+                        return
+                    continue
+                # Update the matching template
+                template = mender_device.run(catcmd)
+                wait_count = 0
+
+        def deployment_triggered_callback():
+            mender_device.run("mender check-update")
+            logger.info("mender client has forced an update check")
+
+        mender_conf = mender_device.run("cat /etc/mender/mender.conf")
+        update_image(
+            mender_device,
+            env.get_virtual_network_host_ip(),
+            install_image=valid_image_with_mender_conf(mender_conf),
+            pre_deployment_callback=deployment_callback,
+            deployment_triggered_callback=deployment_triggered_callback,
+            devauth=devauth,
+            deploy=deploy,
+        )
+
+    def do_test_forced_inventory_update_from_client(self, env):
+        """Forces an inventory update from an idling client."""
+
+        mender_device = env.device
+        inv = Inventory(env.auth)
+
+        # Give the image a really large wait interval.
+        sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % (
+            r"\(.*PollInter.*:\)\( *[0-9]*\)",
+            "\\1 1800",
+        )
+        mender_device.run(sedcmd)
+        client_service_name = mender_device.get_client_service_name()
+        mender_device.run("systemctl restart %s" % client_service_name)
+
+        logger.info("Running pre deployment callback function")
+        wait_count = 0
+        # Match the log template six times to make sure the client is truly sleeping.
+        catcmd = "journalctl -u %s --output=cat" % client_service_name
+        template = mender_device.run(catcmd)
+        while True:
+            logger.info("sleeping...")
+            logger.info("wait_count: %d" % wait_count)
+            time.sleep(10)
+            out = mender_device.run(catcmd)
+            if out == template:
+                wait_count += 1
+                # Only return if the client has been idling in check-wait for a minute.
+                if wait_count == 6:
+                    break
+                continue
+            # Update the matching template.
+            template = mender_device.run(catcmd)
+            wait_count = 0
+
+        # Create some new inventory data from an inventory script.
+        mender_device.run(
+            "cd /usr/share/mender/inventory && echo '#!/bin/sh\necho host=foobar' > mender-inventory-test && chmod +x mender-inventory-test"
+        )
+
+        # Now that the client has settled into the wait-state, run the command, and check if it does indeed exit the wait state,
+        # and send inventory.
+        mender_device.run("mender send-inventory")
+        logger.info("mender client has forced an inventory update")
+
+        for i in range(10):
+            # Check that the updated inventory value is now present.
+            invJSON = inv.get_devices()
+            for element in invJSON[0]["attributes"]:
+                if element["name"] == "host" and element["value"] == "foobar":
+                    return
+            time.sleep(10)
+
+        pytest.fail("The inventory was not updated")
+
+
+class TestBasicIntegrationOpenSource(BaseTestBasicIntegration):
     @MenderTesting.fast
     def test_double_update_rofs(
         self, standard_setup_one_rofs_client_bootstrapped, valid_image_rofs
@@ -75,18 +246,6 @@ class TestBasicIntegration(MenderTesting):
             compression_type="lzma",
         )
         mender_device.run("mount | fgrep 'on / ' | fgrep '(ro,'")
-
-    @MenderTesting.fast
-    def test_update_jwt_expired(
-        self, standard_setup_with_short_lived_token, valid_image
-    ):
-        """Update a device with a short lived JWT token"""
-
-        update_image(
-            standard_setup_with_short_lived_token.device,
-            standard_setup_with_short_lived_token.get_virtual_network_host_ip(),
-            install_image=valid_image,
-        )
 
     @MenderTesting.fast
     def test_update_failover_server(self, setup_failover, valid_image):
@@ -151,131 +310,79 @@ class TestBasicIntegration(MenderTesting):
             os.remove(tmp_image)
 
     @MenderTesting.fast
-    def test_failed_updated_and_valid_update(
-        self, standard_setup_one_client_bootstrapped, valid_image
+    def test_update_jwt_expired(
+        self, standard_setup_with_short_lived_token, valid_image_with_mender_conf
     ):
-        """Upload a device with a broken image, followed by a valid image"""
+        self.do_test_update_jwt_expired(
+            standard_setup_with_short_lived_token, valid_image_with_mender_conf
+        )
 
-        mender_device = standard_setup_one_client_bootstrapped.device
-        host_ip = standard_setup_one_client_bootstrapped.get_virtual_network_host_ip()
-
-        update_image_failed(mender_device, host_ip)
-        update_image(mender_device, host_ip, install_image=valid_image)
+    @MenderTesting.fast
+    def test_failed_updated_and_valid_update(
+        self, standard_setup_one_client_bootstrapped, valid_image_with_mender_conf
+    ):
+        self.do_test_failed_updated_and_valid_update(
+            standard_setup_one_client_bootstrapped, valid_image_with_mender_conf
+        )
 
     def test_update_no_compression(
-        self, standard_setup_one_client_bootstrapped, valid_image
+        self, standard_setup_one_client_bootstrapped, valid_image_with_mender_conf
     ):
-        """Uploads an uncompressed artifact, and runs the whole udpate process."""
-
-        update_image(
-            standard_setup_one_client_bootstrapped.device,
-            standard_setup_one_client_bootstrapped.get_virtual_network_host_ip(),
-            install_image=valid_image,
-            compression_type="none",
+        self.do_test_update_no_compression(
+            standard_setup_one_client_bootstrapped, valid_image_with_mender_conf
         )
 
     def test_forced_update_check_from_client(
-        self, standard_setup_one_client_bootstrapped, valid_image
+        self, standard_setup_one_client_bootstrapped, valid_image_with_mender_conf
     ):
-        """Upload a device with a broken image, followed by a valid image"""
-
-        mender_device = standard_setup_one_client_bootstrapped.device
-
-        # Give the image a really large wait interval.
-        sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % (
-            r"\(.*PollInter.*:\)\( *[0-9]*\)",
-            "\\1 1800",
-        )
-        mender_device.run(sedcmd)
-        client_service_name = mender_device.get_client_service_name()
-        mender_device.run("systemctl restart %s" % client_service_name)
-
-        def deployment_callback():
-            logger.info("Running pre deployment callback function")
-            wait_count = 0
-            # Match the log template six times to make sure the client is truly sleeping.
-            catcmd = "journalctl -u %s --output=cat" % client_service_name
-            template = mender_device.run(catcmd)
-            while True:
-                logger.info("sleeping...")
-                logger.info("wait_count: %d" % wait_count)
-                time.sleep(10)
-                out = mender_device.run(catcmd)
-                if out == template:
-                    wait_count += 1
-                    # Only return if the client has been idling in check-wait for a minute.
-                    if wait_count == 6:
-                        return
-                    continue
-                # Update the matching template
-                template = mender_device.run(catcmd)
-                wait_count = 0
-
-        def deployment_triggered_callback():
-            mender_device.run("mender check-update")
-            logger.info("mender client has forced an update check")
-
-        update_image(
-            mender_device,
-            standard_setup_one_client_bootstrapped.get_virtual_network_host_ip(),
-            install_image=valid_image,
-            pre_deployment_callback=deployment_callback,
-            deployment_triggered_callback=deployment_triggered_callback,
+        self.do_test_forced_update_check_from_client(
+            standard_setup_one_client_bootstrapped, valid_image_with_mender_conf
         )
 
     @pytest.mark.timeout(1000)
     def test_forced_inventory_update_from_client(
-        self, standard_setup_one_client_bootstrapped, valid_image
+        self, standard_setup_one_client_bootstrapped
     ):
-        """Forces an inventory update from an idling client."""
-
-        mender_device = standard_setup_one_client_bootstrapped.device
-
-        # Give the image a really large wait interval.
-        sedcmd = "sed -i.bak 's/%s/%s/' /etc/mender/mender.conf" % (
-            r"\(.*PollInter.*:\)\( *[0-9]*\)",
-            "\\1 1800",
-        )
-        mender_device.run(sedcmd)
-        client_service_name = mender_device.get_client_service_name()
-        mender_device.run("systemctl restart %s" % client_service_name)
-
-        logger.info("Running pre deployment callback function")
-        wait_count = 0
-        # Match the log template six times to make sure the client is truly sleeping.
-        catcmd = "journalctl -u %s --output=cat" % client_service_name
-        template = mender_device.run(catcmd)
-        while True:
-            logger.info("sleeping...")
-            logger.info("wait_count: %d" % wait_count)
-            time.sleep(10)
-            out = mender_device.run(catcmd)
-            if out == template:
-                wait_count += 1
-                # Only return if the client has been idling in check-wait for a minute.
-                if wait_count == 6:
-                    break
-                continue
-            # Update the matching template.
-            template = mender_device.run(catcmd)
-            wait_count = 0
-
-        # Create some new inventory data from an inventory script.
-        mender_device.run(
-            "cd /usr/share/mender/inventory && echo '#!/bin/sh\necho host=foobar' > mender-inventory-test && chmod +x mender-inventory-test"
+        self.do_test_forced_inventory_update_from_client(
+            standard_setup_one_client_bootstrapped
         )
 
-        # Now that the client has settled into the wait-state, run the command, and check if it does indeed exit the wait state,
-        # and send inventory.
-        mender_device.run("mender send-inventory")
-        logger.info("mender client has forced an inventory update")
 
-        for i in range(10):
-            # Check that the updated inventory value is now present.
-            invJSON = inv.get_devices()
-            for element in invJSON[0]["attributes"]:
-                if element["name"] == "host" and element["value"] == "foobar":
-                    return
-            time.sleep(10)
+class TestBasicIntegrationEnterprise(BaseTestBasicIntegration):
+    @MenderTesting.fast
+    def test_update_jwt_expired(
+        self, enterprise_with_short_lived_token, valid_image_with_mender_conf
+    ):
+        self.do_test_update_jwt_expired(
+            enterprise_with_short_lived_token, valid_image_with_mender_conf
+        )
 
-        pytest.fail("The inventory was not updated")
+    @MenderTesting.fast
+    def test_failed_updated_and_valid_update(
+        self, enterprise_one_client_bootstrapped, valid_image_with_mender_conf
+    ):
+        self.do_test_failed_updated_and_valid_update(
+            enterprise_one_client_bootstrapped, valid_image_with_mender_conf
+        )
+
+    def test_update_no_compression(
+        self, enterprise_one_client_bootstrapped, valid_image_with_mender_conf
+    ):
+        self.do_test_update_no_compression(
+            enterprise_one_client_bootstrapped, valid_image_with_mender_conf
+        )
+
+    def test_forced_update_check_from_client(
+        self, enterprise_one_client_bootstrapped, valid_image_with_mender_conf
+    ):
+        self.do_test_forced_update_check_from_client(
+            enterprise_one_client_bootstrapped, valid_image_with_mender_conf
+        )
+
+    @pytest.mark.timeout(1000)
+    def test_forced_inventory_update_from_client(
+        self, enterprise_one_client_bootstrapped
+    ):
+        self.do_test_forced_inventory_update_from_client(
+            enterprise_one_client_bootstrapped
+        )

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -20,22 +20,24 @@ from .. import conftest
 from ..common_setup import (
     standard_setup_one_client,
     standard_setup_one_client_bootstrapped,
+    enterprise_one_client,
+    enterprise_one_client_bootstrapped,
 )
 from .common_update import common_update_procedure
-from ..MenderAPI import devauth, logger
+from ..MenderAPI import DeviceAuthV2, Deployments, logger
 from ..helpers import Helpers
 from .mendertesting import MenderTesting
 
 
-class TestBootstrapping(MenderTesting):
+class BaseTestBootstrapping(MenderTesting):
     MENDER_STORE = "/data/mender/mender-store"
 
-    @MenderTesting.fast
-    def test_bootstrap(self, standard_setup_one_client):
+    def do_test_bootstrap(self, env):
         """Simply make sure we are able to bootstrap a device"""
 
-        mender_device = standard_setup_one_client.device
+        mender_device = env.device
 
+        devauth = DeviceAuthV2(env.auth)
         devauth.check_expected_status("pending", 1)
 
         # iterate over devices and accept them
@@ -54,13 +56,12 @@ class TestBootstrapping(MenderTesting):
         for device in devauth.get_devices_status("accepted"):
             logger.info("Accepted DeviceID: %s" % device["id"])
 
-    @MenderTesting.slow
-    def test_reject_bootstrap(
-        self, standard_setup_one_client_bootstrapped, valid_image
-    ):
+    def do_test_reject_bootstrap(self, env, valid_image):
         """Make sure a rejected device does not perform an upgrade, and that it gets it's auth token removed"""
 
-        mender_device = standard_setup_one_client_bootstrapped.device
+        mender_device = env.device
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
 
         reject_time = time.time()
 
@@ -73,10 +74,12 @@ class TestBootstrapping(MenderTesting):
 
         devauth.check_expected_status("rejected", 1)
 
-        host_ip = standard_setup_one_client_bootstrapped.get_virtual_network_host_ip()
+        host_ip = env.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot:
             try:
-                common_update_procedure(install_image=valid_image)
+                common_update_procedure(
+                    install_image=valid_image, devauth=devauth, deploy=deploy
+                )
             except AssertionError:
                 logger.info("Failed to deploy upgrade to rejected device.")
                 reboot.verify_reboot_not_performed()
@@ -103,3 +106,27 @@ class TestBootstrapping(MenderTesting):
 
         # Check from client side that it can be authorized
         Helpers.check_log_have_authtoken(mender_device)
+
+
+class TestBootstrappingOpenSource(BaseTestBootstrapping):
+    @MenderTesting.fast
+    def test_bootstrap(self, standard_setup_one_client):
+        self.do_test_bootstrap(standard_setup_one_client)
+
+    @MenderTesting.slow
+    def test_reject_bootstrap(
+        self, standard_setup_one_client_bootstrapped, valid_image
+    ):
+        self.do_test_reject_bootstrap(
+            standard_setup_one_client_bootstrapped, valid_image
+        )
+
+
+class TestBootstrappingEnterprise(BaseTestBootstrapping):
+    @MenderTesting.fast
+    def test_bootstrap(self, enterprise_one_client):
+        self.do_test_bootstrap(enterprise_one_client)
+
+    @MenderTesting.slow
+    def test_reject_bootstrap(self, enterprise_one_client_bootstrapped, valid_image):
+        self.do_test_reject_bootstrap(enterprise_one_client_bootstrapped, valid_image)

--- a/tests/tests/test_configuration.py
+++ b/tests/tests/test_configuration.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ class TestConfigurationEnterprise(MenderTesting):
 
         # Add a client to the tenant
         mender_device = new_tenant_client(
-            enterprise_no_client, "configuration-test-container", tenant.tenant_token
+            enterprise_no_client, "mender-client", tenant.tenant_token
         )
         mender_device.ssh_is_opened()
 

--- a/tests/tests/test_deployment_retry.py
+++ b/tests/tests/test_deployment_retry.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ class TestDeploymentRetryEnterprise(MenderTesting):
 
         # Add a client to the tenant
         device = new_tenant_client(
-            enterprise_no_client, "retry-test-container", tenant.tenant_token
+            enterprise_no_client, "mender-client", tenant.tenant_token
         )
         devauth.accept_devices(1)
 

--- a/tests/tests/test_grouping.py
+++ b/tests/tests/test_grouping.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -12,17 +12,21 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import tempfile
+
 from .. import conftest
-from ..common_setup import standard_setup_two_clients_bootstrapped
+from ..common_setup import (
+    standard_setup_two_clients_bootstrapped,
+    enterprise_two_clients_bootstrapped,
+)
 from .common_update import common_update_procedure
-from ..MenderAPI import inv, deploy, logger
+from ..MenderAPI import DeviceAuthV2, Deployments, Inventory, image, logger
 from .mendertesting import MenderTesting
 from ..helpers import Helpers
 
 
-@MenderTesting.fast
-class TestGrouping(MenderTesting):
-    def validate_group_responses(self, device_map):
+class BaseTestGrouping(MenderTesting):
+    def validate_group_responses(self, device_map, inv):
         """Checks whether the device_map corresponds to the server's view of
         the current groups, using all the possible ways to query for this.
         device_map is a map of device to group."""
@@ -60,8 +64,9 @@ class TestGrouping(MenderTesting):
         for device in device_map:
             assert inv.get_device_group(device)["group"] == device_map[device]
 
-    def test_basic_groups(self, standard_setup_two_clients_bootstrapped):
+    def do_test_basic_groups(self, env):
         """Tests various group operations."""
+        inv = Inventory(env.auth)
 
         devices = [device["id"] for device in inv.get_devices()]
         assert len(devices) == 2
@@ -71,29 +76,27 @@ class TestGrouping(MenderTesting):
         bravo = devices[1]
 
         # Start out with no groups.
-        self.validate_group_responses({alpha: None, bravo: None})
+        self.validate_group_responses({alpha: None, bravo: None}, inv)
 
         # Test various group operations.
         inv.put_device_in_group(alpha, "Red")
-        self.validate_group_responses({alpha: "Red", bravo: None})
+        self.validate_group_responses({alpha: "Red", bravo: None}, inv)
 
         inv.put_device_in_group(bravo, "Blue")
-        self.validate_group_responses({alpha: "Red", bravo: "Blue"})
+        self.validate_group_responses({alpha: "Red", bravo: "Blue"}, inv)
 
         inv.delete_device_from_group(alpha, "Red")
-        self.validate_group_responses({alpha: None, bravo: "Blue"})
+        self.validate_group_responses({alpha: None, bravo: "Blue"}, inv)
 
         # Note that this *moves* the device into the group.
         inv.put_device_in_group(bravo, "Red")
-        self.validate_group_responses({alpha: None, bravo: "Red"})
+        self.validate_group_responses({alpha: None, bravo: "Red"}, inv)
 
         # Important: Leave the groups as you found them: Empty.
         inv.delete_device_from_group(bravo, "Red")
-        self.validate_group_responses({alpha: None, bravo: None})
+        self.validate_group_responses({alpha: None, bravo: None}, inv)
 
-    def test_update_device_group(
-        self, standard_setup_two_clients_bootstrapped, valid_image
-    ):
+    def do_test_update_device_group(self, env, valid_image_with_mender_conf):
         """
         Perform a successful upgrade on one group of devices, and assert that:
         * deployment status/logs are correct.
@@ -103,16 +106,21 @@ class TestGrouping(MenderTesting):
         Deployment status will be set as successful for device.
         Logs will not be retrieved, and result in 404.
         """
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
+        inv = Inventory(env.auth)
 
         # Beware that there will two parallel things going on below, one for
         # each group. We aim to update the group alpha, not beta.
 
-        mender_device_group = standard_setup_two_clients_bootstrapped.device_group
+        mender_device_group = env.device_group
         assert len(mender_device_group) == 2
         alpha = mender_device_group[0]
         bravo = mender_device_group[1]
 
-        ip_to_device_id = Helpers.ip_to_device_id_map(mender_device_group)
+        ip_to_device_id = Helpers.ip_to_device_id_map(
+            mender_device_group, devauth=devauth
+        )
         id_alpha = ip_to_device_id[alpha.host_string]
         id_bravo = ip_to_device_id[bravo.host_string]
         logger.info("ID of alpha host: %s" % id_alpha)
@@ -125,13 +133,17 @@ class TestGrouping(MenderTesting):
         inv.put_device_in_group(id_alpha, "Update")
 
         reboot = {alpha: None, bravo: None}
-        host_ip = standard_setup_two_clients_bootstrapped.get_virtual_network_host_ip()
+        host_ip = env.get_virtual_network_host_ip()
         with alpha.get_reboot_detector(host_ip) as reboot[
             alpha
         ], bravo.get_reboot_detector(host_ip) as reboot[bravo]:
 
+            mender_conf = alpha.run("cat /etc/mender/mender.conf")
             deployment_id, expected_image_id = common_update_procedure(
-                valid_image, devices=[id_alpha]
+                valid_image_with_mender_conf(mender_conf),
+                devices=[id_alpha],
+                devauth=devauth,
+                deploy=deploy,
             )
 
             # Extra long wait here, because a real update takes quite a lot of time.
@@ -158,3 +170,29 @@ class TestGrouping(MenderTesting):
 
         # Important: Leave the groups as you found them: Empty.
         inv.delete_device_from_group(id_alpha, "Update")
+
+
+@MenderTesting.fast
+class TestGroupingOpenSource(BaseTestGrouping):
+    def test_basic_groups(self, standard_setup_two_clients_bootstrapped):
+        self.do_test_basic_groups(standard_setup_two_clients_bootstrapped)
+
+    def test_update_device_group(
+        self, standard_setup_two_clients_bootstrapped, valid_image_with_mender_conf
+    ):
+        self.do_test_update_device_group(
+            standard_setup_two_clients_bootstrapped, valid_image_with_mender_conf,
+        )
+
+
+@MenderTesting.fast
+class TestGroupingEnterprise(BaseTestGrouping):
+    def test_basic_groups(self, enterprise_two_clients_bootstrapped):
+        self.do_test_basic_groups(enterprise_two_clients_bootstrapped)
+
+    def test_update_device_group(
+        self, enterprise_two_clients_bootstrapped, valid_image_with_mender_conf
+    ):
+        self.do_test_update_device_group(
+            enterprise_two_clients_bootstrapped, valid_image_with_mender_conf,
+        )

--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -15,26 +15,34 @@
 import pytest
 
 from .. import conftest
-from ..common_setup import standard_setup_one_client_bootstrapped
+from ..common_setup import (
+    standard_setup_one_client_bootstrapped,
+    enterprise_one_client_bootstrapped,
+)
 from .common_update import common_update_procedure
-from ..MenderAPI import devauth, deploy
 from .mendertesting import MenderTesting
+from ..MenderAPI import DeviceAuthV2, Deployments
 
 
-@pytest.mark.usefixtures("standard_setup_one_client_bootstrapped")
-class TestFailures(MenderTesting):
+class BaseTestFailures(MenderTesting):
     @MenderTesting.slow
-    def test_update_image_id_already_installed(
-        self, standard_setup_one_client_bootstrapped, valid_image,
+    def do_test_update_image_id_already_installed(
+        self, env, valid_image_with_mender_conf,
     ):
         """Uploading an image with an incorrect name set results in failure and rollback."""
 
-        mender_device = standard_setup_one_client_bootstrapped.device
+        mender_device = env.device
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
 
-        host_ip = standard_setup_one_client_bootstrapped.get_virtual_network_host_ip()
+        host_ip = env.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot:
+            mender_conf = mender_device.run("cat /etc/mender/mender.conf")
             deployment_id, expected_image_id = common_update_procedure(
-                valid_image, True
+                valid_image_with_mender_conf(mender_conf),
+                True,
+                devauth=devauth,
+                deploy=deploy,
             )
             reboot.verify_reboot_performed()
 
@@ -51,19 +59,51 @@ class TestFailures(MenderTesting):
         deploy.check_expected_status("finished", deployment_id)
 
     @MenderTesting.fast
-    def test_large_update_image(self, standard_setup_one_client_bootstrapped):
+    def do_test_large_update_image(self, env):
         """Installing an image larger than the passive/active parition size should result in a failure."""
 
-        mender_device = standard_setup_one_client_bootstrapped.device
+        mender_device = env.device
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
 
-        host_ip = standard_setup_one_client_bootstrapped.get_virtual_network_host_ip()
+        host_ip = env.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot:
             deployment_id, _ = common_update_procedure(
                 install_image="large_image.dat",
                 # We use verify_status=False because the device is very quick in reporting
                 # failure and the test framework might miss the 'inprogress' status transition.
                 verify_status=False,
+                devauth=devauth,
+                deploy=deploy,
             )
             deploy.check_expected_statistics(deployment_id, "failure", 1)
             reboot.verify_reboot_not_performed()
             deploy.check_expected_status("finished", deployment_id)
+
+
+class TestFailuresOpenSource(BaseTestFailures):
+    @MenderTesting.slow
+    def test_update_image_id_already_installed(
+        self, standard_setup_one_client_bootstrapped, valid_image_with_mender_conf,
+    ):
+        self.do_test_update_image_id_already_installed(
+            standard_setup_one_client_bootstrapped, valid_image_with_mender_conf
+        )
+
+    @MenderTesting.fast
+    def test_large_update_image(self, standard_setup_one_client_bootstrapped):
+        self.do_test_large_update_image(standard_setup_one_client_bootstrapped)
+
+
+class TestFailuresOpenEnterprise(BaseTestFailures):
+    @MenderTesting.slow
+    def test_update_image_id_already_installed(
+        self, enterprise_one_client_bootstrapped, valid_image_with_mender_conf,
+    ):
+        self.do_test_update_image_id_already_installed(
+            enterprise_one_client_bootstrapped, valid_image_with_mender_conf
+        )
+
+    @MenderTesting.fast
+    def test_large_update_image(self, enterprise_one_client_bootstrapped):
+        self.do_test_large_update_image(enterprise_one_client_bootstrapped)

--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -329,7 +329,7 @@ def connected_device(env):
     auth.reset_auth_token()
     devauth = DeviceAuthV2(auth)
 
-    env.new_tenant_client("test-container", ttoken)
+    env.new_tenant_client("mender-client", ttoken)
     device = MenderDevice(env.get_mender_clients()[0])
     devauth.accept_devices(1)
 

--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -282,7 +282,7 @@ class TestMonitorClientEnterprise:
         auth.reset_auth_token()
         devauth_tenant = DeviceAuthV2(auth)
 
-        mender_device = new_tenant_client(env, "test-container", tenant["tenant_token"])
+        mender_device = new_tenant_client(env, "mender-client", tenant["tenant_token"])
         mender_device.ssh_is_opened()
 
         devauth_tenant.accept_devices(1)

--- a/tests/tests/test_signed_image_update.py
+++ b/tests/tests/test_signed_image_update.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -15,43 +15,51 @@
 import pytest
 
 from .. import conftest
-from ..common_setup import standard_setup_with_signed_artifact_client
+from ..common_setup import (
+    standard_setup_with_signed_artifact_client,
+    enterprise_with_signed_artifact_client,
+)
 from .common_update import update_image, common_update_procedure
-from ..MenderAPI import devauth, deploy
+from ..MenderAPI import DeviceAuthV2, Deployments
 from .mendertesting import MenderTesting
 
 
-@MenderTesting.fast
-class TestSignedUpdates(MenderTesting):
+class BaseTestSignedUpdates(MenderTesting):
     """
     Signed artifacts are well tested in the client's acceptance tests, so
     we will only test basic backend integration with signed images here.
     """
 
-    def test_signed_artifact_success(
-        self, standard_setup_with_signed_artifact_client, valid_image
-    ):
-
+    def do_test_signed_artifact_success(self, env, valid_image_with_mender_conf):
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
+        mender_conf = env.device.run("cat /etc/mender/mender.conf")
         update_image(
-            standard_setup_with_signed_artifact_client.device,
-            standard_setup_with_signed_artifact_client.get_virtual_network_host_ip(),
-            install_image=valid_image,
+            env.device,
+            env.get_virtual_network_host_ip(),
+            install_image=valid_image_with_mender_conf(mender_conf),
             signed=True,
+            devauth=devauth,
+            deploy=deploy,
         )
 
-    @pytest.mark.parametrize(
-        "standard_setup_with_signed_artifact_client", ["force_new"], indirect=True
-    )
-    def test_unsigned_artifact_fails_deployment(
-        self, standard_setup_with_signed_artifact_client, valid_image
+    def do_test_unsigned_artifact_fails_deployment(
+        self, env, valid_image_with_mender_conf
     ):
         """
         Make sure that an unsigned image fails, and is handled by the backend.
         Notice that this test needs a fresh new version of the backend, since
         we installed a signed image earlier without a verification key in mender.conf
         """
+        devauth = DeviceAuthV2(env.auth)
+        deploy = Deployments(env.auth, devauth)
 
-        deployment_id, _ = common_update_procedure(install_image=valid_image)
+        mender_conf = env.device.run("cat /etc/mender/mender.conf")
+        deployment_id, _ = common_update_procedure(
+            install_image=valid_image_with_mender_conf(mender_conf),
+            devauth=devauth,
+            deploy=deploy,
+        )
         deploy.check_expected_status("finished", deployment_id)
         deploy.check_expected_statistics(deployment_id, "failure", 1)
 
@@ -60,3 +68,43 @@ class TestSignedUpdates(MenderTesting):
                 "expecting signed artifact, but no signature file found"
                 in deploy.get_logs(d["id"], deployment_id)
             )
+
+
+@MenderTesting.fast
+class TestSignedUpdatesOpenSource(BaseTestSignedUpdates):
+    def test_signed_artifact_success(
+        self, standard_setup_with_signed_artifact_client, valid_image_with_mender_conf
+    ):
+        self.do_test_signed_artifact_success(
+            standard_setup_with_signed_artifact_client, valid_image_with_mender_conf
+        )
+
+    @pytest.mark.parametrize(
+        "standard_setup_with_signed_artifact_client", ["force_new"], indirect=True
+    )
+    def test_unsigned_artifact_fails_deployment(
+        self, standard_setup_with_signed_artifact_client, valid_image_with_mender_conf
+    ):
+        self.do_test_unsigned_artifact_fails_deployment(
+            standard_setup_with_signed_artifact_client, valid_image_with_mender_conf
+        )
+
+
+@MenderTesting.fast
+class TestSignedUpdatesEnterprise(BaseTestSignedUpdates):
+    def test_signed_artifact_success(
+        self, enterprise_with_signed_artifact_client, valid_image_with_mender_conf
+    ):
+        self.do_test_signed_artifact_success(
+            enterprise_with_signed_artifact_client, valid_image_with_mender_conf
+        )
+
+    @pytest.mark.parametrize(
+        "enterprise_with_signed_artifact_client", ["force_new"], indirect=True
+    )
+    def test_unsigned_artifact_fails_deployment(
+        self, enterprise_with_signed_artifact_client, valid_image_with_mender_conf
+    ):
+        self.do_test_unsigned_artifact_fails_deployment(
+            enterprise_with_signed_artifact_client, valid_image_with_mender_conf
+        )

--- a/tests/tests/test_update_control.py
+++ b/tests/tests/test_update_control.py
@@ -61,9 +61,7 @@ class TestUpdateControlEnterprise:
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        device = new_tenant_client(
-            enterprise_no_client, "control-map-test-container", ttoken
-        )
+        device = new_tenant_client(enterprise_no_client, "mender-client", ttoken)
         devauth.accept_devices(1)
 
         deploy = Deployments(auth, devauth)
@@ -215,9 +213,7 @@ class TestUpdateControlEnterprise:
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        device = new_tenant_client(
-            enterprise_no_client, "control-map-test-container", ttoken
-        )
+        device = new_tenant_client(enterprise_no_client, "mender-client", ttoken)
         devauth.accept_devices(1)
 
         deploy = Deployments(auth, devauth)
@@ -291,7 +287,7 @@ class TestUpdateControlEnterprise:
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        new_tenant_client(enterprise_no_client, "control-map-test-container", ttoken)
+        new_tenant_client(enterprise_no_client, "mender-client", ttoken)
         devauth.accept_devices(1)
 
         deploy = Deployments(auth, devauth)
@@ -357,9 +353,7 @@ class TestUpdateControlEnterprise:
         auth.reset_auth_token()
         devauth = DeviceAuthV2(auth)
 
-        device = new_tenant_client(
-            enterprise_no_client, "control-map-test-container", ttoken
-        )
+        device = new_tenant_client(enterprise_no_client, "mender-client", ttoken)
         devauth.accept_devices(1)
 
         deploy = Deployments(auth, devauth)

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -477,7 +477,9 @@ def update_tenant(tid, addons=None, plan=None, container_manager=None):
     assert res.status_code == 202
 
 
-def new_tenant_client(test_env, name: str, tenant: str,) -> MenderDevice:
+def new_tenant_client(
+    test_env, name: str, tenant: str, docker: bool = False
+) -> MenderDevice:
     """Create new Mender client in the test environment with the given name for the given tenant.
 
     The passed test_env must implement new_tenant_client. Currently supported in
@@ -488,7 +490,10 @@ def new_tenant_client(test_env, name: str, tenant: str,) -> MenderDevice:
     """
 
     pre_existing_clients = set(test_env.get_mender_clients())
-    test_env.new_tenant_client(name, tenant)
+    if docker:
+        test_env.new_tenant_docker_client(name, tenant)
+    else:
+        test_env.new_tenant_client(name, tenant)
     all_clients = set(test_env.get_mender_clients())
     new_client = all_clients - pre_existing_clients
     assert len(new_client) == 1

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -312,6 +312,19 @@ class DockerComposeEnterpriseLegacyClientSetup(DockerComposeEnterpriseSetup):
             )
 
 
+class DockerComposeEnterpriseRofsClientSetup(DockerComposeEnterpriseSetup):
+    def __init__(self, name, num_clients=0):
+        self.num_clients = num_clients
+        if self.num_clients > 0:
+            raise NotImplementedError(
+                "Clients not implemented on setup time, use new_tenant_client"
+            )
+        else:
+            DockerComposeNamespace.__init__(
+                self, name, self.ENTERPRISE_FILES + self.QEMU_CLIENT_ROFS_FILES
+            )
+
+
 class DockerComposeEnterpriseDockerClientSetup(DockerComposeEnterpriseSetup):
     def __init__(self, name, num_clients=0):
         self.num_clients = num_clients

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -273,6 +273,69 @@ class DockerComposeEnterpriseSetup(DockerComposeNamespace):
         time.sleep(5)
 
 
+class DockerComposeEnterpriseSignedArtifactClientSetup(DockerComposeEnterpriseSetup):
+    def new_tenant_client(self, name, tenant):
+        if not self.MT_CLIENT_FILES[0] in self.docker_compose_files:
+            self.extra_files += self.MT_CLIENT_FILES
+            self.extra_files += self.SIGNED_ARTIFACT_CLIENT_FILES
+        logger.info("creating client connected to tenant: " + tenant)
+        self._docker_compose_cmd(
+            "run -d --name=%s_%s mender-client" % (self.name, name),
+            env={"TENANT_TOKEN": "%s" % tenant},
+        )
+        time.sleep(45)
+
+
+class DockerComposeEnterpriseShortLivedTokenSetup(DockerComposeEnterpriseSetup):
+    def __init__(self, name, num_clients=0):
+        self.num_clients = num_clients
+        if self.num_clients > 0:
+            raise NotImplementedError(
+                "Clients not implemented on setup time, use new_tenant_client"
+            )
+        else:
+            DockerComposeNamespace.__init__(
+                self, name, self.ENTERPRISE_FILES + self.SHORT_LIVED_TOKEN_FILES
+            )
+
+
+class DockerComposeEnterpriseLegacyClientSetup(DockerComposeEnterpriseSetup):
+    def __init__(self, name, num_clients=0):
+        self.num_clients = num_clients
+        if self.num_clients > 0:
+            raise NotImplementedError(
+                "Clients not implemented on setup time, use new_tenant_client"
+            )
+        else:
+            DockerComposeNamespace.__init__(
+                self, name, self.ENTERPRISE_FILES + self.LEGACY_CLIENT_FILES
+            )
+
+
+class DockerComposeEnterpriseDockerClientSetup(DockerComposeEnterpriseSetup):
+    def __init__(self, name, num_clients=0):
+        self.num_clients = num_clients
+        if self.num_clients > 0:
+            raise NotImplementedError(
+                "Clients not implemented on setup time, use new_tenant_client"
+            )
+        else:
+            DockerComposeNamespace.__init__(
+                self, name, self.ENTERPRISE_FILES + self.MT_DOCKER_CLIENT_FILES
+            )
+
+    def setup(self):
+        compose_args = "up -d --scale mender-client=0"
+        self._docker_compose_cmd(compose_args)
+
+    def new_tenant_docker_client(self, name, tenant):
+        logger.info("creating docker client connected to tenant: " + tenant)
+        self._docker_compose_cmd(
+            "up -d --scale mender-client=1", env={"TENANT_TOKEN": "%s" % tenant},
+        )
+        time.sleep(5)
+
+
 class DockerComposeCompatibilitySetup(DockerComposeNamespace):
     def __init__(self, name, enterprise=False):
         self._enterprise = enterprise

--- a/testutils/infra/container_manager/factory.py
+++ b/testutils/infra/container_manager/factory.py
@@ -19,10 +19,14 @@ from .docker_compose_manager import (
     DockerComposeDockerClientSetup,
     DockerComposeRofsClientSetup,
     DockerComposeLegacyClientSetup,
+    DockerComposeEnterpriseDockerClientSetup,
     DockerComposeSignedArtifactClientSetup,
     DockerComposeShortLivedTokenSetup,
     DockerComposeFailoverServerSetup,
     DockerComposeEnterpriseSetup,
+    DockerComposeEnterpriseSignedArtifactClientSetup,
+    DockerComposeEnterpriseShortLivedTokenSetup,
+    DockerComposeEnterpriseLegacyClientSetup,
     DockerComposeCustomSetup,
     DockerComposeCompatibilitySetup,
     DockerComposeMTLSSetup,
@@ -82,6 +86,22 @@ class ContainerManagerFactory:
         """Setup with enterprise versions for the applicable services"""
         pass
 
+    def getEnterpriseSignedArtifactClientSetup(self, name=None):
+        """Enterprise setup with pre-installed verification key in the client"""
+        pass
+
+    def getEnterpriseShortLivedTokenSetup(self, name=None, num_clients=0):
+        """Enterprise setup on which deviceauth has a short lived token (expire timeout = 0)"""
+        pass
+
+    def getEnterpriseLegacyClientSetup(self, name=None, num_clients=0):
+        """Enterprise setup with one Mender client v1.7"""
+        pass
+
+    def getEnterpriseDockerClientSetup(self, name=None, num_clients=0):
+        """Enterprise setup with one Mender Docker client"""
+        pass
+
     def getEnterpriseSMTPSetup(self, name=None):
         """Enterprise setup with SMTP enabled"""
         pass
@@ -122,6 +142,18 @@ class DockerComposeManagerFactory(ContainerManagerFactory):
 
     def getEnterpriseSetup(self, name=None, num_clients=0):
         return DockerComposeEnterpriseSetup(name, num_clients)
+
+    def getEnterpriseSignedArtifactClientSetup(self, name=None):
+        return DockerComposeEnterpriseSignedArtifactClientSetup(name)
+
+    def getEnterpriseShortLivedTokenSetup(self, name=None):
+        return DockerComposeEnterpriseShortLivedTokenSetup(name)
+
+    def getEnterpriseLegacyClientSetup(self, name=None, num_clients=0):
+        return DockerComposeEnterpriseLegacyClientSetup(name, num_clients)
+
+    def getEnterpriseDockerClientSetup(self, name=None, num_clients=0):
+        return DockerComposeEnterpriseDockerClientSetup(name, num_clients)
 
     def getCompatibilitySetup(self, name=None, **kwargs):
         return DockerComposeCompatibilitySetup(name, **kwargs)

--- a/testutils/infra/container_manager/factory.py
+++ b/testutils/infra/container_manager/factory.py
@@ -27,6 +27,7 @@ from .docker_compose_manager import (
     DockerComposeEnterpriseSignedArtifactClientSetup,
     DockerComposeEnterpriseShortLivedTokenSetup,
     DockerComposeEnterpriseLegacyClientSetup,
+    DockerComposeEnterpriseRofsClientSetup,
     DockerComposeCustomSetup,
     DockerComposeCompatibilitySetup,
     DockerComposeMTLSSetup,
@@ -102,6 +103,10 @@ class ContainerManagerFactory:
         """Enterprise setup with one Mender Docker client"""
         pass
 
+    def getEnterpriseRofsClientSetup(self, name=None, num_clients=0):
+        """Enterprise setup with one Mender QEMU Read-Only FS client"""
+        pass
+
     def getEnterpriseSMTPSetup(self, name=None):
         """Enterprise setup with SMTP enabled"""
         pass
@@ -154,6 +159,9 @@ class DockerComposeManagerFactory(ContainerManagerFactory):
 
     def getEnterpriseDockerClientSetup(self, name=None, num_clients=0):
         return DockerComposeEnterpriseDockerClientSetup(name, num_clients)
+
+    def getEnterpriseRofsClientSetup(self, name=None, num_clients=0):
+        return DockerComposeEnterpriseRofsClientSetup(name, num_clients)
 
     def getCompatibilitySetup(self, name=None, **kwargs):
         return DockerComposeCompatibilitySetup(name, **kwargs)


### PR DESCRIPTION
Rework tests in the following files to run both in open-source and
enterprise:

- test_basic_integration.py
- test_db_migration.py
- test_fault_tolerance.py
- test_security.py
- test_signed_image_update.py
- test_update_modules.py

Changelog: none
Ticket: QA-332

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>

Based on: https://github.com/mendersoftware/integration/pull/1920