### PR TITLE
test: increase recv timeout to 5 seconds

### DIFF
--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -54,12 +54,7 @@ class _TestRemoteTerminalBase:
 
             # Drain any initial output from the prompt. It should end in either "# "
             # (root) or "$ " (user).
-            output = b""
-            for i in range(10):
-                output += shell.recvOutput()
-                if len(output) >= 2:
-                    break
-                time.sleep(1)
+            output = shell.recvOutput()
             assert shell.protomsg.props["status"] == protomsg.PROP_STATUS_NORMAL
             assert output[-2:].decode() in [
                 "# ",

--- a/testutils/api/proto_shell.py
+++ b/testutils/api/proto_shell.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class ProtoShell:
         msg = self.protomsg.encode(data)
         self.ws.send(msg)
 
-    def recvOutput(self, timeout=1):
+    def recvOutput(self, timeout=5):
         body = b""
         try:
             while True:


### PR DESCRIPTION
When running multiple tests in parallel, there is a high risk the shell
running in the Qemu device and controlled by mender-connect is not fast
enough at sending the output to deviceconnect. We increase the timeout
from one second to five to make sure we receive the full output before
proceeding with the tests.

Changelog: None
Ticket: None

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>