### PR TITLE
fix: Rerun filetransfer tests on 408 timeouts

### DIFF
--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -278,8 +278,7 @@ def running_custom_production_setup(request):
     return env
 
 
-@pytest.fixture(scope="function")
-def enterprise_no_client(request):
+def enterprise_no_client_impl(request):
     env = container_factory.get_enterprise_setup(num_clients=0)
     request.addfinalizer(env.teardown)
 
@@ -287,6 +286,16 @@ def enterprise_no_client(request):
     reset_mender_api(env)
 
     return env
+
+
+@pytest.fixture(scope="function")
+def enterprise_no_client(request):
+    return enterprise_no_client_impl(request)
+
+
+@pytest.fixture(scope="class")
+def enterprise_no_client_class(request):
+    return enterprise_no_client_impl(request)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
This is a pretty serious refactor of the filetransfer tests.

In essence this splits them up into separate tests, as opposed to having a lot
of different tests serialised in one test as before.

The class structure is used to a larger extent now, with a base test class
holding the tests, and then the sub OS and Enterprise test classes is simply
overriding the needed fixtures in order to provide the given OS and enterprise setups.

Tests have also been rewritten to be re-entrant. This was needed, since we now
rerun a given test on 408 timeouts (which we know can happen occasionally).
Hence, the names used in the tests are randomly generated, and not static and
semantic as before. However, I do not believe this should be a problem.

Doing this enables us to rerun each test a given number of times (in this
instance by flaky, so default=3).

Also, this opens the door to running these tests in parallel, even though they
are using the same client in the setup.

I want to double highlight the above. All tests in a given class (OS or
Enterprise) share a given setup environment. This means that all tests are run
with the same backend, and the same client.

Take heed!

Ticket: QA-456
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>