### PR TITLE
smtpd workaround

### DIFF
--- a/extra/smtp-testing/smtp.mock.yml
+++ b/extra/smtp-testing/smtp.mock.yml
@@ -2,7 +2,7 @@ version: '2.3'
 services:
 
     local-smtp:
-        image: python
+        image: python:3.11.6
         environment:
             - PYTHONUNBUFFERED=1
         command: bash -c "mkdir -p /var/spool/mail; stdbuf -oL python -m smtpd -n -c DebuggingServer 0.0.0.0:1025 > /var/spool/mail/local"


### PR DESCRIPTION
In the python 3.12, smtpd package has been removed.
We need to migrate to aiosmtpd (QA-603), but for now,
as a workaround, we'll use python 3.11.6.
