### PR TITLE
MEN-6671: White-list the missing test case from `test_state_scripts`

### DIFF
--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -703,11 +703,6 @@ class BaseTestStateScripts(MenderTesting):
         """Test that state scripts are executed in right order, and that errors
         are treated like they should."""
 
-        if description == "Corrupted_script_version_in_etc" and not (
-            os.environ.get("NIGHTLY_BUILD", "false") == "true"
-        ):
-            pytest.skip("MEN-6671")
-
         mender_device = env.device
         devauth = DeviceAuthV2(env.auth)
         deploy = Deployments(env.auth, devauth)


### PR DESCRIPTION
Specifically,
`test_state_scripts[Corrupted_script_version_in_etc-test_set11]`.

Fixed in:
* https://github.com/mendersoftware/mender/pull/1511