### PR TITLE
QA-609: Enable `test_generate_release_notes_from_master`

### DIFF
--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -922,7 +922,6 @@ def test_generate_release_notes(request, capsys):
         del os.environ["TEST_RELEASE_TOOL_LIST_OPEN_SOURCE_ONLY"]
 
 
-@pytest.mark.skip(reason="QA-609")
 def test_generate_release_notes_from_master(request, capsys, is_master):
     if not is_master:
         pytest.skip("This test requires master tags in the docker-compose files.")


### PR DESCRIPTION
The test issue was fixed indirectly when removing `reporting` at:
* https://github.com/mendersoftware/integration/pull/2486

Whenever reporting is ready for production, very likely it is out of the release tool so we don't need to deal about old missing tags.

Ticket: QA-609