### PR TITLE
test: Move branch detection to the function where it is used

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -55,32 +55,34 @@ while [ -n "$1" ]; do
     shift
 done
 
-MENDER_BRANCH=$(../extra/release_tool.py --version-of mender)
-if [[ $? -ne 0 ]]; then
-    echo "Failed to determine mender version using release_tool.py"
-    exit 1
-fi
-
-MENDER_ARTIFACT_BRANCH=$(../extra/release_tool.py --version-of mender-artifact)
-if [[ $? -ne 0 ]]; then
-    echo "Failed to determine mender-artifact version using release_tool.py"
-    exit 1
-fi
-
-MENDER_CLI_BRANCH=$(../extra/release_tool.py --version-of mender-cli)
-if [[ $? -ne 0 ]]; then
-    echo "Failed to determine mender-cli version using release_tool.py"
-    exit 1
-fi
-
-echo "Detected Mender branch: $MENDER_BRANCH"
-echo "Detected mender-artifact branch: $MENDER_ARTIFACT_BRANCH"
-echo "Detected mender-cli branch: $MENDER_CLI_BRANCH"
-
 function get_requirements() {
     # Download what we need.
     mkdir -p downloaded-tools
 
+    # Detect the branches from where to download the tools
+    MENDER_BRANCH=$(../extra/release_tool.py --version-of mender)
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to determine mender version using release_tool.py"
+        exit 1
+    fi
+
+    MENDER_ARTIFACT_BRANCH=$(../extra/release_tool.py --version-of mender-artifact)
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to determine mender-artifact version using release_tool.py"
+        exit 1
+    fi
+
+    MENDER_CLI_BRANCH=$(../extra/release_tool.py --version-of mender-cli)
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to determine mender-cli version using release_tool.py"
+        exit 1
+    fi
+
+    echo "Detected Mender branch: $MENDER_BRANCH"
+    echo "Detected mender-artifact branch: $MENDER_ARTIFACT_BRANCH"
+    echo "Detected mender-cli branch: $MENDER_CLI_BRANCH"
+
+    # Download the tools
     curl --fail "https://downloads.mender.io/mender-artifact/${MENDER_ARTIFACT_BRANCH}/linux/mender-artifact" \
          -o downloaded-tools/mender-artifact \
          -z downloaded-tools/mender-artifact


### PR DESCRIPTION
It saves the script to run release_tool commands for no good reason when not downloading the tools.