### PR TITLE
Unstable test upgrades

### DIFF
--- a/tests/tests/common_connect.py
+++ b/tests/tests/common_connect.py
@@ -70,7 +70,7 @@ def prepare_env_for_connect(env):
     return devid, authtoken, auth, mender_device
 
 
-def wait_for_connect(auth, devid):
+def wait_for_connect(auth: authentication.Authentication, devid: str):
     devconn = ApiClient(
         host=get_container_manager().get_mender_gateway(),
         base_url=deviceconnect.URL_MGMT,

--- a/tests/tests/test_access.py
+++ b/tests/tests/test_access.py
@@ -18,6 +18,7 @@ import os
 
 from testutils.common import Tenant, User, update_tenant, new_tenant_client
 from testutils.infra.cli import CliTenantadm
+from testutils.infra.container_manager.base import BaseContainerManagerNamespace
 from testutils.infra.container_manager.kubernetes_manager import isK8S
 from testutils.api.client import ApiClient
 import testutils.api.deviceconnect as deviceconnect
@@ -238,7 +239,7 @@ class TestAccessEnterprise(_TestAccessBase):
         not bool(os.environ.get("STRIPE_API_KEY")),
         reason="STRIPE_API_KEY not provided",
     )
-    def test_upgrades(self, docker_env):
+    def test_upgrades(self, docker_env: BaseContainerManagerNamespace):
         """Test that plan/addon upgrades take effect on feature availability.
         Special case is the trial tenant upgrade to a paid plan.
         """

--- a/tests/tests/test_access.py
+++ b/tests/tests/test_access.py
@@ -239,6 +239,7 @@ class TestAccessEnterprise(_TestAccessBase):
         not bool(os.environ.get("STRIPE_API_KEY")),
         reason="STRIPE_API_KEY not provided",
     )
+    @pytest.mark.xfail(reason="QA-451")
     def test_upgrades(self, docker_env: BaseContainerManagerNamespace):
         """Test that plan/addon upgrades take effect on feature availability.
         Special case is the trial tenant upgrade to a paid plan.


### PR DESCRIPTION
test(unstable): Mark test_upgrades as xfail

Changelog: None
Ticket: QA-451
Signed-off-by: Maciej Tomczuk <maciej.tomczuk@northern.tech>