### PR TITLE
chore: enhance tests to run on scratch images

### DIFF
--- a/testutils/infra/container_manager/base.py
+++ b/testutils/infra/container_manager/base.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -43,6 +43,14 @@ class BaseContainerManagerNamespace:
 
     def cmd(self, container_id, docker_cmd, cmd=[]):
         """Executes a docker command with arguments on an specific container"""
+        raise NotImplementedError
+
+    def download(self, container_id, source, destination):
+        """Download a file from a container"""
+        raise NotImplementedError
+
+    def upload(self, container_id, source, destination):
+        """Upload a file to a container"""
         raise NotImplementedError
 
     def getid(self, filters):

--- a/testutils/infra/container_manager/docker_manager.py
+++ b/testutils/infra/container_manager/docker_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -37,6 +37,17 @@ class DockerNamespace(BaseContainerManagerNamespace):
             cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         return ret.stdout.decode("utf-8").strip()
+
+    def download(self, container_id, source, destination):
+        return self._cp(f"{container_id}:{source}", destination)
+
+    def upload(self, container_id, source, destination):
+        return self._cp(source, f"{container_id}:{destination}")
+
+    def _cp(self, source, destination):
+        cmd = ["docker", "cp", source, destination]
+        ret = subprocess.check_output(cmd).decode("utf-8").strip()
+        return ret
 
     def getid(self, filters):
         filters.append(self.name)


### PR DESCRIPTION
The resulting image doesn't provide `sed` or other CLI tools when
building the back-end containers using the scratch Docker image.
Therefore, we must use the `cp` command to download and upload files to
and from the container when we need to change their content.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>