### PR TITLE
test: disable backoff for monitor-client test

### DIFF
--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -1580,6 +1580,8 @@ class TestMonitorClientEnterprise:
             + "/' "
             + "-e 's/DEFAULT_ALERT_STORE_RESEND_INTERVAL_S=.*/DEFAULT_ALERT_STORE_RESEND_INTERVAL_S="
             + str(alert_resend_interval_s)
+            + "/' "
+            + "-e 's/SEND_ALERT_MAX_INTERVAL_S=.*/SEND_ALERT_MAX_INTERVAL_S=0"
             + "/' /usr/share/mender-monitor/config/config.sh"
         )
 


### PR DESCRIPTION
Test is not compatible with backoff implementation, and we're already testing backoff in another test.

See pr:https://github.com/mendersoftware/monitor-client/pull/136