### PR TITLE
fix: change the default sleep time for the redo loop

### DIFF
--- a/tests/tests/common_connect.py
+++ b/tests/tests/common_connect.py
@@ -76,7 +76,7 @@ def wait_for_connect(auth, devid):
         base_url=deviceconnect.URL_MGMT,
     )
 
-    for _ in redo.retrier(attempts=60, sleeptime=1):
+    for _ in redo.retrier(attempts=12, sleeptime=5):
         logger.info("waiting for device in deviceconnect")
         res = devconn.call(
             "GET",


### PR DESCRIPTION
By default the redo loop uses a jitter variable to add randomness to the
sleeptime. This value defaults to 1.

Only seen locally, but did experience underflow in the case of the jitter value
being close to the sleeptime of 1.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>