### PR TITLE
chore: moved setup specific for certain tests from run.sh to pytest fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Northern.tech AS
+# Copyright 2024 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ import os
 import subprocess
 import shutil
 import tempfile
+import yaml
 from distutils.version import LooseVersion
 
 import filelock
 import pytest
+from filelock import FileLock
 from testutils.infra.container_manager.base import BaseContainerManagerNamespace
 from testutils.infra.device import MenderDevice, MenderDeviceGroup
 
@@ -55,9 +57,142 @@ def pytest_addoption(parser):
     )
 
 
+def _remove_ports(file, output_file):
+    with open(file, "r") as f, open(output_file, "w") as out:
+        file = yaml.safe_load(f)
+        for key in file["services"]:
+            services = file["services"][key]
+            if services.get("ports", False):
+                del services["ports"]
+        yaml.safe_dump(file, out, sort_keys=False)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def modify_compose_for_testing(request):
+    demo = "../docker-compose.demo.yml"
+    storage_proxy_demo = "../storage-proxy/docker-compose.storage-proxy.demo.yml"
+    # Output files after modifying for testing
+    testing = "../docker-compose.testing.yml"
+    storage_proxy_testing = "../storage-proxy/docker-compose.storage-proxy.testing.yml"
+
+    # Remove published ports from docker-compose-demo
+    _remove_ports(demo, testing)
+    # Remove published ports from docker-compose.storage-proxy.demo
+    _remove_ports(storage_proxy_demo, storage_proxy_testing)
+
+
+def _extract_fs_from_image(request, client_compose_file, filename):
+    if os.path.exists(os.path.join(THIS_DIR, filename)):
+        return filename
+    d = os.path.join(THIS_DIR, "output")
+    image_type = "mender-client"
+    if "gateway" in client_compose_file:
+        image_type = "mender-gateway"
+
+    with open(client_compose_file) as f:
+        data = yaml.safe_load(f)
+        image = data["services"][image_type]["image"]
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--privileged",
+            "--entrypoint",
+            "/extract_fs",
+            "--volume",
+            d + ":/output",
+            image,
+        ]
+    )
+
+    if not os.path.exists(os.path.join(THIS_DIR, filename)):
+        shutil.copy(os.path.join(d, filename), THIS_DIR)
+
+    def cleanup():
+        shutil.rmtree(d, ignore_errors=True)
+
+    request.addfinalizer(cleanup)
+
+    return filename
+
+
+def _image(request, compose_file, filename):
+    return _extract_fs_from_image(
+        request, os.path.join(THIS_DIR, "..", compose_file), filename
+    )
+
+
+# https://pytest-xdist.readthedocs.io/en/latest/how-to.html#making-session-scoped-fixtures-execute-only-once
+def run_if_non_existent(request, tmp_path_factory, compose_file, filename):
+    """
+    Makes session scoped fixtures only run once
+    to avoid conflict while running multiple workers with xdist
+    """
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    file_lock = root_tmp_dir / filename
+
+    with FileLock(f"{file_lock}.lock"):
+        if file_lock.is_file() and os.path.exists(os.path.join(THIS_DIR, filename)):
+            return filename
+    return _image(request, compose_file, filename)
+
+
 @pytest.fixture(scope="session")
