### PR TITLE
test: Fix test_release_tool from release branches

### DIFF
--- a/.gitlab-ci-default-pipeline.yml
+++ b/.gitlab-ci-default-pipeline.yml
@@ -35,7 +35,7 @@ test:extra-tools:
     - git submodule update --init --recursive
 
     # Fetch all Open Source release repositories for testing release_tool.
-    - for repo in $(env TEST_RELEASE_TOOL_LIST_OPEN_SOURCE_ONLY=1 extra/release_tool.py --list); do
+    - for repo in $(env TEST_RELEASE_TOOL_LIST_OPEN_SOURCE_ONLY=1 extra/release_tool.py --list --all); do
     -   if [ $repo == integration ]; then
     -     continue
     -   fi

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -256,6 +256,7 @@ BACKEND_SERVICES_ENT = {
     "auditlogs",
     "mtls-ambassador",
     "devicemonitor",
+    "mender-conductor-enterprise",
 }
 BACKEND_SERVICES_OPEN_ENT = {
     "deployments",


### PR DESCRIPTION
By checking out all repositories, including the deprecated ones.

This fixes for example a case when master introduce a new repository that a release branch is not aware of.