### PR TITLE
feat: enabled http3 in traefik & the demo setup

### DIFF
--- a/config/traefik/static/traefik.demo.yaml
+++ b/config/traefik/static/traefik.demo.yaml
@@ -3,7 +3,7 @@
 #
 providers:
   file:
-    directory: "/etc/traefik/config"
+    directory: '/etc/traefik/config'
     watch: true
 
 experimental:
@@ -11,7 +11,7 @@ experimental:
 
 entryPoints:
   https:
-    address: ":443"
+    address: :443
     http3:
       advertisedPort: 443
     transport:
@@ -21,7 +21,7 @@ entryPoints:
         writeTimeout: 7200
 
   http:
-    address: ":80"
+    address: :80
     http:
       redirections:
         entryPoint:
@@ -32,3 +32,11 @@ entryPoints:
 accessLog:
   format: json
 
+api:
+  dashboard: true
+  insecure: true
+
+log:
+  level: DEBUG
+
+ping: {}

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -24,22 +24,9 @@ services:
     mender-api-gateway:
         ports:
             - 80:80
-            - 443:443
+            - 443:443/tcp
+            - 443:443/udp
             - 8080:8080
-        command:
-            - --accesslog=true
-            - --api.dashboard=true
-            - --api.insecure=true
-            - --entrypoints.http.address=:80
-            - --entrypoints.http.http.redirections.entryPoint.scheme=https
-            - --entrypoints.http.http.redirections.entryPoint.to=https
-            - --entrypoints.https.address=:443
-            - --entryPoints.https.transport.respondingTimeouts.idleTimeout=7200
-            - --entryPoints.https.transport.respondingTimeouts.readTimeout=7200
-            - --entryPoints.https.transport.respondingTimeouts.writeTimeout=7200
-            - --log.level=DEBUG
-            - --ping=true
-            - --providers.file.directory=/etc/traefik/config
         environment:
             MENDER_DEMO: "true"
             TRAEFIK_API: "true"
@@ -49,6 +36,7 @@ services:
                     - docker.mender.io
                     - s3.docker.mender.io
         volumes:
+            - ./config/traefik/static/traefik.demo.yaml:/etc/traefik/traefik.yaml:ro
             - ./config/traefik/traefik.tls.yaml:/etc/traefik/config/traefik.tls.yaml:ro
             - ./cert/cert.crt:/etc/traefik/certs/cert.crt
             - ./cert/private.key:/etc/traefik/certs/private.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,24 +57,15 @@ services:
     # mender-api-gateway
     #
     mender-api-gateway:
-        image: traefik:v2.8
+        image: traefik:v2.10
         extends:
             file: common.yml
             service: mender-base
-        # Enables the web UI and tells Traefik to listen to docker
-        command:
-            - --accesslog=true
-            - --entrypoints.http.address=:80
-            - --entrypoints.http.http.redirections.entryPoint.scheme=https
-            - --entrypoints.http.http.redirections.entryPoint.to=https
-            - --entrypoints.https.address=:443
-            - --entryPoints.https.transport.respondingTimeouts.idleTimeout=7200
-            - --entryPoints.https.transport.respondingTimeouts.readTimeout=7200
-            - --entryPoints.https.transport.respondingTimeouts.writeTimeout=7200
-            - --providers.file.directory=/etc/traefik/config
         volumes:
             # So that Traefik can listen to the Docker events
             - /var/run/docker.sock:/var/run/docker.sock:ro
+            # Static configuration file
+            - ./config/traefik/static/traefik.yaml:/etc/traefik/traefik.yaml:ro
             # Dynamic configuration files
             - ./config/traefik/traefik.yaml:/etc/traefik/config/traefik.yaml:ro
             - ./config/traefik/traefik.middlewares.yaml:/etc/traefik/config/traefik.middlewares.yaml:ro


### PR DESCRIPTION
- this allows decreasing the time taken to init the gui on load
+ also made traefik rely on the static config from a mounted file

Ticket: None
Changelog: None