### PR TITLE
QA-525: test: Fix and enable `TestClientCompatibility`

### DIFF
--- a/extra/integration-testing/test-compat/docker-compose.compat-2.0.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.0.yml
@@ -8,7 +8,7 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       # Provision demo certificate
       - ./cert/cert.crt:/mnt/config/server.crt

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.1.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.1.yml
@@ -8,7 +8,7 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       # Provision demo certificate
       - ./cert/cert.crt:/mnt/config/server.crt

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.2.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.2.yml
@@ -8,7 +8,7 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       # Provision demo certificate
       - ./cert/cert.crt:/mnt/config/server.crt

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.3.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.3.yml
@@ -8,7 +8,7 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       # Provision demo certificate
       - ./cert/cert.crt:/mnt/config/server.crt

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.4.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.4.yml
@@ -8,7 +8,7 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       # Provision demo certificate
       - ./cert/cert.crt:/mnt/config/server.crt

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.5.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.5.yml
@@ -8,7 +8,7 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       # Provision demo certificate
       - ./cert/cert.crt:/mnt/config/server.crt

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.6.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.6.yml
@@ -8,7 +8,7 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       # Provision demo certificate
       - ./cert/cert.crt:/mnt/config/server.crt

--- a/extra/integration-testing/test-compat/docker-compose.compat-3.0.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-3.0.yml
@@ -8,7 +8,7 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       # NOTE: These volume mounts are only necessary for <= 3.0
       # Provision demo certificate

--- a/extra/integration-testing/test-compat/docker-compose.compat-3.1.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-3.1.yml
@@ -8,7 +8,7 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
     volumes:
       - ./extra/integration-testing/setup-mender-configuration.py:/setup-mender-configuration.py
 

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.2.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.2.yml
@@ -8,5 +8,5 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
 

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.3.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.3.yml
@@ -8,5 +8,5 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
 

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.4.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.4.yml
@@ -8,5 +8,5 @@ services:
     tty: true
     privileged: true
     environment:
-      TENANT_TOKEN: ""
+      - TENANT_TOKEN=$TENANT_TOKEN
 

--- a/tests/tests/test_compat.py
+++ b/tests/tests/test_compat.py
@@ -316,7 +316,6 @@ class TestClientCompatibilityBase:
             assert_successful_deployment(api_deployments, deployment_id)
 
 
-@pytest.mark.skip(reason="See QA-525")
 class TestClientCompatibilityOpenSource(TestClientCompatibilityBase):
     def test_compatibility(self, setup_os_compat):
         for version in COMPAT_MENDER_VERSIONS:
@@ -325,7 +324,6 @@ class TestClientCompatibilityOpenSource(TestClientCompatibilityBase):
             env.teardown()
 
 
-@pytest.mark.skip(reason="See QA-525")
 @pytest.mark.skipif(
     isK8S(), reason="not relevant in a staging or production environment"
 )

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -426,7 +426,7 @@ class DockerComposeCompatibilitySetup(DockerComposeNamespace):
         # In order for `ps --services` to return the services, the must have
         # been created, but they don't need to be running.
         self._docker_compose_cmd("up --no-start")
-        services = self._docker_compose_cmd("ps --services").split()
+        services = self._docker_compose_cmd("ps --services --all").split()
         clients = []
         for service in services:
             if service.startswith("mender-client"):

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -440,19 +440,16 @@ class DockerComposeCompatibilitySetup(DockerComposeNamespace):
         self._docker_compose_cmd(compose_args)
         self._wait_for_containers()
 
-    def populate_clients(self, name=None, tenant_token="", replicas=1):
-        client_services = self.client_services()
-        compose_cmd = "run -d"
-        if tenant_token != "":
-            compose_cmd += " -e TENANT_TOKEN={tkn}".format(tkn=tenant_token)
+    def populate_clients(self, name=None, tenant_token=""):
+        compose_cmd = "up -d " + " ".join(
+            ["--scale %s=1" % service for service in self.client_services()]
+        )
         if name is not None:
             compose_cmd += " --name '{name}'".format(name=name)
 
-        compose_cmd += " {service}"
-
-        for i in range(replicas):
-            for service in client_services:
-                self._docker_compose_cmd(compose_cmd.format(service=service))
+        self._docker_compose_cmd(
+            compose_cmd, env={"TENANT_TOKEN": "%s" % tenant_token},
+        )
 
     def get_mender_clients(self, network="mender"):
         cmd = [


### PR DESCRIPTION
It is unknown at which point in time started to fail - the assumption is that an update in upstream `docker-compose` made this error reveal itself.

Basically the test was combining `up ... scale=0` with `run ...` which in effect would create two `mender-client` services. Although one will still be not running, the later logic to check that we have only one client would fail.

Moved also the TENANT_TOKEN to a shell variable because `up` command, unlike `run`, does not support `-e` options in the command line.