### PR TITLE
ci: Pin integration tests image to Alpine 3.18

### DIFF
--- a/.gitlab-ci-default-pipeline.yml
+++ b/.gitlab-ci-default-pipeline.yml
@@ -99,7 +99,7 @@ test:integration-tests:requirements:
       - tests/requirements-system/apk-requirements.txt
       - tests/requirements-python/python-requirements.txt
   # Use same image as in mender-qa
-  image: docker:dind
+  image: docker:24.0.7-dind-alpine3.18
   script:
     # Get and install the integration test requirements
     - apk add $(cat tests/requirements-system/apk-requirements.txt)


### PR DESCRIPTION
Which still provides an OpenSSL 1.1 compatibility package, required for `mender-artifact`.