### PR TITLE
Setup docker-compose healthcheck for MinIO

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -74,6 +74,12 @@ services:
         environment:
             MINIO_ACCESS_KEY: minio
             MINIO_SECRET_KEY: minio123
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+            interval: 1s
+            timeout: 5s
+            retries: 10
+            start_period: 5s
         # use rate limiting, for more options see: https://docs.traefik.io/v2.2/middlewares/ratelimit/
         # labels:
         #     - traefik.http.middlewares.demo-ratelimit.ratelimit.average=30

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -7,7 +7,7 @@ services:
     minio:
         # DO NOT upgrade this to any version "2021.05" or later.
         # We want to stay on Apache license for now.
-        image: minio/minio:RELEASE.2019-04-23T23-50-36Z
+        image: minio/minio:RELEASE.2021-04-22T15-44-28Z
         restart: on-failure
         networks:
             mender:

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -16,6 +16,12 @@ services:
         environment:
             MINIO_HTTP_TRACE: /dev/stdout
         command: server /export
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+            interval: 60s
+            timeout: 5s
+            retries: 2
+            start_period: 10s
 
     mender-api-gateway:
       environment:

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -24,10 +24,10 @@ services:
             start_period: 10s
 
     mender-api-gateway:
-      environment:
-        STORAGE_URL: ${STORAGE_URL:-s3.docker.mender.io}
-      volumes:
-        - ./config/traefik/traefik.minio.yaml:/etc/traefik/config/traefik.minio.yaml:ro
+        environment:
+            STORAGE_URL: ${STORAGE_URL:-s3.docker.mender.io}
+        volumes:
+            - ./config/traefik/traefik.minio.yaml:/etc/traefik/config/traefik.minio.yaml:ro
 
     #
     # mender-deployments depends on minio if minio is in use

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -28,6 +28,9 @@ logger = logging.getLogger("root")
 
 class DockerComposeNamespace(DockerComposeBaseNamespace):
     COMPOSE_FILES_PATH = DockerComposeBaseNamespace.COMPOSE_FILES_PATH
+    # Please note that the compose files sequence matters!
+    # The same parameter in different files can have different values and
+    # a value from the last yaml will be used.
     BASE_FILES = [
         COMPOSE_FILES_PATH + "/docker-compose.yml",
         COMPOSE_FILES_PATH + "/docker-compose.storage.minio.yml",


### PR DESCRIPTION
Changelog: None
Ticket: QA-421
Signed-off-by: Alex Miliukov <alex@northern.tech>

As discussed recently, now, when we have more stable pipelines, it makes sense to get this improvement merged.

Related to the following tickets:
- https://tracker.mender.io/browse/QA-434
- https://tracker.mender.io/browse/QA-421