### PR TITLE
fix(changelog-generator): Put links after code blocks, not in them.

### DIFF
--- a/extra/changelog-generator/changelog-generator
+++ b/extra/changelog-generator/changelog-generator
@@ -503,7 +503,10 @@ for repo in repos:
                 )
             entry = entry.strip("\n")
             if tracker:
-                if len(entry) - entry.rfind("\n") + len(tracker) >= 70:
+                if (
+                    entry.endswith("```")
+                    or len(entry) - entry.rfind("\n") + len(tracker) >= 70
+                ):
                     entry += "\n"
                 else:
                     entry += " "

--- a/extra/changelog-generator/test-changelog-generator
+++ b/extra/changelog-generator/test-changelog-generator
@@ -539,6 +539,17 @@ git checkout $main
 
 ################################################################################
 
+git commit --allow-empty -m 'fix: Ending with a code example N103
+
+```
+code example
+```
+
+Changelog: Commit
+Ticket:MEN-1234'
+
+################################################################################
+
 "$SRC_DIR/changelog-generator" --repo --sort-changelog prev_branch..$main > result.txt 2>stderr.txt || {
     echo "Script failed with $?"
     echo "--------"
@@ -563,6 +574,12 @@ New changes in test-changelog-generator.$$ since prev_branch:
 
   Should be included N82
 * Custom changelog with keyword, should be fix N99
+  ([MEN-1234](https://tracker.mender.io/browse/MEN-1234))
+* Ending with a code example N103
+
+  \`\`\`
+  code example
+  \`\`\`
   ([MEN-1234](https://tracker.mender.io/browse/MEN-1234))
 * Fix type N79
 * Aggregated Dependabot Changelogs:


### PR DESCRIPTION
Otherwise it is misrendered.

Changelog: None
Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>