### PR TITLE
perf: Run the tests under xdist with the scope scheduler

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -217,6 +217,7 @@ python3 -m pytest \
     $EXTRA_TEST_ARGS \
     --verbose \
     --junitxml=results.xml \
+    --dist=loadscope \
     $HTML_REPORT \
     "$@" \
     $SPECIFIC_INTEGRATION_TEST_FLAG ${SPECIFIC_INTEGRATION_TEST:+"$SPECIFIC_INTEGRATION_TEST"}


### PR DESCRIPTION
This makes tests scheduled onto an xdist worker whilst respecting (to a large
degree) the scopes under which they are defined.

This is beneficial, as say tests under a class scope are otherwise sorted onto
different runners, and the time saved by having the same scope on all of them is
lost, as they will all have to do the common setup and teardown multiple times.

This can also apply within a given runner, if the scoped tests are not run sequentially.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>