### PR TITLE
fix: wrong path for the useradm private key in the prod yaml templates

### DIFF
--- a/production/config/enterprise.yml.template
+++ b/production/config/enterprise.yml.template
@@ -18,3 +18,7 @@ services:
     mender-deviceconnect:
         environment:
             DEVICECONNECT_ENABLE_AUDIT: "1"
+
+    mender-useradm:
+        volumes:
+            - ./production/keys-generated/keys/useradm/private.key:/etc/useradm-enterprise/rsa/private.pem:ro


### PR DESCRIPTION
Changelog: Title
Ticket: MEN-5641

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit 9a2e38a2e4c812e7c50c22f478b5e628ab300b12)