### PR TITLE
fix: bump docker compose file format version to 2.3

### DIFF
--- a/backend-tests/docker/docker-compose.backend-tests.yml
+++ b/backend-tests/docker/docker-compose.backend-tests.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
     mender-backend-tests-runner:
         image: mendersoftware/mender-test-containers:backend-integration-testing

--- a/common.yml
+++ b/common.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
     mender-base:
         stdin_open: false

--- a/docker-compose.client-dev.yml
+++ b/docker-compose.client-dev.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.client.demo.yml
+++ b/docker-compose.client.demo.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.client.rofs.commercial.yml
+++ b/docker-compose.client.rofs.commercial.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.client.rofs.yml
+++ b/docker-compose.client.rofs.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     mender-iot-manager:

--- a/docker-compose.docker-client.addons.yml
+++ b/docker-compose.docker-client.addons.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     mender-client:

--- a/docker-compose.docker-client.yml
+++ b/docker-compose.docker-client.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     mender-client:

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     # redis cache

--- a/docker-compose.mender-gateway.commercial.demo.yml
+++ b/docker-compose.mender-gateway.commercial.demo.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.mender-gateway.commercial.yml
+++ b/docker-compose.mender-gateway.commercial.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.monitor-client.commercial.yml
+++ b/docker-compose.monitor-client.commercial.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.mt.client.yml
+++ b/docker-compose.mt.client.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.no-ssl.yml
+++ b/docker-compose.no-ssl.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     mender-api-gateway:

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.storage.s3.yml
+++ b/docker-compose.storage.s3.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/docker-compose.testing.enterprise.yml
+++ b/docker-compose.testing.enterprise.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     mender-device-auth:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/extra/expired-token-testing/docker-compose.short-token.yml
+++ b/extra/expired-token-testing/docker-compose.short-token.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
     mender-device-auth:
         environment:

--- a/extra/failover-testing/docker-compose.failover-server.yml
+++ b/extra/failover-testing/docker-compose.failover-server.yml
@@ -2,7 +2,7 @@
 # and docker-compose.storage.minio.yml, as they appeared when this file was
 # written.
 
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/extra/integration-testing/docker-compose.mender.2.5.yml
+++ b/extra/integration-testing/docker-compose.mender.2.5.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   #
   # Setup including older clients with mender-connect

--- a/extra/integration-testing/docker-compose.yml
+++ b/extra/integration-testing/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 
 services:
   mender-api-gateway:

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.0.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.0.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-2-0:
     image: mendersoftware/mender-client-qemu:2.0

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.1.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.1.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-2-1:
     image: mendersoftware/mender-client-qemu:2.1

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.2.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.2.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-2-2:
     image: mendersoftware/mender-client-qemu:2.2

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.3.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.3.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-2-3:
     image: mendersoftware/mender-client-qemu:2.3

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.4.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.4.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-2-4:
     image: mendersoftware/mender-client-qemu:2.4

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.5.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.5.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-2-5:
     image: mendersoftware/mender-client-qemu:2.5

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.6.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.6.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-2-6:
     image: mendersoftware/mender-client-qemu:2.6

--- a/extra/integration-testing/test-compat/docker-compose.compat-3.0.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-3.0.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-3-0:
     image: mendersoftware/mender-client-qemu:3.0

--- a/extra/integration-testing/test-compat/docker-compose.compat-3.1.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-3.1.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-3-1:
     image: mendersoftware/mender-client-qemu:3.1

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.2.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.2.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-3-2:
     image: mendersoftware/mender-client-qemu:mender-3.2

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.3.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.3.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-3-3:
     image: mendersoftware/mender-client-qemu:mender-3.3

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.4.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.4.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-client-3-4:
     image: mendersoftware/mender-client-qemu:mender-3.4

--- a/extra/mender-gateway/docker-compose.client.yml
+++ b/extra/mender-gateway/docker-compose.client.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/extra/mender-gateway/docker-compose.test.yml
+++ b/extra/mender-gateway/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mender-gateway:
     networks:

--- a/extra/mtls/docker-compose.mtls-ambassador-test.yml
+++ b/extra/mtls/docker-compose.mtls-ambassador-test.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   mtls-ambassador:
     image: registry.mender.io/mendersoftware/mtls-ambassador:master

--- a/extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml
+++ b/extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     mender-tenantadm:

--- a/extra/signed-artifact-client-testing/docker-compose.signed-client.yml
+++ b/extra/signed-artifact-client-testing/docker-compose.signed-client.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/extra/smtp-testing/smtp.mock.yml
+++ b/extra/smtp-testing/smtp.mock.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     local-smtp:

--- a/extra/smtp-testing/workflows-worker-smtp-mock.yml
+++ b/extra/smtp-testing/workflows-worker-smtp-mock.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     mender-workflows-worker:

--- a/extra/smtp-testing/workflows-worker-smtp-test.yml
+++ b/extra/smtp-testing/workflows-worker-smtp-test.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     mender-workflows-worker:

--- a/extra/stripe-testing/stripe-test.docker-compose.yml
+++ b/extra/stripe-testing/stripe-test.docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     mender-tenantadm:

--- a/migration/migration-helper.yml
+++ b/migration/migration-helper.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/production/config/enterprise.yml.template
+++ b/production/config/enterprise.yml.template
@@ -5,7 +5,7 @@
 # Notes:
 # - integration/docker-compose.enterprise.yml file is assumed to be included
 
-version: '2.1'
+version: '2.3'
 services:
 
     mender-device-auth:

--- a/production/config/prod.yml.template
+++ b/production/config/prod.yml.template
@@ -16,7 +16,7 @@
 # - https://github.com/docker/compose/issues/3568
 # - https://github.com/docker/compose/issues/3219
 
-version: '2.1'
+version: '2.3'
 services:
 
     mender-iot-manager:

--- a/storage-proxy/docker-compose.storage-proxy.demo.yml
+++ b/storage-proxy/docker-compose.storage-proxy.demo.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #

--- a/storage-proxy/docker-compose.storage-proxy.yml
+++ b/storage-proxy/docker-compose.storage-proxy.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
     #
     # storage-proxy

--- a/tests/legacy-v1-client.yml
+++ b/tests/legacy-v1-client.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
 
     #


### PR DESCRIPTION
This is because the start_period option which we're started to use was added in file format 2.3 (see the [docs](https://docs.docker.com/compose/compose-file/compose-file-v2/#healthcheck))

