### PR TITLE
chore: Upgrade minio version to the latest Apache Licesnsed version

### DIFF
--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -7,7 +7,7 @@ services:
     minio:
         # DO NOT upgrade this to any version "2021.05" or later.
         # We want to stay on Apache license for now.
-        image: minio/minio:RELEASE.2019-04-23T23-50-36Z
+        image: minio/minio:RELEASE.2021-04-22T15-44-28Z
         restart: on-failure
         networks:
             mender:
@@ -28,5 +28,4 @@ services:
     #
     mender-deployments:
         depends_on:
-            minio:
-                condition: service_healthy
+          - minio


### PR DESCRIPTION
This version removes the HEALTHCHECK command from the docker file, making the startup time significantly faster.