-def valid_image(request):
-    return "core-image-full-cmdline-%s.ext4" % machine_name
+def valid_image(request, tmp_path_factory, worker_id):
+    compose_file = "docker-compose.client.yml"
+    filename = f"core-image-full-cmdline-{machine_name}.ext4"
+
+    if worker_id == "master":
+        return filename
+
+    return run_if_non_existent(request, tmp_path_factory, compose_file, filename)
+
+
+@pytest.fixture(scope="session")
+def gateway_image(request, tmp_path_factory, worker_id):
+    compose_file = "docker-compose.mender-gateway.commercial.yml"
+    filename = f"mender-gateway-image-full-cmdline-{machine_name}.ext4"
+
+    if worker_id == "master":
+        return filename
+
+    return run_if_non_existent(request, tmp_path_factory, compose_file, filename)
+
+
+def _special_image(request, image, command):
+    subprocess.run(command, check=True)
+    return image
+
+
+@pytest.fixture(scope="session")
+def broken_network_image(request, valid_image):
+    image = f"core-image-full-cmdline-{machine_name}-broken-network.ext4"
+    shutil.copy(valid_image, image)
+    return _special_image(
+        request,
+        image,
+        ["debugfs", "-w", "-R", "rm /lib/systemd/systemd-networkd", image],
+    )
+
+
+@pytest.fixture(scope="session")
+def large_image(request):
+    return _special_image(
+        request,
+        "large_image.dat",
+        ["dd", "if=/dev/zero", "of=large_image.dat", "bs=300M", "count=1"],
+    )
+
+
+@pytest.fixture(scope="session")
+def broken_update_image(request):
+    return _special_image(
+        request,
+        "broken_update.ext4",
+        ["dd", "if=/dev/urandom", "of=broken_update.ext4", "bs=10M", "count=5"],
+    )
 
 
 def add_mender_conf_to_image(image, d, mender_conf):
@@ -98,7 +233,7 @@ def add_mender_conf_to_image(image, d, mender_conf):
     return new_image
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def valid_image_with_mender_conf(request, valid_image):
     """Insert the given mender_conf into a valid_image"""
     with tempfile.TemporaryDirectory() as d:
@@ -112,7 +247,13 @@ def valid_image_with_mender_conf(request, valid_image):
 
 @pytest.fixture(scope="session")
 def valid_image_rofs_with_mender_conf(request):
-    valid_image = "mender-image-full-cmdline-rofs-%s.ext4" % machine_name
+
+    valid_image = _image(
+        request,
+        "docker-compose.client.rofs.yml",
+        f"mender-image-full-cmdline-rofs-{machine_name}.ext4",
+    )
+
     if not os.path.exists(valid_image):
         yield None
         return
@@ -128,7 +269,13 @@ def valid_image_rofs_with_mender_conf(request):
 
 @pytest.fixture(scope="session")
 def valid_image_rofs_commercial_with_mender_conf(request):
