### PR TITLE
MEN-6888: Re-enable (and modify) `test_in_poor_network_environment`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,6 +253,7 @@ def pytest_exception_interact(node, call, report):
                 "mender-connect",
                 "mender-monitor",
                 "mender-gateway",
+                "mender-client",
             ]:
                 try:
                     logger.info("Printing %s systemd log, if possible:" % service)

--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -363,7 +363,7 @@ class _TestRemoteTerminalBaseBogusProtoMessage:
             assert isinstance(body.get("err"), str) and len(body.get("err")) > 0
 
 
-class TestRemoteTerminal(
+class TestRemoteTerminalOpenSource(
     _TestRemoteTerminalBase, _TestRemoteTerminalBaseBogusProtoMessage
 ):
     @pytest.fixture(scope="class")

--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -197,7 +197,7 @@ class _TestRemoteTerminalBase:
 
         receive_timeout_s = 16
 
-        def is_shell_is_working(shell):
+        def is_shell_working(shell):
             # Test if a simple command works.
             shell.sendInput("ls /\n".encode())
             output = shell.recvOutput(receive_timeout_s)
@@ -221,7 +221,7 @@ class _TestRemoteTerminalBase:
                 "$ ",
             ], "Could not detect shell prompt."
 
-            is_shell_is_working(shell)
+            is_shell_working(shell)
 
             docker_env.device.run(
                 "iptables -A OUTPUT -j DROP --destination docker.mender.io"
@@ -234,7 +234,7 @@ class _TestRemoteTerminalBase:
             docker_env.device.run("iptables -D OUTPUT 1")
 
             time.sleep(30)
-            is_shell_is_working(shell)
+            is_shell_working(shell)
 
     @flaky(max_runs=3)
     def test_session_recording(self, docker_env):


### PR DESCRIPTION
    The original test design assumed that `mender-connect` could reuse the
    same TCP connection after the network is restored. However, the
    `http-forwarder` in the Mender client (`mender` or `mender-auth`) do
    close the TCP connection when we mess it up with `iptables`.
    
    Modify the test to expect `mender-connect` to be able to open a new
    shell after the connection is restored, which is evidence that it can
    "auto-heal" after a network disruption.
    
    `mender-connect` 2.2.0 and older do not pass this test due to MEN-6888.
    It is fixed now at:
    * https://github.com/mendersoftware/mender-connect/pull/130
