### PR TITLE
test: Do not reuse CompatibilySetup for Mender 2.5 setup

### DIFF
--- a/tests/tests/test_filetransfer.py
+++ b/tests/tests/test_filetransfer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -751,15 +751,11 @@ class BaseFileTransferLegacyClient(MenderTesting):
 class TestFileTransferLegacyClientOS(BaseFileTransferLegacyClient):
     @pytest.fixture(scope="function")
     def setup_mender_connect_1_0(self, request):
-        self.env = container_factory.get_mender_client_2_5()
+        self.env = container_factory.get_mender_client_2_5_setup(num_clients=1)
         request.addfinalizer(self.env.teardown)
         self.env.setup()
 
-        self.env.populate_clients(replicas=1)
-
-        clients = self.env.get_mender_clients()
-        assert len(clients) == 1, "Failed to setup client"
-        self.env.device = MenderDevice(clients[0])
+        self.env.device = MenderDevice(self.env.get_mender_clients()[0])
         self.env.device.ssh_is_opened()
 
         reset_mender_api(self.env)
@@ -781,7 +777,7 @@ class TestFileTransferLegacyClientOS(BaseFileTransferLegacyClient):
 class TestFileTransferLegacyClientEnterprise(BaseFileTransferLegacyClient):
     @pytest.fixture(scope="function")
     def setup_mender_connect_1_0(self, request):
-        self.env = container_factory.get_mender_client_2_5(enterprise=True)
+        self.env = container_factory.get_mender_client_2_5_enterprise_setup()
         request.addfinalizer(self.env.teardown)
         self.env.setup()
         reset_mender_api(self.env)

--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -330,15 +330,11 @@ class TestRemoteTerminal_1_0(_TestRemoteTerminalBase):
 
     @pytest.fixture(autouse=True, scope="class")
     def docker_env(self, request):
-        env = container_factory.get_mender_client_2_5()
+        env = container_factory.get_mender_client_2_5_setup(num_clients=1)
         request.addfinalizer(env.teardown)
         env.setup()
 
-        env.populate_clients(replicas=1)
-
-        clients = env.get_mender_clients()
-        assert len(clients) == 1, "Failed to setup client"
-        env.device = MenderDevice(clients[0])
+        env.device = MenderDevice(env.get_mender_clients()[0])
         env.device.ssh_is_opened()
 
         reset_mender_api(env)
@@ -410,7 +406,7 @@ class TestRemoteTerminalEnterprise_1_0(_TestRemoteTerminalBase):
 
     @pytest.fixture(autouse=True, scope="class")
     def docker_env(self, request):
-        env = container_factory.get_mender_client_2_5(enterprise=True)
+        env = container_factory.get_mender_client_2_5_enterprise_setup()
         request.addfinalizer(env.teardown)
         env.setup()
 

--- a/testutils/infra/container_manager/docker_compose_base_manager.py
+++ b/testutils/infra/container_manager/docker_compose_base_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -46,11 +46,13 @@ class DockerComposeBaseNamespace(DockerNamespace):
         self._debug_log_containers_logs()
         self._stop_docker_compose()
 
-    def get_mender_clients(self, network="mender"):
+    def get_mender_clients(self, network="mender", client_service_name="mender-client"):
         """Returns IP address(es) of mender-client container(s)"""
         clients = [
             ip + ":8822"
-            for ip in self.get_ip_of_service("mender-client", network=network)
+            for ip in self.get_ip_of_service(
+                service=client_service_name, network=network
+            )
         ]
         return clients
 

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -520,20 +520,34 @@ class DockerComposeMTLSSetup(DockerComposeNamespace):
         time.sleep(45)
 
 
-class DockerComposeMenderClient_2_5(DockerComposeCompatibilitySetup):
-    """
-    Setup is identical to DockerComposeCompatiblitySetup but excluding images
-    without mender-connect.
-    """
+class DockerComposeMenderClient_2_5_Setup(DockerComposeNamespace):
+    """OS setup with mender-connect 1.0."""
 
