### PR TITLE
feat(release_tool): Add the mender-qemu-rofs-commercial docker image

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -21,8 +21,10 @@ git:
     independent_component: true
 
   mender-binary-delta:
-    docker_image: []
-    docker_container: []
+    docker_image:
+      - mender-qemu-rofs-commercial
+    docker_container:
+      - mender-client
     release_component: true
     independent_component: true
 
@@ -116,6 +118,7 @@ git:
     docker_image:
     - mender-client-qemu
     - mender-client-qemu-rofs
+    - mender-qemu-rofs-commercial
     - mender-client-docker
     - mender-client-docker-addons
     - mender-monitor-qemu-commercial
@@ -240,6 +243,7 @@ git:
     docker_image:
     - mender-client-qemu
     - mender-client-qemu-rofs
+    - mender-qemu-rofs-commercial
     - mender-client-docker-addons
     - mender-monitor-qemu-commercial
     docker_container:
@@ -380,6 +384,16 @@ docker_image:
     git:
     - mender
     - mender-connect
+    docker_container:
+    - mender-client
+    release_component: true
+    independent_component: false
+
+  mender-qemu-rofs-commercial:
+    git:
+    - mender
+    - mender-connect
+    - mender-binary-delta
     docker_container:
     - mender-client
     release_component: true
@@ -601,12 +615,14 @@ docker_container:
     - mender
     - monitor-client
     - mender-connect
+    - mender-binary-delta
     docker_image:
     - mender-client-docker
     - mender-client-docker-addons
     - mender-client-qemu
     - mender-client-qemu-rofs
     - mender-monitor-qemu-commercial
+    - mender-qemu-rofs-commercial
     release_component: true
 
   mender-api-gateway:

--- a/other-components-docker.yml
+++ b/other-components-docker.yml
@@ -6,3 +6,5 @@ services:
         image: registry.mender.io/mendersoftware/mtls-ambassador:mender-master
     mender-ci-workflows:
         image: mendersoftware/mender-ci-tools:mender-master
+    mender-client:
+        image: registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:mender-master


### PR DESCRIPTION
This adds support for the `mender-qemu-rofs-commercial` docker image.

The image contains the fulls rofs setup with a read-only rootfs along with
`mender-binary-delta` already installed.

Ticket: MEN-6004
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>