### PR TITLE
test: Do not override `mender-iot-manager` image for backend-tests

### DIFF
--- a/backend-tests/docker/docker-compose.backend-tests.yml
+++ b/backend-tests/docker/docker-compose.backend-tests.yml
@@ -49,7 +49,6 @@ services:
             REPORTING_REV: ${REPORTING_REV}
 
     mender-iot-manager:
-        image: mendersoftware/iot-manager:mender-master
         environment:
           IOT_MANAGER_DOMAIN_WHITELIST: "*.azure-devices.net *.iot.*.amazonaws.com mender-backend-tests-runner"
 


### PR DESCRIPTION
I believe that the only intention of having the service in the testing docker-compose file is to set the environment variable.

Specifying here the `image` is wrong, as it will override what we have in the root compose files and hence not run the tests with the freshly build image of `iot-manager` from the PR.