### PR TITLE
MEN-6294: fix(demo): Include `testing` composition with `--enterprise-testing`

### DIFF
--- a/demo
+++ b/demo
@@ -11,7 +11,7 @@ EXTRA_FILES=""
 
 DEMO_FILES="-f docker-compose.yml -f docker-compose.storage.minio.yml -f docker-compose.demo.yml"
 CLIENT_FILES="-f docker-compose.client.yml -f docker-compose.client.demo.yml"
-ENTERPRISE_FILES="-f docker-compose.enterprise.yml"
+ENTERPRISE_FILES="-f docker-compose.enterprise.yml -f docker-compose.testing.enterprise.yml"
 ENTERPRISE_CLIENT_FILES="-f docker-compose.monitor-client.commercial.yml -f docker-compose.client.demo.yml"
 
 CLIENT=0


### PR DESCRIPTION
We need this in order to correctly set the environment for `generate-delta-worker` container.

This is an internal and undocumented flag that we use for enterprise testing, so there should be no issue with adding all the testing settings into the composition.