### PR TITLE
test: Stop running with capture=no so the test runner captures it.

### DIFF
--- a/backend-tests/tests/run.sh
+++ b/backend-tests/tests/run.sh
@@ -38,4 +38,4 @@ fi
 
 chmod 755 /usr/local/bin/mender-artifact
 
-python3 -m pytest -v -s /tests/test_*.py $PYTEST_EXTRA_ARGS "$@"
+python3 -m pytest -v /tests/test_*.py $PYTEST_EXTRA_ARGS "$@"

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -6,7 +6,6 @@
 #  see https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#tls-warnings
 [pytest]
 addopts =
-    --capture=no
     -W ignore::DeprecationWarning:invoke.loader
     -W ignore::urllib3.exceptions.InsecureRequestWarning:urllib3.connectionpool
 #


### PR DESCRIPTION
Then we can see the output localized to each test instead, both in the log and in HTML output.

This is only possible because Fabric has been removed.