### PR TITLE
test(backend): Update backend test for ALV-213 edge case

### DIFF
--- a/backend-tests/tests/test_devauth.py
+++ b/backend-tests/tests/test_devauth.py
@@ -1038,7 +1038,7 @@ class TestAuthsetMgmtBase:
             change_authset_status(devauthm, dev.id, aset.id, "accepted", utoken)
 
             # in case of originally preauthd/accepted devs: the original authset must be rejected now
-            if dev.status in ["accepted", "preauthorized"]:
+            if dev.status in ["accepted"]:
                 aset_to_reject = [a for a in dev.authsets if a.status == dev.status]
                 assert len(aset_to_reject) == 1
                 aset_to_reject[0].status = "rejected"


### PR DESCRIPTION
There is one edge case in the backend integration test that covers one `pending` and one `preauthorized` auth sets where accepting the `pending` auth set will reject the `preauthorized` auth set. This is no longer the case. Only previously `accepted` auth sets are rejected.