### PR TITLE
fix: Mark generate-delta-worker as an Enterprise repository. 

### DIFF
--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -257,6 +257,7 @@ BACKEND_SERVICES_ENT = {
     "mtls-ambassador",
     "devicemonitor",
     "mender-conductor-enterprise",
+    "generate-delta-worker",
 }
 BACKEND_SERVICES_OPEN_ENT = {
     "deployments",


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>