### PR TITLE
MEN-5956: Remove deprecated `version` from all docker-compose files

### DIFF
--- a/backend-tests/docker/docker-compose.azblob.setup.yml
+++ b/backend-tests/docker/docker-compose.azblob.setup.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   azblob-container-setup:

--- a/backend-tests/docker/docker-compose.backend-tests.yml
+++ b/backend-tests/docker/docker-compose.backend-tests.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
     mender-backend-tests-runner:
         image: mendersoftware/mender-test-containers:backend-integration-testing

--- a/backend-tests/docker/docker-compose.storage.azblob.yml
+++ b/backend-tests/docker/docker-compose.storage.azblob.yml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
     minio:
       image: alpine

--- a/common.yml
+++ b/common.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
     mender-base:
         stdin_open: false

--- a/docker-compose.client-dev.yml
+++ b/docker-compose.client-dev.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.client.demo.yml
+++ b/docker-compose.client.demo.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.client.rofs.commercial.yml
+++ b/docker-compose.client.rofs.commercial.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.client.rofs.yml
+++ b/docker-compose.client.rofs.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     mender-iot-manager:

--- a/docker-compose.docker-client.addons.yml
+++ b/docker-compose.docker-client.addons.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     mender-client:

--- a/docker-compose.docker-client.yml
+++ b/docker-compose.docker-client.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     mender-client:

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     # redis cache

--- a/docker-compose.mender-gateway.commercial.demo.yml
+++ b/docker-compose.mender-gateway.commercial.demo.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.mender-gateway.commercial.yml
+++ b/docker-compose.mender-gateway.commercial.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.monitor-client.commercial.yml
+++ b/docker-compose.monitor-client.commercial.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.mt.client.yml
+++ b/docker-compose.mt.client.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.no-ssl.yml
+++ b/docker-compose.no-ssl.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     mender-api-gateway:

--- a/docker-compose.reporting.yml
+++ b/docker-compose.reporting.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.storage.minio.yml
+++ b/docker-compose.storage.minio.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.storage.s3.yml
+++ b/docker-compose.storage.s3.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/docker-compose.testing.enterprise.yml
+++ b/docker-compose.testing.enterprise.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     mender-device-auth:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/extra/expired-token-testing/docker-compose.short-token.yml
+++ b/extra/expired-token-testing/docker-compose.short-token.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
     mender-device-auth:
         environment:

--- a/extra/failover-testing/docker-compose.failover-server.yml
+++ b/extra/failover-testing/docker-compose.failover-server.yml
@@ -2,7 +2,6 @@
 # and docker-compose.storage.minio.yml, as they appeared when this file was
 # written.
 
-version: '2.3'
 services:
 
     #

--- a/extra/integration-testing/docker-compose.yml
+++ b/extra/integration-testing/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 
 services:
   mender-api-gateway:

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.0.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.0.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-2-0:
     image: mendersoftware/mender-client-qemu:2.0

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.1.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.1.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-2-1:
     image: mendersoftware/mender-client-qemu:2.1

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.2.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.2.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-2-2:
     image: mendersoftware/mender-client-qemu:2.2

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.3.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.3.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-2-3:
     image: mendersoftware/mender-client-qemu:2.3

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.4.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.4.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-2-4:
     image: mendersoftware/mender-client-qemu:2.4

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.5.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.5.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-2-5:
     image: mendersoftware/mender-client-qemu:2.5

--- a/extra/integration-testing/test-compat/docker-compose.compat-2.6.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-2.6.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-2-6:
     image: mendersoftware/mender-client-qemu:2.6

--- a/extra/integration-testing/test-compat/docker-compose.compat-3.0.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-3.0.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-3-0:
     image: mendersoftware/mender-client-qemu:3.0

--- a/extra/integration-testing/test-compat/docker-compose.compat-3.1.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-3.1.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-3-1:
     image: mendersoftware/mender-client-qemu:3.1

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.2.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.2.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-3-2:
     image: mendersoftware/mender-client-qemu:mender-3.2

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.3.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.3.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-3-3:
     image: mendersoftware/mender-client-qemu:mender-3.3

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.4.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.4.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-3-4:
     image: mendersoftware/mender-client-qemu:mender-3.4

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.5.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.5.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-3-5:
     image: mendersoftware/mender-client-qemu:mender-3.5

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.6.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.6.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-3-6:
     image: mendersoftware/mender-client-qemu:mender-3.6

--- a/extra/integration-testing/test-compat/docker-compose.compat-mender-3.7.yml
+++ b/extra/integration-testing/test-compat/docker-compose.compat-mender-3.7.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-client-3-7:
     image: mendersoftware/mender-client-qemu:mender-3.7

--- a/extra/mender-gateway/docker-compose.client.yml
+++ b/extra/mender-gateway/docker-compose.client.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/extra/mender-gateway/docker-compose.test.yml
+++ b/extra/mender-gateway/docker-compose.test.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mender-gateway:
     networks:

--- a/extra/mtls/docker-compose.mtls-ambassador-test.yml
+++ b/extra/mtls/docker-compose.mtls-ambassador-test.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
   mtls-ambassador:
     image: registry.mender.io/mendersoftware/mtls-ambassador:master

--- a/extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml
+++ b/extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     mender-tenantadm:

--- a/extra/signed-artifact-client-testing/docker-compose.signed-client.yml
+++ b/extra/signed-artifact-client-testing/docker-compose.signed-client.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/extra/smtp-testing/smtp.mock.yml
+++ b/extra/smtp-testing/smtp.mock.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     local-smtp:

--- a/extra/smtp-testing/workflows-worker-smtp-mock.yml
+++ b/extra/smtp-testing/workflows-worker-smtp-mock.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     mender-workflows-worker:

--- a/extra/smtp-testing/workflows-worker-smtp-test.yml
+++ b/extra/smtp-testing/workflows-worker-smtp-test.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     mender-workflows-worker:

--- a/extra/stripe-testing/stripe-test.docker-compose.yml
+++ b/extra/stripe-testing/stripe-test.docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     mender-tenantadm:

--- a/migration/migration-helper.yml
+++ b/migration/migration-helper.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/storage-proxy/docker-compose.storage-proxy.demo.yml
+++ b/storage-proxy/docker-compose.storage-proxy.demo.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #

--- a/storage-proxy/docker-compose.storage-proxy.yml
+++ b/storage-proxy/docker-compose.storage-proxy.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
     #
     # storage-proxy

--- a/tests/legacy-v1-client.yml
+++ b/tests/legacy-v1-client.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
 
     #


### PR DESCRIPTION
Solves deprecation warnings on start-up:
```
Starting the Mender demo environment...
WARN[0000] /home/lluis/northern.work/integration/docker-compose.yml: `version` is obsolete
WARN[0000] /home/lluis/northern.work/integration/docker-compose.storage.minio.yml: `version` is obsolete
WARN[0000] /home/lluis/northern.work/integration/docker-compose.demo.yml: `version` is obsolete
...
```

Ticket: MEN-5956