### PR TITLE
fix: Bump mender-binary-delta to 1.4.x.

### DIFF
--- a/other-components.yml
+++ b/other-components.yml
@@ -11,7 +11,7 @@ services:
         image: mendersoftware/mender-cli:1.8.x
 
     mender-binary-delta:
-        image: mendersoftware/mender-binary-delta:1.3.x
+        image: mendersoftware/mender-binary-delta:1.4.x
 
     mender-convert:
         image: mendersoftware/mender-convert:3.0.x


### PR DESCRIPTION
Although it may seem wrong to do this in a patch release, the reality
is that we never documented the 1.3 series in the 3.3 mender-docs
site. Instead we documented 1.4. Since there is no strong dependency
relationship between mender-binary-delta and the rest of the
components anyway, it's better to change it to the one we document,
and then stick to that from now on.

Changelog: None
Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>