### PR TITLE
feat: make use of the S3 external URI configuration for deployments

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -61,7 +61,8 @@ services:
             STORAGE_BACKEND_CERT: /etc/ssl/certs/docker.mender.io.crt
             DEPLOYMENTS_AWS_AUTH_KEY: minio
             DEPLOYMENTS_AWS_AUTH_SECRET: minio123
-            DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io
+            DEPLOYMENTS_AWS_URI: http://minio:9000
+            DEPLOYMENTS_AWS_EXTERNAL_URI: https://s3.docker.mender.io
         depends_on:
             - mender-mongo
 

--- a/docker-compose.no-ssl.yml
+++ b/docker-compose.no-ssl.yml
@@ -16,4 +16,4 @@ services:
 
     mender-deployments:
         environment:
-            DEPLOYMENTS_AWS_URI: http://s3.docker.mender.io
+            DEPLOYMENTS_AWS_EXTERNAL_URI: http://s3.docker.mender.io

--- a/docker-compose.storage.s3.yml
+++ b/docker-compose.storage.s3.yml
@@ -20,4 +20,5 @@ services:
             DEPLOYMENTS_AWS_REGION: us-west-1
             DEPLOYMENTS_AWS_URI: https://s3-us-west-1.amazonaws.com
             DEPLOYMENTS_AWS_BUCKET: mender-artifacts-int-testing-us
+            DEPLOYMENTS_AWS_EXTERNAL_URI: ""
 

--- a/extra/failover-testing/docker-compose.failover-server.yml
+++ b/extra/failover-testing/docker-compose.failover-server.yml
@@ -46,7 +46,8 @@ services:
             STORAGE_BACKEND_CERT: /etc/ssl/certs/docker.mender.io.crt
             DEPLOYMENTS_AWS_AUTH_KEY: minio
             DEPLOYMENTS_AWS_AUTH_SECRET: minio123
-            DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io
+            DEPLOYMENTS_AWS_URI: http://minio:9000
+            DEPLOYMENTS_AWS_EXTERNAL_URI: https://s3.docker.mender.io
 
     #
     # mender-gui

--- a/production/config/prod.yml.template
+++ b/production/config/prod.yml.template
@@ -112,7 +112,8 @@ services:
             # storage-proxy using exactly the same name as devices will; if
             # devices will access storage using https://s3.acme.org, then
             # set this to https://s3.acme.org
-            DEPLOYMENTS_AWS_URI: https://set-my-alias-here.com
+            DEPLOYMENTS_AWS_EXTERNAL_URI: https://set-my-alias-here.com
+            DEPLOYMENTS_AWS_URI: http://minio:9000
         logging:
             options:
                 max-file: "10"

--- a/storage-proxy/docker-compose.storage-proxy.demo.yml
+++ b/storage-proxy/docker-compose.storage-proxy.demo.yml
@@ -35,4 +35,5 @@ services:
     # 
     mender-deployments:
         environment:
-            DEPLOYMENTS_AWS_URI: https://s3.docker.mender.io:9000
+            DEPLOYMENTS_AWS_URI: http://minio:9000
+            DEPLOYMENTS_AWS_EXTERNAL_URI: https://s3.docker.mender.io:9000


### PR DESCRIPTION
The deployments service supports a new setting which allows specifying
the external URL to use when generating pre-signed URL. Therefore, the
communication between the deployments service and the storage layer can
now use the internal service name (minio) instead of routing requests to
the API gateway with the public-facing URL.

Changelog: Title
Ticket: MEN-5280

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>