### PR TITLE
MEN-6843: Modify test to accommodate behavior change

### DIFF
--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -92,14 +92,14 @@ class TestDeploymentAbortingOpenSource(BaseTestDeploymentAborting):
         self.abort_deployment(standard_setup_one_client_bootstrapped, valid_image)
 
     @MenderTesting.fast
-    @pytest.mark.skipif(
-        not (os.environ.get("NIGHTLY_BUILD", "false") == "true"), reason="MEN-6671",
-    )
     def test_deployment_abortion_downloading(
         self, standard_setup_one_client_bootstrapped, valid_image
     ):
         self.abort_deployment(
-            standard_setup_one_client_bootstrapped, valid_image, "downloading"
+            standard_setup_one_client_bootstrapped,
+            valid_image,
+            "downloading",
+            mender_performs_reboot=True,
         )
 
     @MenderTesting.fast


### PR DESCRIPTION
Since the removal of the update control maps, the new client won't check for the deployment status _after_ the download and _before_ reboot, so this test needs to expect a reboot and rollback before failing the deployment.