### PR TITLE
chore: disable addons by default when creating tenants

### DIFF
--- a/backend-tests/tests/test_aws_iotcore.py
+++ b/backend-tests/tests/test_aws_iotcore.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -231,7 +231,10 @@ def user(clean_mongo) -> Optional[User]:
     uuidv4 = str(uuid.uuid4())
     try:
         tenant = create_org(
-            "test.mender.io-" + uuidv4, f"user+{uuidv4}@example.com", "password123",
+            "test.mender.io-" + uuidv4,
+            f"user+{uuidv4}@example.com",
+            "password123",
+            addons=["configure"],
         )
         user = tenant.users[0]
         user.tenant = tenant

--- a/backend-tests/tests/test_azure_iothub.py
+++ b/backend-tests/tests/test_azure_iothub.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -220,7 +220,10 @@ def azure_user(clean_mongo) -> Optional[User]:
     uuidv4 = str(uuid.uuid4())
     try:
         tenant = create_org(
-            "test.mender.io-" + uuidv4, f"user+{uuidv4}@example.com", "password123",
+            "test.mender.io-" + uuidv4,
+            f"user+{uuidv4}@example.com",
+            "password123",
+            addons=["configure"],
         )
         user = tenant.users[0]
         user.tenant = tenant

--- a/backend-tests/tests/test_monitoring.py
+++ b/backend-tests/tests/test_monitoring.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ def tenants_users(clean_migrated_mongo):
             "ci.email.tests+" + uuidv4 + "@mender.io",
             "secretsecret",
         )
-        tenants.append(create_org(tenant, username, password))
+        tenants.append(create_org(tenant, username, password, addons=["monitor"]))
 
     yield tenants
 

--- a/demo
+++ b/demo
@@ -255,6 +255,9 @@ create_user() {
                 $(run_compose_command ps -q mender-tenantadm) \
                 /usr/bin/tenantadm create-org \
                 --name=DemoOrganization \
+                --addon configure \
+                --addon monitor \
+                --addon troubleshoot \
                 --username=${USER} \
                 --password=${PASSWORD})
         retval=$?

--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -299,7 +299,7 @@ class TestMonitorClientEnterprise:
 
         uuidv4 = str(uuid.uuid4())
         name = "test.mender.io-" + uuidv4
-        tid = cli.create_org(name, u.name, u.pwd, plan="enterprise")
+        tid = cli.create_org(name, u.name, u.pwd, plan="enterprise", addons=["monitor"])
 
         # at the moment we do not have a notion of a monitor add-on in the
         # backend, but this will be needed here, see MEN-4809

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import uuid
 import os
 import subprocess
 from contextlib import contextmanager
+from typing import List
 
 import docker
 import redo
@@ -162,6 +163,7 @@ def create_org(
     username: str,
     password: str,
     plan: str = "os",
+    addons: List[str] = [],
     containers_namespace: str = "backend-tests",
     container_manager=None,
 ) -> Tenant:
@@ -169,7 +171,7 @@ def create_org(
         containers_namespace=containers_namespace, container_manager=container_manager
     )
     user_id = None
-    tenant_id = cli.create_org(name, username, password, plan=plan)
+    tenant_id = cli.create_org(name, username, password, plan=plan, addons=addons)
     tenant_token = json.loads(cli.get_tenant(tenant_id))["tenant_token"]
 
     host = GATEWAY_HOSTNAME

--- a/testutils/infra/cli.py
+++ b/testutils/infra/cli.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ class CliTenantadm(BaseCli):
         enterprise = Microservice("/usr/bin/tenantadm", "/etc/tenantadm")
         self.choose_binary_and_config_paths([enterprise], self.service_name)
 
-    def create_org(self, name, username, password, plan="os") -> str:
+    def create_org(self, name, username, password, plan="os", addons=[]) -> str:
         cmd = [
             self.service.bin_path,
             "create-org",
@@ -130,6 +130,8 @@ class CliTenantadm(BaseCli):
             "--plan",
             plan,
         ]
+        for addon in addons:
+            cmd.extend(["--addon", addon])
 
         tid = self.container_manager.execute(self.cid, cmd)
         return tid


### PR DESCRIPTION
tenantadm CLI commands to create tenants now support flags to enable the addons; by default, all addons are disabled. Adapt the demo script and the tests to enable all the addons.

Changelog: None
Ticket: MEN-6292

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>