-    valid_image = "mender-image-full-cmdline-rofs-commercial-%s.ext4" % machine_name
+
+    valid_image = _image(
+        request,
+        "docker-compose.client.rofs.commercial.yml",
+        f"mender-image-full-cmdline-rofs-commercial-{machine_name}.ext4",
+    )
+
     if not os.path.exists(valid_image):
         yield None
         return

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -90,10 +90,6 @@ function modify_services_for_testing() {
     # Remove all published ports for testing
     sed -e '/9000:9000/d' -e '/8080:8080/d' -e '/443:443/d' -e '/80:80/d' -e '/ports:/d' ../docker-compose.demo.yml > ../docker-compose.testing.yml
     sed -e '/9000:9000/d' -e '/ports:/d' ../storage-proxy/docker-compose.storage-proxy.demo.yml > ../storage-proxy/docker-compose.storage-proxy.testing.yml
-    # disable download speed limits
-    sed -e 's/DOWNLOAD_SPEED/#DOWNLOAD_SPEED/' -i ../docker-compose.testing.yml
-    # whitelist *all* IPs/DNS names in the gateway (will be accessed via dynamically assigned IP in tests)
-    sed -e 's/ALLOWED_HOSTS: .*/ALLOWED_HOSTS: ~./' -i ../docker-compose.testing.yml
 }
 
 function inject_pre_generated_ssh_keys() {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -86,13 +86,6 @@ echo "Detected Mender branch: $MENDER_BRANCH"
 echo "Detected mender-artifact branch: $MENDER_ARTIFACT_BRANCH"
 echo "Detected mender-cli branch: $MENDER_CLI_BRANCH"
 
-function inject_pre_generated_ssh_keys() {
-    ssh-keygen -f /tmp/mender-id_rsa -t rsa -N ''
-    printf "cd /home/root/\nmkdir .ssh\ncd .ssh\nwrite /tmp/mender-id_rsa.pub id_rsa.pub\nwrite /tmp/mender-id_rsa id_rsa\n" | debugfs -w core-image-full-cmdline-$MACHINE_NAME.ext4
-    rm /tmp/mender-id_rsa.pub
-    rm /tmp/mender-id_rsa
-}
-
 function get_requirements() {
     # Download what we need.
     mkdir -p downloaded-tools

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -104,7 +104,7 @@ class BaseTestBasicIntegration(MenderTesting):
         )
 
     def do_test_failed_updated_and_valid_update(
-        self, env, valid_image_with_mender_conf
+        self, env, valid_image_with_mender_conf, broken_update_image
     ):
         """Upload a device with a broken image, followed by a valid image"""
         devauth = DeviceAuthV2(env.auth)
@@ -345,10 +345,15 @@ class TestBasicIntegrationOpenSource(BaseTestBasicIntegration):
 
     @MenderTesting.fast
     def test_failed_updated_and_valid_update(
-        self, standard_setup_one_client_bootstrapped, valid_image_with_mender_conf
+        self,
+        standard_setup_one_client_bootstrapped,
+        valid_image_with_mender_conf,
+        broken_update_image,
     ):
         self.do_test_failed_updated_and_valid_update(
-            standard_setup_one_client_bootstrapped, valid_image_with_mender_conf
+            standard_setup_one_client_bootstrapped,
+            valid_image_with_mender_conf,
+            broken_update_image,
         )
 
     def test_update_no_compression(
@@ -402,10 +407,15 @@ class TestBasicIntegrationEnterprise(BaseTestBasicIntegration):
 
     @MenderTesting.fast
     def test_failed_updated_and_valid_update(
-        self, enterprise_one_client_bootstrapped, valid_image_with_mender_conf
+        self,
+        enterprise_one_client_bootstrapped,
+        valid_image_with_mender_conf,
+        broken_update_image,
     ):
         self.do_test_failed_updated_and_valid_update(
-            enterprise_one_client_bootstrapped, valid_image_with_mender_conf
+            enterprise_one_client_bootstrapped,
+            valid_image_with_mender_conf,
+            broken_update_image,
         )
 
     def test_update_no_compression(

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -127,7 +127,7 @@ class BasicTestFaultTolerance(MenderTesting):
         logger.info("Waiting for system to finish download")
 
     def do_test_update_image_breaks_networking(
-        self, env, install_image,
+        self, env, broken_network_image,
     ):
         """
         Install an image without systemd-networkd binary existing.
@@ -143,7 +143,7 @@ class BasicTestFaultTolerance(MenderTesting):
         host_ip = env.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot:
             deployment_id, _ = common_update_procedure(
-                install_image, devauth=devauth, deploy=deploy
+                broken_network_image, devauth=devauth, deploy=deploy
             )
             reboot.verify_reboot_performed()  # since the network is broken, two reboots will be performed, and the last one will be detected
             deploy.check_expected_statistics(deployment_id, "failure", 1)
@@ -361,13 +361,10 @@ class BasicTestFaultTolerance(MenderTesting):
 class TestFaultToleranceOpenSource(BasicTestFaultTolerance):
     @MenderTesting.slow
     def test_update_image_breaks_networking(
-        self, standard_setup_one_client_bootstrapped,
+        self, standard_setup_one_client_bootstrapped, broken_network_image,
     ):
-        install_image = (
-            "core-image-full-cmdline-%s-broken-network.ext4" % conftest.machine_name
-        )
         self.do_test_update_image_breaks_networking(
-            standard_setup_one_client_bootstrapped, install_image
+            standard_setup_one_client_bootstrapped, broken_network_image,
         )
 
     @MenderTesting.slow
@@ -405,13 +402,10 @@ class TestFaultToleranceOpenSource(BasicTestFaultTolerance):
 class TestFaultToleranceEnterprise(BasicTestFaultTolerance):
     @MenderTesting.slow
     def test_update_image_breaks_networking(
-        self, enterprise_one_client_bootstrapped,
+        self, enterprise_one_client_bootstrapped, broken_network_image,
     ):
-        install_image = (
-            "core-image-full-cmdline-%s-broken-network.ext4" % conftest.machine_name
-        )
         self.do_test_update_image_breaks_networking(
-            enterprise_one_client_bootstrapped, install_image
+            enterprise_one_client_bootstrapped, broken_network_image,
         )
 
     @MenderTesting.slow

--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -56,7 +56,7 @@ class BaseTestFailures(MenderTesting):
         deploy.check_expected_status("finished", deployment_id)
 
     @MenderTesting.fast
-    def do_test_large_update_image(self, env):
+    def do_test_large_update_image(self, env, large_image):
         """Installing an image larger than the passive/active partition size should result in a failure."""
 
         mender_device = env.device
@@ -66,7 +66,7 @@ class BaseTestFailures(MenderTesting):
         host_ip = env.get_virtual_network_host_ip()
         with mender_device.get_reboot_detector(host_ip) as reboot:
             deployment_id, _ = common_update_procedure(
-                install_image="large_image.dat",
+                install_image=large_image,
                 # We use verify_status=False because the device is very quick in reporting
                 # failure and the test framework might miss the 'inprogress' status transition.
                 verify_status=False,
@@ -88,8 +88,12 @@ class TestFailuresOpenSource(BaseTestFailures):
         )
 
     @MenderTesting.fast
-    def test_large_update_image(self, standard_setup_one_client_bootstrapped):
-        self.do_test_large_update_image(standard_setup_one_client_bootstrapped)
+    def test_large_update_image(
+        self, standard_setup_one_client_bootstrapped, large_image
+    ):
+        self.do_test_large_update_image(
+            standard_setup_one_client_bootstrapped, large_image
+        )
 
 
 class TestFailuresOpenEnterprise(BaseTestFailures):
@@ -102,5 +106,5 @@ class TestFailuresOpenEnterprise(BaseTestFailures):
         )
 
     @MenderTesting.fast
-    def test_large_update_image(self, enterprise_one_client_bootstrapped):
-        self.do_test_large_update_image(enterprise_one_client_bootstrapped)
+    def test_large_update_image(self, enterprise_one_client_bootstrapped, large_image):
+        self.do_test_large_update_image(enterprise_one_client_bootstrapped, large_image)

--- a/tests/tests/test_legacy_golang_update.py
+++ b/tests/tests/test_legacy_golang_update.py
@@ -53,7 +53,7 @@ class BaseTestLegacyGolangUpdate(MenderTesting):
         )
 
     def do_test_migrate_from_legacy_mender_v3_failure(
-        self, env, valid_image,
+        self, env, valid_image, broken_update_image,
     ):
         """
         Start a legacy client (3.6 bundle, the last golang client) and do one failed update followed
@@ -93,10 +93,10 @@ class TestLegacyGolangUpdateOpenSource(BaseTestLegacyGolangUpdate):
         )
 
     def test_migrate_from_legacy_mender_v3_failure(
-        self, setup_with_legacy_v3_client, valid_image
+        self, setup_with_legacy_v3_client, valid_image, broken_update_image,
     ):
         self.do_test_migrate_from_legacy_mender_v3_failure(
-            setup_with_legacy_v3_client, valid_image
+            setup_with_legacy_v3_client, valid_image, broken_update_image,
         )
 
 
@@ -112,11 +112,16 @@ class TestLegacyGolangUpdateEnterprise(BaseTestLegacyGolangUpdate):
         )
 
     def test_migrate_from_legacy_mender_v3_failure(
-        self, enterprise_with_legacy_v3_client, valid_image_with_mender_conf
+        self,
+        enterprise_with_legacy_v3_client,
+        valid_image_with_mender_conf,
+        broken_update_image,
     ):
         mender_conf = enterprise_with_legacy_v3_client.device.run(
             "cat /etc/mender/mender.conf"
         )
         self.do_test_migrate_from_legacy_mender_v3_failure(
-            enterprise_with_legacy_v3_client, valid_image_with_mender_conf(mender_conf)
+            enterprise_with_legacy_v3_client,
+            valid_image_with_mender_conf(mender_conf),
+            broken_update_image,
         )

--- a/tests/tests/test_mender_gateway.py
+++ b/tests/tests/test_mender_gateway.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2024 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ def add_mender_conf_and_mender_gateway_conf(d, image, mender_conf, mender_gatewa
         f.write(mender_gateway_conf)
     new_image = os.path.join(d, image)
     shutil.copy(image, new_image)
+
     instr_file = os.path.join(d, "write.instr")
     with open(os.path.join(d, "write.instr"), "w") as f:
         f.write(
@@ -119,6 +120,7 @@ class BaseTestMenderGateway(MenderTesting):
         env,
         valid_image_with_mender_conf,
         image_with_mender_conf_and_mender_gateway_conf,
+        gateway_image,
     ):
         mender_device = env.device
         mender_gateway = env.device_gateway
@@ -139,9 +141,7 @@ class BaseTestMenderGateway(MenderTesting):
         )
 
         mender_gateway_image = image_with_mender_conf_and_mender_gateway_conf(
-            "mender-gateway-image-full-cmdline-%s.ext4" % conftest.machine_name,
-            mender_gateway_mender_conf,
-            mender_gateway_gateway_conf,
+            gateway_image, mender_gateway_mender_conf, mender_gateway_gateway_conf,
         )
 
         def update_device():
@@ -263,7 +263,7 @@ class BaseTestMenderGateway(MenderTesting):
         deploy.check_expected_status("finished", deployment_id_2)
 
     def do_test_deployment_two_devices_parallel_updates_one_failure(
-        self, env, valid_image_with_mender_conf
+        self, env, valid_image_with_mender_conf, broken_update_image,
     ):
         device_group = env.device_group
         mender_device_1 = device_group[0]
@@ -288,7 +288,7 @@ class BaseTestMenderGateway(MenderTesting):
             )
 
             deployment_id_2, expected_image_id_2 = common_update_procedure(
-                "broken_update.ext4",
+                broken_update_image,
                 devices=[device_id_2],
                 devauth=devauth,
                 deploy=deploy,
@@ -443,11 +443,13 @@ class TestMenderGatewayOpenSource(BaseTestMenderGateway):
         standard_setup_one_client_bootstrapped_with_gateway,
         valid_image_with_mender_conf,
         image_with_mender_conf_and_mender_gateway_conf,
+        gateway_image,
     ):
         self.do_test_deployment_gateway_and_one_device(
             standard_setup_one_client_bootstrapped_with_gateway,
             valid_image_with_mender_conf,
             image_with_mender_conf_and_mender_gateway_conf,
+            gateway_image,
         )
 
     @flaky(max_runs=3)
