### PR TITLE
fix: test: test_compat: UTC TZ does not need +hh:mm

### DIFF
--- a/tests/tests/test_compat.py
+++ b/tests/tests/test_compat.py
@@ -159,9 +159,9 @@ def assert_inventory_updated(api_inventory, num_devices, timeout=TIMEOUT):
             # datetime does not have an RFC3339 parser, but we can convert
             # the timestamp to a compatible ISO format by removing
             # fractions and replacing the Zulu timezone with GMT.
-            updated_ts = datetime.fromisoformat(
-                device["updated_ts"].split(".")[0] + "+00:00"
-            )
+            updated_ts = datetime.fromisoformat(device["updated_ts"].split(".")[0])
+            updated_ts = updated_ts.replace(tzinfo=timezone.utc)
+            update_after = update_after.replace(tzinfo=timezone.utc)
             if updated_ts > update_after:
                 num_updated += 1
             else:


### PR DESCRIPTION
```
#python3.11
Python 3.11.2 (main, Mar 30 2023, 07:21:54) [Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> '2023-07-12T11:51:57Z+00:00'
'2023-07-12T11:51:57Z+00:00'
>>> from datetime import datetime
>>>
>>> datetime.fromisoformat('2023-07-12T11:51:57Z+00:00')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Invalid isoformat string: '2023-07-12T11:51:57Z+00:00'
>>> datetime.fromisoformat('2023-07-12T11:51:57Z')
datetime.datetime(2023, 7, 12, 11, 51, 57, tzinfo=datetime.timezone.utc)
>>>
```

python 3.11 checks it.

while python 3.7 does not:

```
datetime.fromisoformatPython 3.7.16 (default, Mar 30 2023, 08:04:28)
[Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from datetime import datetime
>>> datetime.fromisoformat('2023-07-12T11:51:57Z+00:00')
datetime.datetime(2023, 7, 12, 11, 51, 57, tzinfo=datetime.timezone.utc)
```

how on earth does it pass, and fail only occasionally?

Changelog: Title
Ticket: None
Signed-off-by: Peter Grzybowski <peter@northern.tech>
(cherry picked from commit e5b429cd23bffa3e1130afd9585984870273a2a7)