### PR TITLE
test: Replace deprecated docker-compose create with up --no-start

### DIFF
--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -411,7 +411,7 @@ class DockerComposeCompatibilitySetup(DockerComposeNamespace):
     def client_services(self):
         # In order for `ps --services` to return the services, the must have
         # been created, but they don't need to be running.
-        self._docker_compose_cmd("create")
+        self._docker_compose_cmd("up --no-start")
         services = self._docker_compose_cmd("ps --services").split()
         clients = []
         for service in services:


### PR DESCRIPTION
See: https://github.com/docker/compose/pull/5142