### PR TITLE
chore(release_tool): When doing a release build also build the BBB

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -1757,6 +1757,7 @@ DR = Disable automatic publishing of the release
                 set_param("BUILD_SERVERS", action)
                 set_param("BUILD_MENDER_DIST_PACKAGES", action)
                 set_param("BUILD_MENDER_CONVERT", action)
+                set_param("BUILD_BEAGLEBONEBLACK", action)
             else:
                 action = "false"
             set_param("PUBLISH_RELEASE_AUTOMATIC", action)


### PR DESCRIPTION
Just so that the non-test release build maps to the release testing form 1:1,
which is less confusing for all parties involved.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>