### PR TITLE
test: Top timeouts to 10 minutes

### DIFF
--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -160,7 +160,7 @@ class Deployments:
         return json.loads(r.text)
 
     def check_expected_status(
-        self, expected_status, deployment_id, max_wait=60 * 60, polling_frequency=0.2
+        self, expected_status, deployment_id, max_wait=10 * 60, polling_frequency=0.2
     ):
         timeout = time.time() + max_wait
 
@@ -184,7 +184,7 @@ class Deployments:
         )
 
     def check_not_in_status(
-        self, expected_status, deployment_id, max_wait=60 * 60, polling_frequency=0.2
+        self, expected_status, deployment_id, max_wait=10 * 60, polling_frequency=0.2
     ):
         timeout = time.time() + max_wait
 
@@ -212,7 +212,7 @@ class Deployments:
         deployment_id,
         expected_status,
         expected_count,
-        max_wait=60 * 60,
+        max_wait=10 * 60,
         polling_frequency=0.2,
     ):
         timeout = time.time() + max_wait

--- a/tests/MenderAPI/devauth.py
+++ b/tests/MenderAPI/devauth.py
@@ -109,7 +109,7 @@ class DeviceAuthV2:
         assert r.status_code == requests.status_codes.codes.no_content
 
     def check_expected_status(
-        self, status, expected_value, max_wait=60 * 60, polling_frequency=1
+        self, status, expected_value, max_wait=10 * 60, polling_frequency=1
     ):
         timeout = time.time() + max_wait
         seen = set()

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -109,7 +109,7 @@ class BasicTestFaultTolerance(MenderTesting):
     def wait_for_download_retry_attempts(self, device, search_string):
         """ Block until logs contain messages related to failed download attempts """
 
-        timeout_time = int(time.time()) + (60 * 10)
+        timeout_time = int(time.time()) + (10 * 60)
 
         while int(time.time()) < timeout_time:
             output = device.run(

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -653,7 +653,7 @@ class BaseTestStateScripts(MenderTesting):
                 # wait until the last script has been run
                 logger.debug("Wait until the last script has been run")
                 script_logs = ""
-                timeout = time.time() + 60 * 60
+                timeout = time.time() + 10 * 60
                 while timeout >= time.time():
                     time.sleep(3)
                     try:
@@ -818,7 +818,7 @@ class BaseTestStateScripts(MenderTesting):
                     "for fd in /proc/`pgrep mender`/fdinfo/*; do echo $fd:; cat $fd; done",
                 ]
                 starttime = time.time()
-                while starttime + 60 * 60 >= time.time():
+                while starttime + 10 * 60 >= time.time():
                     output = mender_device.run(
                         "grep Error /data/test_state_scripts.log", warn_only=True
                     )

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -106,7 +106,7 @@ class MenderDevice:
 
         _put(self, file, local_path, remote_path)
 
-    def ssh_is_opened(self, wait=60 * 60):
+    def ssh_is_opened(self, wait=10 * 60):
         """Block until SSH connection is established on the device
 
         Keyword arguments:
@@ -238,7 +238,7 @@ class RebootDetector:
                 logger.info("Client has rebooted %d time(s)", reboot_count)
                 return True
 
-    def verify_reboot_performed(self, max_wait=60 * 60, number_of_reboots=1):
+    def verify_reboot_performed(self, max_wait=10 * 60, number_of_reboots=1):
         if self.server is None:
             raise RuntimeError(
                 "verify_reboot_performed() used outside of 'with' scope."
@@ -296,7 +296,7 @@ class MenderDeviceGroup:
             output_dict[dev.host_string] = output
         return output_dict
 
-    def ssh_is_opened(self, wait=60 * 60):
+    def ssh_is_opened(self, wait=10 * 60):
         """Block until SSH connection is established for all devices in group sequentially
 
         see MenderDevice.ssh_is_opened
@@ -359,9 +359,8 @@ def _put(device, file, local_path=".", remote_path="."):
             break
 
 
-# Roughly the execution time of the slowest test (*) times 3
-# (*) As per 2020-03-24 test_image_download_retry_hosts_broken takes 515.13 seconds
-_DEFAULT_WAIT_TIME = 25 * 60
+# TODO: Revisit this arbitrary value.
+_DEFAULT_WAIT_TIME = 10 * 60
 
 
 def _run(conn, cmd, **kw):


### PR DESCRIPTION
The one hours timeouts are ancient, they come from the Jenkins time. With such long timeouts, it is impossible to run the full suite when there are bugs in the software (the CI jobs will timeout after 8h and no results will be gathered).

My reasoning is that if a devices takes more than 10 minutes to respond to something, we have bugs in the software or we have such an overloaded CI that we might as well just abort.