### PR TITLE
chore: Switch back `mender` version to `master`

### DIFF
--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -102,15 +102,13 @@ def test_version_of(capsys, is_master):
 
     # Querying mender with version-type docker should error, since it maps to
     # multiple containers and we don't know which one to choose.
-    run_main_assert_result(capsys, ["--version-of", "mender"], "feature-c++-client")
+    run_main_assert_result(capsys, ["--version-of", "mender"], "master")
     with pytest.raises(Exception):
         run_main_assert_result(
             capsys, ["--version-of", "mender", "--version-type", "docker"], "master"
         )
     run_main_assert_result(
-        capsys,
-        ["--version-of", "mender", "--version-type", "git"],
-        "feature-c++-client",
+        capsys, ["--version-of", "mender", "--version-type", "git"], "master",
     )
 
     # For an independent component, it should also error because it doesn't have

--- a/git-versions.yml
+++ b/git-versions.yml
@@ -47,7 +47,7 @@ services:
     # client repositories - container and image names are placeholders
     #
     mender:
-        image: mendersoftware/mender:feature-c++-client
+        image: mendersoftware/mender:master
 
     mender-connect:
         image: mendersoftware/mender-connect:master


### PR DESCRIPTION
The feature branch has already been merged.