### PR TITLE
fix: path to the tenantadm binary misses the leading slash

### DIFF
--- a/testutils/infra/cli.py
+++ b/testutils/infra/cli.py
@@ -138,7 +138,7 @@ class CliTenantadm(BaseCli):
         if isK8S():
             return
 
-        cmd = ["usr/bin/tenantadm", "migrate"]
+        cmd = ["/usr/bin/tenantadm", "migrate"]
 
         self.container_manager.execute(self.cid, cmd)
 


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>