### PR TITLE
chore: enhance wait_for_connect making it more robust

### DIFF
--- a/tests/tests/common_connect.py
+++ b/tests/tests/common_connect.py
@@ -76,6 +76,7 @@ def wait_for_connect(auth, devid):
         base_url=deviceconnect.URL_MGMT,
     )
 
+    connected = 0
     for _ in redo.retrier(attempts=12, sleeptime=5):
         logger.info("waiting for device in deviceconnect")
         res = devconn.call(
@@ -84,7 +85,11 @@ def wait_for_connect(auth, devid):
             headers=auth.get_auth_token(),
             path_params={"id": devid},
         )
-        if res.status_code == 200 and res.json()["status"] == "connected":
+        if not (res.status_code == 200 and res.json()["status"] == "connected"):
+            connected = 0
+            continue
+        connected += 1
+        if connected >= 2:
             break
     else:
         assert False, "timed out waiting for /connect"


### PR DESCRIPTION
TestAccessEnterprise.test_upgrades occasionally fails because
mender-connect running on the device is not connected when performing
troubleshoot add-on tests. This can happen because the tenant upgrade
triggers a workflow that resets the JWT tokens, and it can take a few
seconds for the Mender client to authorize again.

This change makes sure wait_for_connect waits for two consecutive checks
with 5 seconds interval before declaring the mender-connect client
component is available.

Changelog: None
Ticket: None

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>