### PR TITLE
QA-461: test: Improve robustness of test_keepalive_disable

### DIFF
--- a/tests/tests/test_keepalive.py
+++ b/tests/tests/test_keepalive.py
@@ -192,9 +192,14 @@ class TestMenderClientKeepAlive:
         )
         assert get_opened_tcp_connections(mender_device) > 0
 
-        configure_connectivity(mender_device, disable_keep_alive=disable_keep_alive)
+        configure_connectivity(
+            mender_device,
+            disable_keep_alive=disable_keep_alive,
+            inventory_poll=3600,
+            update_poll=3600,
+        )
         logger.info("test_keepalive_disable: waiting for client to restart")
-        time.sleep(1)
+        time.sleep(15)
         assert get_opened_tcp_connections(mender_device) == 0
         logger.info("test_keepalive_disable: ok, no connections to backend")
 


### PR DESCRIPTION
The mender client will always do an inventory update on boot, which is what presumably that 1s sleep was trying to wait for.

Increase considerably the sleep, while making the poll intervals long so that no new inventory update (nor update check) happen for the rest of the test.

This does not modify the goal of the test, which is to verify that the client respects keep alive settings (specifically, that disabling it does not keep TCP connections lingering around).