### PR TITLE
chore: Revert "chore(docker-addons/Dockerfile): Update base image to Ubuntu 22"

### DIFF
--- a/extra/mender-client-docker-addons/Dockerfile
+++ b/extra/mender-client-docker-addons/Dockerfile
@@ -1,6 +1,6 @@
 # Creates a container which acts as a bare bones non-VM based Mender
 # installation, for use in tests.
-FROM ubuntu:22.04 AS build
+FROM ubuntu:20.04 AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y make git build-essential golang liblzma-dev \
@@ -47,7 +47,7 @@ RUN make DESTDIR=/mender-install install
 
 RUN mkdir -p /mender-install/var/lib/mender && echo device_type=docker-client > /mender-install/var/lib/mender/device_type
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 RUN mkdir -p /run/dbus && apt-get update && apt-get install -y liblzma5 dbus openssh-server
 


### PR DESCRIPTION
This reverts commit d920eb88cf4666d701711f1542100afaa747fb5d.

Seems to be a problem in CI building this image. Revert the upgrade for now to unblock other work and follow-up independently.