### PR TITLE
chore: migrated smtpd to aiosmtpd

### DIFF
--- a/tests/requirements-python/python-requirements.in
+++ b/tests/requirements-python/python-requirements.in
@@ -19,3 +19,4 @@ urllib3==1.26.18
 websockets==12.0
 flaky==3.7.0
 stripe==7.10.0
+aiosmtpd==1.4.4.post2

--- a/tests/requirements-python/python-requirements.txt
+++ b/tests/requirements-python/python-requirements.txt
@@ -4,6 +4,12 @@
 #
 #    pip-compile python-requirements.in
 #
+aiosmtpd==1.4.4.post2
+    # via -r python-requirements.in
+atpublic==4.0
+    # via aiosmtpd
+attrs==23.2.0
+    # via aiosmtpd
 bcrypt==4.0.1
     # via paramiko
 cachetools==5.3.1


### PR DESCRIPTION
Smtpd is fully removed in python3.12.
Moved from smtpd and asyncore to aiosmtpd.

Ticket: QA-603