### PR TITLE
Update test_rootfs_image_rejected + Improve robustness of test_monitorclient_alert_email

### DIFF
--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -60,7 +60,8 @@ class BaseTestUpdateModules(MenderTesting):
             deploy.check_expected_statistics(deployment_id, "failure", 1)
 
             output = mender_device.run("mender --no-syslog show-artifact").strip()
-            assert output == "original"
+            # The update failed but the database got initialized with artifact-name "unknown"
+            assert output == "unknown"
 
             output = env.get_logs_of_service("mender-client")
             assert (


### PR DESCRIPTION
    test(test_rootfs_image_rejected): Update test
    
    Following implementation of bootstrap Artifact support.
    
    Ticket: MEN-2583


    test(test_monitorclient_alert_email): Improve robustness
    
    Disable the checks of each scenario when the verification is done.
    
    This test covers different (independent!) scenarios, creating and
    enabling checks for each of them. In some cases the alerts from one
    scenario can leak to the next, and then the logic of "expect the alert
    in the last received message" is too naive.

    The last scenario (expiration) needs now to create the check from
    scratch because it is disabled previously.

    Moved also the mender-monitor paths definitions to a single place.