@@ -492,10 +494,12 @@ class TestMenderGatewayOpenSource(BaseTestMenderGateway):
         self,
         standard_setup_two_clients_bootstrapped_with_gateway,
         valid_image_with_mender_conf,
+        broken_update_image,
     ):
         self.do_test_deployment_two_devices_parallel_updates_one_failure(
             standard_setup_two_clients_bootstrapped_with_gateway,
             valid_image_with_mender_conf,
+            broken_update_image,
         )
 
     @flaky(max_runs=3)
@@ -543,11 +547,13 @@ class TestMenderGatewayEnterprise(BaseTestMenderGateway):
         enterprise_one_client_bootstrapped_with_gateway,
         valid_image_with_mender_conf,
         image_with_mender_conf_and_mender_gateway_conf,
+        gateway_image,
     ):
         self.do_test_deployment_gateway_and_one_device(
             enterprise_one_client_bootstrapped_with_gateway,
             valid_image_with_mender_conf,
             image_with_mender_conf_and_mender_gateway_conf,
+            gateway_image,
         )
 
     @flaky(max_runs=3)
@@ -592,10 +598,12 @@ class TestMenderGatewayEnterprise(BaseTestMenderGateway):
         self,
         enterprise_two_clients_bootstrapped_with_gateway,
         valid_image_with_mender_conf,
+        broken_update_image,
     ):
         self.do_test_deployment_two_devices_parallel_updates_one_failure(
             enterprise_two_clients_bootstrapped_with_gateway,
             valid_image_with_mender_conf,
+            broken_update_image,
         )
 
     @flaky(max_runs=3)


### PR DESCRIPTION

Removes the setup of unnecessary files when running the run.sh wrapper script. Special images are now created when needed.

Ticket: QA-649