### PR TITLE
ci: install openssh-client instead of openssh

### DIFF
--- a/tests/requirements/apk-requirements.txt
+++ b/tests/requirements/apk-requirements.txt
@@ -1,7 +1,7 @@
 bash
 curl
 git
-openssh
+openssh-client
 device-mapper
 py-pip
 iptables


### PR DESCRIPTION
Avoid the following error:

ERROR: unable to select packages:
  openssh-client-common-9.0_p1-r1:
    breaks: openssh-client-default-9.0_p1-r2[openssh-client-common=9.0_p1-r2]

Changelog: None
Ticket: None

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>