### PR TITLE
Removed duplicated minio network

### DIFF
--- a/demo
+++ b/demo
@@ -252,6 +252,8 @@ start_server() {
             sleep 1
         done
     done
+    # Sleep some seconds more to further waiting for the useradm service
+    sleep 5
 }
 
 create_user() {

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -67,10 +67,6 @@ services:
             - mender-mongo
 
     minio:
-        networks:
-            mender:
-                aliases:
-                    - minio.s3.docker.mender.io
         environment:
             MINIO_ACCESS_KEY: minio
             MINIO_SECRET_KEY: minio123


### PR DESCRIPTION
This duplication prevents the newest docker compose versions to startup the demo job.
The network is already defined [here](https://github.com/mendersoftware/integration/blob/master/docker-compose.storage.minio.yml#L15).
With docker compose plugin, version 2.24, you got:
```
▶ ./demo up
Starting the Mender demo environment...
validating /home/giova/src/github/mendersoftware/worktrees/integration/master/docker-compose.demo.yml: services.minio.networks.mender.aliases array items[0,1] must be unique
Failed to start docker compose
```

Ticket: QA-660
Changelog: None