### PR TITLE
test: Remove `docker-compose` from tests requirements

### DIFF
--- a/tests/requirements/python-requirements.txt
+++ b/tests/requirements/python-requirements.txt
@@ -1,6 +1,5 @@
 cryptography==39.0.1
 docker==6.0.1
-docker-compose==1.29.2
 fabric==2.7.1
 filelock==3.9.0
 invoke==1.7.3
@@ -10,7 +9,6 @@ paramiko==2.12.0
 py3dns==3.2.1
 pymongo==4.3.3
 PyNaCl==1.5.0
-pyrsistent==0.19.3
 pytest==7.2.0
 pytest-forked==1.4.0
 pytest-html==3.2.0


### PR DESCRIPTION
Since Docker 20.10.15 release, the `docker:dind` image comes with `docker-compose` installed which basically is shadowing the version we later install with pip.

See related commit b5ac0e32b786e88aff9ef8be98e9f9ae8f024303.