### PR TITLE
QA-387 Extract clean image for tests.

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -153,15 +153,23 @@ if [[ -z "$BUILDDIR" ]] && [[ -n "$DOWNLOAD_REQUIREMENTS" ]]; then
 fi
 
 # Extract file system images from Docker images
+# the argument for the /extract_fs is the prefix of the image name
+# as per QA-387 now we are explicitly extracting a clean image
+# that is: an image which is crafted to be the one we update to.
+IMG_PREFIX="clean-"
 mkdir -p output
-docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
-       mendersoftware/mender-client-qemu:$(../extra/release_tool.py --version-of mender-client-qemu --version-type docker)
-docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
-        mendersoftware/mender-client-qemu-rofs:$(../extra/release_tool.py --version-of mender-client-qemu-rofs --version-type docker)
-docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
-        registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:$(../extra/release_tool.py --version-of mender-gateway --version-type docker)
+docker run --rm --privileged --entrypoint /extract_fs -v "${PWD}"/output:/output \
+       mendersoftware/mender-client-qemu:$(../extra/release_tool.py --version-of mender-client-qemu --version-type docker) "${IMG_PREFIX}"
+docker run --rm --privileged --entrypoint /extract_fs -v "${PWD}"/output:/output \
+        mendersoftware/mender-client-qemu-rofs:$(../extra/release_tool.py --version-of mender-client-qemu-rofs --version-type docker) "${IMG_PREFIX}"
+docker run --rm --privileged --entrypoint /extract_fs -v "${PWD}"/output:/output \
+        registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:$(../extra/release_tool.py --version-of mender-gateway --version-type docker) "${IMG_PREFIX}"
 mv output/* .
 rmdir output
+
+for i in ${IMG_PREFIX}*; do
+    mv -v "$i" "${i/${IMG_PREFIX}/}"
+done
 
 modify_services_for_testing
 

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -69,6 +69,17 @@ class BaseTestBasicIntegration(MenderTesting):
         # Verify that partition is read-only as expected
         mender_device.run("mount | fgrep 'on / ' | fgrep '(ro,'")
 
+        # in the so-called clean image the artifact_info is "artifact_name=mender-image-clean\n"
+        # see: https://github.com/mendersoftware/mender-qa/pull/580/commits/a4c54e9ebf5879f0837789cbc7c74cb1102b2caa#diff-7031fcd5c934f225781febe446a34594a9a36b335c540379c0dd376a8f06ba28R263
+        # so first we expect it to be set to master, as this is what we
+        # have in the initial image, after update we expect it to change
+        expected_artifact_info = "artifact_name=mender-image-master\n"
+        artifact_info = mender_device.run(
+            "cat /etc/mender/artifact_info | sed -e '/artifact_name/q'"
+        )
+        logger.info("before update got %s" % artifact_info)
+        assert artifact_info == expected_artifact_info
+
         host_ip = env.get_virtual_network_host_ip()
         update_image(
             mender_device,
@@ -80,6 +91,17 @@ class BaseTestBasicIntegration(MenderTesting):
         )
         mender_device.run("mount | fgrep 'on / ' | fgrep '(ro,'")
 
+        # after the update we expect the artifact info to be different
+        # ("artifact_name=mender-image-clean\n")
+        # since this is what is in the embedded image decompressed
+        # in the tests/run.sh
+        expected_artifact_info = "artifact_name=mender-image-clean\n"
+        artifact_info = mender_device.run(
+            "cat /etc/mender/artifact_info | sed -e '/artifact_name/q'"
+        )
+        logger.info("after update got %s" % artifact_info)
+        assert expected_artifact_info == artifact_info
+
         update_image(
             mender_device,
             host_ip,
@@ -89,6 +111,17 @@ class BaseTestBasicIntegration(MenderTesting):
             deploy=deploy,
         )
         mender_device.run("mount | fgrep 'on / ' | fgrep '(ro,'")
+
+        # after the update we expect the artifact info to be different
+        # ("artifact_name=mender-image-clean\n")
+        # since this is what is in the embedded image decompressed
+        # in the tests/run.sh
+        expected_artifact_info = "artifact_name=mender-image-clean\n"
+        artifact_info = mender_device.run(
+            "cat /etc/mender/artifact_info | sed -e '/artifact_name/q'"
+        )
+        logger.info("after update got %s" % artifact_info)
+        assert expected_artifact_info == artifact_info
 
     def do_test_update_jwt_expired(self, env, valid_image_with_mender_conf):
         """Update a device with a short lived JWT token"""
@@ -125,12 +158,24 @@ class BaseTestBasicIntegration(MenderTesting):
         )
 
     def do_test_update_no_compression(self, env, valid_image_with_mender_conf):
-        """Uploads an uncompressed artifact, and runs the whole udpate process."""
+        """Uploads an uncompressed artifact, and runs the whole update process."""
         devauth = DeviceAuthV2(env.auth)
         deploy = Deployments(env.auth, devauth)
 
         mender_device = env.device
         mender_conf = mender_device.run("cat /etc/mender/mender.conf")
+
+        # in the so-called clean image the artifact_info is "artifact_name=mender-image-clean\n"
+        # see: https://github.com/mendersoftware/mender-qa/pull/580/commits/a4c54e9ebf5879f0837789cbc7c74cb1102b2caa#diff-7031fcd5c934f225781febe446a34594a9a36b335c540379c0dd376a8f06ba28R263
+        # so first we expect it to be set to master, as this is what we
+        # have in the initial image, after update we expect it to change
+        expected_artifact_info = "artifact_name=mender-image-master\n"
+        artifact_info = mender_device.run(
+            "cat /etc/mender/artifact_info | sed -e '/artifact_name/q'"
+        )
+        logger.info("before update got %s" % artifact_info)
+        assert artifact_info == expected_artifact_info
+
         update_image(
             env.device,
             env.get_virtual_network_host_ip(),
@@ -139,6 +184,17 @@ class BaseTestBasicIntegration(MenderTesting):
             devauth=devauth,
             deploy=deploy,
         )
+
+        # after the update we expect the artifact info to be different
+        # ("artifact_name=mender-image-clean\n")
+        # since this is what is in the embedded image decompressed
+        # in the tests/run.sh
+        expected_artifact_info = "artifact_name=mender-image-clean\n"
+        artifact_info = mender_device.run(
+            "cat /etc/mender/artifact_info | sed -e '/artifact_name/q'"
+        )
+        logger.info("after update got %s" % artifact_info)
+        assert artifact_info == expected_artifact_info
 
     def do_test_forced_update_check_from_client(
         self, env, valid_image_with_mender_conf


### PR DESCRIPTION
Those go together:

* https://github.com/mendersoftware/mender-qa/pull/580
  build and prepare so called clean images and pass them to build-docker
  to embed in the images we later /extract_fs in integration tests
* https://github.com/mendersoftware/meta-mender/pull/1663
  support for a new flag that allows to specify an extra image
  to embed in the container
* https://github.com/mendersoftware/integration/pull/1983
  use the clean images in the tests and test for artifact_info
  in a explicit manner

ChangeLog: none
Signed-off-by: Peter Grzybowski <peter@northern.tech>