### PR TITLE
feat(mender-connect): New test for poor connectivity environments

### DIFF
--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -191,6 +191,51 @@ class _TestRemoteTerminalBase:
             assert prot.protoType == proto_shell.PROTO_TYPE_SHELL
             assert prot.typ == "bogusmessage"
 
+    @pytest.mark.xfail(reason="CE-277")
+    def test_in_poor_network_environment(self, docker_env):
+        self.assert_env(docker_env)
+
+        receive_timeout_s = 16
+
+        def is_shell_is_working(shell):
+            # Test if a simple command works.
+            shell.sendInput("ls /\n".encode())
+            output = shell.recvOutput(receive_timeout_s)
+            assert shell.protomsg.props["status"] == protomsg.PROP_STATUS_NORMAL
+            output = output.decode()
+            assert "usr" in output
+            assert "etc" in output
+
+        with docker_env.devconnect.get_websocket() as ws:
+            shell = proto_shell.ProtoShell(ws)
+            body = shell.startShell()
+            assert shell.protomsg.props["status"] == protomsg.PROP_STATUS_NORMAL
+            assert body == proto_shell.MSG_BODY_SHELL_STARTED
+
+            # Drain any initial output from the prompt. It should end in either "# "
+            # (root) or "$ " (user).
+            output = shell.recvOutput(receive_timeout_s)
+            assert shell.protomsg.props["status"] == protomsg.PROP_STATUS_NORMAL
+            assert output[-2:].decode() in [
+                "# ",
+                "$ ",
+            ], "Could not detect shell prompt."
+
+            is_shell_is_working(shell)
+
+            docker_env.device.run(
+                "iptables -A OUTPUT -j DROP --destination docker.mender.io"
+            )
+
+            # Plenty of time for the session to mess up
+            time.sleep(60)
+
+            # Re-enable a good connection
+            docker_env.device.run("iptables -D OUTPUT 1")
+
+            time.sleep(30)
+            is_shell_is_working(shell)
+
     def test_session_recording(self, docker_env):
         self.assert_env(docker_env)
 


### PR DESCRIPTION
Mind you, this although it might look right (and I believe it should be), fails in both instances, since the ping-pong handler does not seem to be working:

```
time="2024-01-05T13:18:59Z" level=trace msg="messageLoop: called readMessage: &{{1 shell 0464b56d-e245-4c17-aeff-3a533ad948ac map[user_id:3f5f877e-78ae-4e85-80c2-55599f145dc2]} [108 115 32 47 10]},<nil>"
time="2024-01-05T13:18:59Z" level=trace msg="got message: type:shell data length:5"
time="2024-01-05T13:18:59Z" level=debug msg="executed: 'ls /\n'"
time="2024-01-05T13:18:59Z" level=trace msg="messageLoop: calling readMessage"
time="2024-01-05T13:19:09Z" level=trace msg="dbusEventLoop: WaitForJwtTokenStateChange [], err timeout waiting for signal JwtTokenStateChange"
time="2024-01-05T13:19:20Z" level=trace msg="dbusEventLoop: WaitForJwtTokenStateChange [], err timeout waiting for signal JwtTokenStateChange"
time="2024-01-05T13:19:30Z" level=debug msg="PingHandler called"
time="2024-01-05T13:19:30Z" level=debug msg="ping message"
time="2024-01-05T13:19:30Z" level=debug msg="PongHandler called"
time="2024-01-05T13:19:31Z" level=trace msg="dbusEventLoop: WaitForJwtTokenStateChange [], err timeout waiting for signal JwtTokenStateChange"
time="2024-01-05T13:19:42Z" level=trace msg="dbusEventLoop: WaitForJwtTokenStateChange [], err timeout waiting for signal JwtTokenStateChange"
time="2024-01-05T13:19:43Z" level=debug msg="session 0464b56d-e245-4c17-aeff-3a533ad948ac healthcheck ping"
time="2024-01-05T13:19:48Z" level=error msg="session 0464b56d-e245-4c17-aeff-3a533ad948ac, health check failed, connection with the client lost"
time="2024-01-05T13:19:53Z" level=trace msg="dbusEventLoop: WaitForJwtTokenStateChange [], err timeout waiting for signal JwtTokenStateChange"
time="2024-01-05T13:20:03Z" level=trace msg="webSock.ReadMessage()=&{Header:{Proto:1 MsgType:stop SessionID:0464b56d-e245-4c17-aeff-3a533ad948ac Properties:map[status:2 user_id:3f5f877e-78ae-4e85-80c2-55599f145dc2]} Body:[117 115 101 114 32 100 105 115 99 111 110 110 101 99 116 101 100]},<nil>"
time="2024-01-05T13:20:03Z" level=trace msg="messageLoop: called readMessage: &{{1 stop 0464b56d-e245-4c17-aeff-3a533ad948ac map[status:2 user_id:3f5f877e-78ae-4e85-80c2-55599f145dc2]} [117 115 101 114 32 100 105 115 99 111 110 110 101 99 116 101 100]},<nil>"
time="2024-01-05T13:20:03Z" level=trace msg="got message: type:stop data length:17"
time="2024-01-05T13:20:03Z" level=info msg="session 0464b56d-e245-4c17-aeff-3a533ad948ac status:0 stopping shell"
time="2024-01-05T13:20:04Z" level=trace msg="dbusEventLoop: WaitForJwtTokenStateChange [], err timeout waiting for signal JwtTokenStateChange"
time="2024-01-05T13:20:07Z" level=trace msg="responseMessage: webSock.WriteMessage(&{Header:{Proto:1 MsgType:stop SessionID:0464b56d-e245-4c17-aeff-3a533ad948ac Properties:map[status:1]} Body:[]})"
time="2024-01-05T13:20:07Z" level=trace msg="messageLoop: calling readMessage"
time="2024-01-05T13:20:15Z" level=trace msg="dbusEventLoop: WaitForJwtTokenStateChange [], err timeout waiting for signal JwtTokenStateChange"
time="2024-01-05T13:20:24Z" level=debug msg="ping message"
time="2024-01-05T13:20:24Z" level=debug msg="PongHandler called"
^[time="2024-01-05T13:20:26Z" level=trace msg="dbusEventLoop: WaitForJwtTokenStateChange [], err timeout waiting for signal JwtTokenStateChange"
```

Although we see that the `PongHandler` is called. However, the health-check relies on some `wsshell.MessageTypePongShell`. 

And, yeh. I dunno what is going on at this point.