### PR TITLE
MEN-5532: Fix test_deployment_gateway_and_one_device

### DIFF
--- a/tests/tests/test_mender_gateway.py
+++ b/tests/tests/test_mender_gateway.py
@@ -61,6 +61,7 @@ def add_mender_conf_and_mender_gateway_conf(d, image, mender_conf, mender_gatewa
         f.write(
             """cd /etc/mender
         rm mender.conf
+        rm mender-gateway.conf
         write {local1} mender.conf
         write {local2} mender-gateway.conf
         """.format(

--- a/tests/tests/test_mender_gateway.py
+++ b/tests/tests/test_mender_gateway.py
@@ -119,8 +119,11 @@ class BaseTestMenderGateway(MenderTesting):
         devauth = DeviceAuthV2(env.auth)
         deploy = Deployments(env.auth, devauth)
 
-        mender_conf = mender_device.run("cat /etc/mender/mender.conf")
-        mender_gateway_conf = mender_gateway.run("cat /etc/mender/mender-gateway.conf")
+        mender_device_mender_conf = mender_device.run("cat /etc/mender/mender.conf")
+        mender_gateway_gateway_conf = mender_gateway.run(
+            "cat /etc/mender/mender-gateway.conf"
+        )
+        mender_gateway_mender_conf = mender_gateway.run("cat /etc/mender/mender.conf")
 
         host_ip = env.get_virtual_network_host_ip()
 
@@ -131,8 +134,8 @@ class BaseTestMenderGateway(MenderTesting):
 
         mender_gateway_image = image_with_mender_conf_and_mender_gateway_conf(
             "mender-gateway-image-full-cmdline-%s.ext4" % conftest.machine_name,
-            mender_conf,
-            mender_gateway_conf,
+            mender_gateway_mender_conf,
+            mender_gateway_gateway_conf,
         )
 
         def update_device():
@@ -141,7 +144,7 @@ class BaseTestMenderGateway(MenderTesting):
                 mender_device,
                 host_ip,
                 expected_mender_clients=1,
-                install_image=valid_image_with_mender_conf(mender_conf),
+                install_image=valid_image_with_mender_conf(mender_device_mender_conf),
                 devauth=devauth,
                 deploy=deploy,
                 devices=[device_id],
@@ -158,6 +161,7 @@ class BaseTestMenderGateway(MenderTesting):
         )
 
         deploy.check_expected_statistics(deployment_id, "success", 1)
+        deploy.check_expected_status("finished", deployment_id)
 
     def do_test_deployment_two_devices_update_both(
         self, env, valid_image_with_mender_conf


### PR DESCRIPTION
    The base image for mender gateway now contains a mender-gateway.conf
    file, which was making the debugfs silently fail in installing the new
    config file.


In addition:

    test: gateway_and_one_device: User correct mender.conf on gateway
    
    Previously, we were updating the mender.conf for the gateway device with
    the values coming from the local device, iow setting ServerURL to the
    gateway url. This actually works just fine, as now the client in the
    gateway will use the gateway itself to talk to the backend...
    
    Fixing for correctness of the test.