### PR TITLE
fix: Update `mender-client-docker-addons` image for C++ client

### DIFF
--- a/extra/mender-client-docker-addons/Dockerfile
+++ b/extra/mender-client-docker-addons/Dockerfile
@@ -30,8 +30,8 @@ RUN (cd /src/mender-configure-module && \
 RUN mkdir --parents /mender-install/etc/mender
 
 WORKDIR /src/mender
-RUN if [ -f CMakeLists.txt ]; then cmake -D MENDER_NO_BUILD=1 -S .; fi
-RUN DESTDIR=/mender-install make prefix=/usr install
+RUN cmake -D CMAKE_INSTALL_PREFIX:PATH=/usr -S .
+RUN DESTDIR=/mender-install make --jobs=$(nproc --all) install
 RUN jq ".ServerCertificate=\"/usr/share/doc/mender-client/examples/demo.crt\" | .ServerURL=\"https://docker.mender.io/\"" \
     < examples/mender.conf.demo > /mender-install/etc/mender/mender.conf
 

--- a/extra/mender-client-docker-addons/entrypoint.sh
+++ b/extra/mender-client-docker-addons/entrypoint.sh
@@ -26,7 +26,9 @@ fi
 cp /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf /etc/dbus-1/system-local.conf
 dbus-daemon --nofork --nopidfile --system &
 sleep 8
-mender --no-syslog daemon &
+mender-auth daemon &
+sleep 1
+mender-update daemon &
 sleep 8
 mender-connect daemon &
 while true; do sleep 10; done


### PR DESCRIPTION
There are three fixes:
* Actually build the binaries (removing `MENDER_NO_BUILD`). We need the binaries in the final image, we don't know what the author of 394d99ab was thinking
* Set install prefix to `/usr` when configuring with CMake. Otherwise it would default to `/usr/local`. See: https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html
* Call the new binaries from the `entrypoint.sh` script.

And some optimizations:
* Remove conditional check for `CMakeLists.txt` and assume always new client (as we have done for the tests, for example). Note that `integration` repository is versioned so it will always follow _one_ version of the client.
* Run as many jobs in parallel with `make`.

Changelog: None
Ticket: None