### PR TITLE
ci: Use GitHub token in addition to SSH key and fix hub command

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ publish:versions:
   image: python:slim
   before_script:
     - apt-get update && apt-get install -qqy curl hub unzip
+    - export GITHUB_TOKEN="$GITHUB_BOT_TOKEN_REPO_FULL"
     - pip3 install pyyaml
     - curl -fsSL https://deno.land/x/install/install.sh | sh
     - curl -sLO https://docs.mender.io/releases/versions.json
@@ -39,8 +40,9 @@ publish:versions:
     - python extra/release_info_generator.py
     - /root/.deno/bin/deno fmt versions.json
     - hub clone mendersoftware/mender-docs-site && mv versions.json mender-docs-site/versions.json && cd mender-docs-site
+    - git checkout -b update-versions-$(date +%s)
     - "git add versions.json && git commit --signoff -m 'chore: Version information update'"
-    - hub pull-request --push --draft --base mendersoftware/mender-docs-site --message "Version information update" --message "keeping up with the versions"
+    - hub pull-request --push --draft --base mendersoftware:master --message "Version information update" --message "keeping up with the versions"
   artifacts:
     expire_in: 2w
     paths:


### PR DESCRIPTION
This commit partially reverts 7bb7fc0. It uses a different token because the previous one only had repo:status permissions.

It took me a while to realize that we actually need both the token and the SSH key. See this comment:
* https://github.com/github/hub/issues/1644#issuecomment-359002547

Additionally, fix the hub command: a pull request needs to be launched
from a different fork or branch.