-    def __init__(self, name, enterprise=False):
-        self._enterprise = enterprise
-        extra_files = self.MENDER_2_5_FILES
-        if self._enterprise:
-            extra_files += self.ENTERPRISE_FILES
-        super(DockerComposeCompatibilitySetup, self).__init__(
-            name, extra_files=extra_files
+    def __init__(self, name, num_clients=1):
+        self.num_clients = num_clients
+        super().__init__(name, self.MENDER_2_5_FILES)
+
+    def setup(self):
+        self._docker_compose_cmd(
+            "up -d --scale mender-client-2-5=%d" % self.num_clients
         )
+        self._wait_for_containers()
+
+    def get_mender_clients(self, network="mender"):
+        return super().get_mender_clients(
+            client_service_name="mender-client-2-5", network=network
+        )
+
+
+class DockerComposeMenderClient_2_5_EnterpriseSetup(DockerComposeNamespace):
+    """Enterprise setup with mender-connect 1.0."""
+
+    def __init__(self, name, num_clients=0):
+        super().__init__(name, self.ENTERPRISE_FILES + self.MENDER_2_5_FILES)
+
+    def setup(self):
+        self._docker_compose_cmd("up -d --scale mender-client-2-5=0")
+        self._wait_for_containers()
 
     def new_tenant_client(self, name, tenant):
         logger.info("creating client connected to tenant: " + tenant)
@@ -542,6 +556,11 @@ class DockerComposeMenderClient_2_5(DockerComposeCompatibilitySetup):
             env={"TENANT_TOKEN": "%s" % tenant},
         )
         time.sleep(45)
+
+    def get_mender_clients(self, network="mender"):
+        return super().get_mender_clients(
+            client_service_name="mender-client-2-5", network=network
+        )
 
 
 class DockerComposeCustomSetup(DockerComposeNamespace):

--- a/testutils/infra/container_manager/factory.py
+++ b/testutils/infra/container_manager/factory.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -34,7 +34,8 @@ from .docker_compose_manager import (
     DockerComposeCustomSetup,
     DockerComposeCompatibilitySetup,
     DockerComposeMTLSSetup,
-    DockerComposeMenderClient_2_5,
+    DockerComposeMenderClient_2_5_Setup,
+    DockerComposeMenderClient_2_5_EnterpriseSetup,
 )
 from .kubernetes_manager import (
     KubernetesEnterpriseSetup,
@@ -197,8 +198,11 @@ class DockerComposeManagerFactory(ContainerManagerFactory):
     def get_mtls_setup(self, name=None, **kwargs):
         return DockerComposeMTLSSetup(name, **kwargs)
 
-    def get_mender_client_2_5(self, name=None, **kwargs):
-        return DockerComposeMenderClient_2_5(name, **kwargs)
+    def get_mender_client_2_5_setup(self, name=None, num_clients=1, **kwargs):
+        return DockerComposeMenderClient_2_5_Setup(name, num_clients, **kwargs)
+
+    def get_mender_client_2_5_enterprise_setup(self, name=None, num_clients=0):
+        return DockerComposeMenderClient_2_5_EnterpriseSetup(name, num_clients)
 
     def get_custom_setup(self, name=None):
         return DockerComposeCustomSetup(name)
@@ -223,8 +227,11 @@ class KubernetesManagerFactory(ContainerManagerFactory):
     def get_enterprise_short_lived_token_setup(self, name=None, num_clients=0):
         return KubernetesEnterpriseSetup(name, num_clients)
 
-    def get_mender_client_2_5(self, name=None, **kwargs):
-        return DockerComposeMenderClient_2_5(name, **kwargs)
+    def get_mender_client_2_5_setup(self, name=None, num_clients=1, **kwargs):
+        return DockerComposeMenderClient_2_5_Setup(name, num_clients, **kwargs)
+
+    def get_mender_client_2_5_enterprise_setup(self, name=None, num_clients=0):
+        return DockerComposeMenderClient_2_5_EnterpriseSetup(name, num_clients)
 
 
 def get_factory():


### PR DESCRIPTION
There are a set of tests that specifically verify `mender-connect` 1.0 with current server versions, and for historical reasons they were reusing the `DockerComposeCompatibilitySetup`. Leave the latter for the rather specific test setup used there, and create new (smipler?) setups for the tests requiring only this specific client.

This commit workarounds the problem for QA-525 by not using this setup in other tests. The root cause for QA-525 is still unknown.