### PR TITLE
test_compat.py: Modify test to deploy a single-file Artifact

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -125,6 +125,17 @@ function get_requirements() {
 
     chmod +x downloaded-tools/directory-artifact-gen
 
+    curl --fail "https://raw.githubusercontent.com/mendersoftware/mender/${MENDER_BRANCH}/support/modules-artifact-gen/single-file-artifact-gen" \
+         -o downloaded-tools/single-file-artifact-gen \
+         -z downloaded-tools/single-file-artifact-gen
+
+    if [ $? -ne 0 ]; then
+        echo "failed to download single-file-artifact-gen"
+        exit 1
+    fi
+
+    chmod +x downloaded-tools/single-file-artifact-gen
+
     export PATH=$PWD/downloaded-tools:$PATH
 
     inject_pre_generated_ssh_keys


### PR DESCRIPTION
New builds of client images come with an empty inactive partition, so
the trick of deploying full rootfs-image Artifacts with no payload won't
do anymore.

See:
https://github.com/mendersoftware/meta-mender/commit/cfdeb3d1e77228ddfb0a04b79119ae104c2ca2d6