### PR TITLE
chore: Bump versions for Mender 3.6.5-build3.

### DIFF
--- a/docker-compose.client.rofs.commercial.yml
+++ b/docker-compose.client.rofs.commercial.yml
@@ -5,4 +5,4 @@ services:
     # mender-client
     #
     mender-client:
-        image: registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:mender-3.6.x
+        image: registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:mender-3.6.5-build3

--- a/docker-compose.client.rofs.yml
+++ b/docker-compose.client.rofs.yml
@@ -5,4 +5,4 @@ services:
     # mender-client
     #
     mender-client:
-        image: mendersoftware/mender-client-qemu-rofs:mender-3.6.x
+        image: mendersoftware/mender-client-qemu-rofs:mender-3.6.5-build3

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -5,7 +5,7 @@ services:
     # mender-client
     #
     mender-client:
-        image: mendersoftware/mender-client-qemu:mender-3.6.x
+        image: mendersoftware/mender-client-qemu:mender-3.6.5-build3
         networks:
             - mender
         stdin_open: true

--- a/docker-compose.docker-client.addons.yml
+++ b/docker-compose.docker-client.addons.yml
@@ -3,7 +3,7 @@ services:
 
     mender-client:
         # Needs to be built in extra/mender-client-docker-addons
-        image: mendersoftware/mender-client-docker-addons:mender-3.6.x
+        image: mendersoftware/mender-client-docker-addons:mender-3.6.5-build3
         networks:
             - mender
 

--- a/docker-compose.docker-client.yml
+++ b/docker-compose.docker-client.yml
@@ -3,7 +3,7 @@ services:
 
     mender-client:
         # Needs to be built in mender client's test directory.
-        image: mendersoftware/mender-client-docker:mender-3.6.x
+        image: mendersoftware/mender-client-docker:mender-3.6.5-build3
         networks:
             - mender
 

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -12,18 +12,18 @@ services:
 
     # subsitute services with 'enterprise' versions
     mender-deployments:
-        image: registry.mender.io/mendersoftware/deployments-enterprise:mender-3.6.x
+        image: registry.mender.io/mendersoftware/deployments-enterprise:mender-3.6.5-build3
         environment:
             DEPLOYMENTS_ENABLE_AUDIT: 1
 
     mender-inventory:
-        image: registry.mender.io/mendersoftware/inventory-enterprise:mender-3.6.x
+        image: registry.mender.io/mendersoftware/inventory-enterprise:mender-3.6.5-build3
 
     mender-workflows-server:
-        image: registry.mender.io/mendersoftware/workflows-enterprise:mender-3.6.x
+        image: registry.mender.io/mendersoftware/workflows-enterprise:mender-3.6.5-build3
 
     mender-workflows-worker:
-        image: registry.mender.io/mendersoftware/workflows-enterprise-worker:mender-3.6.x
+        image: registry.mender.io/mendersoftware/workflows-enterprise-worker:mender-3.6.5-build3
         environment:
             HAVE_AUDITLOGS: 1
             HAVE_DEVICECONFIG: 1
@@ -31,7 +31,7 @@ services:
 
     # add services
     mender-tenantadm:
-        image: registry.mender.io/mendersoftware/tenantadm:mender-3.6.x
+        image: registry.mender.io/mendersoftware/tenantadm:mender-3.6.5-build3
         environment:
             TENANTADM_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
             TENANTADM_ENABLE_SELF_SERVICE_SIGN_UP: 1
@@ -45,7 +45,7 @@ services:
 
     # configure the rest
     mender-device-auth:
-        image: registry.mender.io/mendersoftware/deviceauth-enterprise:mender-3.6.x
+        image: registry.mender.io/mendersoftware/deviceauth-enterprise:mender-3.6.5-build3
         environment:
             DEVICEAUTH_REDIS_ADDR: "mender-redis:6379"
             DEVICEAUTH_REDIS_USERNAME: ""
@@ -58,7 +58,7 @@ services:
             DEVICEAUTH_ENABLE_AUDIT: 1
 
     mender-useradm:
-        image: registry.mender.io/mendersoftware/useradm-enterprise:mender-3.6.x
+        image: registry.mender.io/mendersoftware/useradm-enterprise:mender-3.6.5-build3
         environment:
             USERADM_REDIS_ADDR: "mender-redis:6379"
             USERADM_REDIS_USERNAME: ""
@@ -71,7 +71,7 @@ services:
             USERADM_ENABLE_AUDIT: 1
 
     mender-auditlogs:
-        image: registry.mender.io/mendersoftware/auditlogs:mender-3.6.x
+        image: registry.mender.io/mendersoftware/auditlogs:mender-3.6.5-build3
         extends:
             file: common.yml
             service: mender-base
@@ -104,7 +104,7 @@ services:
             DEVICECONNECT_ENABLE_AUDIT: 1
 
     mender-generate-delta-worker:
-        image: registry.mender.io/mendersoftware/generate-delta-worker:mender-3.6.x
+        image: registry.mender.io/mendersoftware/generate-delta-worker:mender-3.6.5-build3
         extends:
             file: common.yml
             service: mender-base
@@ -118,7 +118,7 @@ services:
             - mender-nats
 
     mender-devicemonitor:
-        image: registry.mender.io/mendersoftware/devicemonitor:mender-3.6.x
+        image: registry.mender.io/mendersoftware/devicemonitor:mender-3.6.5-build3
         command: server --automigrate
         extends:
             file: common.yml

--- a/docker-compose.mender-gateway.commercial.demo.yml
+++ b/docker-compose.mender-gateway.commercial.demo.yml
@@ -15,7 +15,7 @@ services:
     # mender-client
     #
     mender-client:
-        image: mendersoftware/mender-client-qemu:mender-3.6.x
+        image: mendersoftware/mender-client-qemu:mender-3.6.5-build3
         networks:
             mender_local:
         stdin_open: true

--- a/docker-compose.mender-gateway.commercial.yml
+++ b/docker-compose.mender-gateway.commercial.yml
@@ -5,7 +5,7 @@ services:
     # mender-gateway
     #
     mender-gateway:
-        image: registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:mender-3.6.x
+        image: registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:mender-3.6.5-build3
         networks:
             - mender
         stdin_open: true

--- a/docker-compose.monitor-client.commercial.yml
+++ b/docker-compose.monitor-client.commercial.yml
@@ -5,7 +5,7 @@ services:
     # monitor-client
     #
     mender-client:
-        image: registry.mender.io/mendersoftware/mender-monitor-qemu-commercial:mender-3.6.x
+        image: registry.mender.io/mendersoftware/mender-monitor-qemu-commercial:mender-3.6.5-build3
         networks:
             - mender
         stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # mender-iot-manager
     #
     mender-iot-manager:
-        image: mendersoftware/iot-manager:mender-3.6.x
+        image: mendersoftware/iot-manager:mender-3.6.5-build3
         extends:
             file: common.yml
             service: mender-base
@@ -20,7 +20,7 @@ services:
     # mender-deployments
     #
     mender-deployments:
-        image: mendersoftware/deployments:mender-3.6.x
+        image: mendersoftware/deployments:mender-3.6.5-build3
         extends:
             file: common.yml
             service: mender-base
@@ -35,7 +35,7 @@ services:
     # mender-gui
     #
     mender-gui:
-        image: mendersoftware/gui:mender-3.6.x
+        image: mendersoftware/gui:mender-3.6.5-build3
         extends:
             file: common.yml
             service: mender-base
@@ -90,7 +90,7 @@ services:
     # mender-device-auth
     #
     mender-device-auth:
-        image: mendersoftware/deviceauth:mender-3.6.x
+        image: mendersoftware/deviceauth:mender-3.6.5-build3
         environment:
             DEVICEAUTH_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
         extends:
@@ -108,7 +108,7 @@ services:
     # mender-inventory
     #
     mender-inventory:
-        image: mendersoftware/inventory:mender-3.6.x
+        image: mendersoftware/inventory:mender-3.6.5-build3
         environment:
             INVENTORY_ORCHESTRATOR_ADDR: http://mender-workflows-server:8080/
         extends:
@@ -125,7 +125,7 @@ services:
     # mender-useradm
     #
     mender-useradm:
-        image: mendersoftware/useradm:mender-3.6.x
+        image: mendersoftware/useradm:mender-3.6.5-build3
         extends:
             file: common.yml
             service: mender-base
@@ -140,7 +140,7 @@ services:
     # mender-workflows-server
     #
     mender-workflows-server:
-        image: mendersoftware/workflows:mender-3.6.x
+        image: mendersoftware/workflows:mender-3.6.5-build3
         environment:
             WORKFLOWS_MONGO_URL: mongodb://mender-mongo:27017
         extends:
@@ -158,7 +158,7 @@ services:
     # mender-workflows-worker
     #
     mender-workflows-worker:
-        image: mendersoftware/workflows-worker:mender-3.6.x
+        image: mendersoftware/workflows-worker:mender-3.6.5-build3
         command: worker --excluded-workflows generate_artifact,generate_delta_artifact
         environment:
             WORKFLOWS_MONGO_URL: mongodb://mender-mongo:27017
@@ -179,7 +179,7 @@ services:
     # mender-create-artifact-worker
     #
     mender-create-artifact-worker:
-        image: mendersoftware/create-artifact-worker:mender-3.6.x
+        image: mendersoftware/create-artifact-worker:mender-3.6.5-build3
         extends:
             file: common.yml
             service: mender-base
@@ -195,7 +195,7 @@ services:
     # mender-deviceconnect
     #
     mender-deviceconnect:
-        image: mendersoftware/deviceconnect:mender-3.6.x
+        image: mendersoftware/deviceconnect:mender-3.6.5-build3
         command: server --automigrate
         extends:
             file: common.yml
@@ -215,7 +215,7 @@ services:
     # mender-deviceconfig
     #
     mender-deviceconfig:
-        image: mendersoftware/deviceconfig:mender-3.6.x
+        image: mendersoftware/deviceconfig:mender-3.6.5-build3
         extends:
             file: common.yml
             service: mender-base

--- a/git-versions-enterprise.yml
+++ b/git-versions-enterprise.yml
@@ -8,34 +8,34 @@ services:
     # backend enterprise services
     #
     mender-deployments:
-        image: registry.mender.io/mendersoftware/deployments-enterprise:4.5.x
+        image: registry.mender.io/mendersoftware/deployments-enterprise:4.5.2
 
     mender-inventory:
-        image: registry.mender.io/mendersoftware/inventory-enterprise:4.3.x
+        image: registry.mender.io/mendersoftware/inventory-enterprise:4.3.2
 
     mender-workflows-server:
-        image: registry.mender.io/mendersoftware/workflows-enterprise:2.5.x
+        image: registry.mender.io/mendersoftware/workflows-enterprise:2.5.2-build3
 
     mender-workflows-worker:
         image: registry.mender.io/mendersoftware/workflows-enterprise-worker:master
 
     mender-tenantadm:
-        image: registry.mender.io/mendersoftware/tenantadm:4.0.x
+        image: registry.mender.io/mendersoftware/tenantadm:4.0.0
 
     mender-useradm:
-        image: registry.mender.io/mendersoftware/useradm-enterprise:1.21.x
+        image: registry.mender.io/mendersoftware/useradm-enterprise:1.21.4-build3
 
     mender-auditlogs:
-        image: registry.mender.io/mendersoftware/auditlogs:3.1.x
+        image: registry.mender.io/mendersoftware/auditlogs:3.1.1
 
     mtls-ambassador:
-        image: registry.mender.io/mendersoftware/mtls-ambassador:1.2.x
+        image: registry.mender.io/mendersoftware/mtls-ambassador:1.2.1
 
     mender-devicemonitor:
-        image: registry.mender.io/mendersoftware/devicemonitor:1.4.x
+        image: registry.mender.io/mendersoftware/devicemonitor:1.4.1
 
     mender-device-auth:
-        image: registry.mender.io/mendersoftware/deviceauth-enterprise:3.5.x
+        image: registry.mender.io/mendersoftware/deviceauth-enterprise:3.5.0
 
     mender-generate-delta-worker:
-        image: registry.mender.io/mendersoftware/generate-delta-worker:1.0.x
+        image: registry.mender.io/mendersoftware/generate-delta-worker:1.0.2

--- a/git-versions.yml
+++ b/git-versions.yml
@@ -8,58 +8,58 @@ services:
     # backend open source services
     #
     mender-iot-manager:
-        image: mendersoftware/iot-manager:1.2.x
+        image: mendersoftware/iot-manager:1.2.1
 
     mender-deployments:
-        image: mendersoftware/deployments:4.5.x
+        image: mendersoftware/deployments:4.5.2
 
     mender-gui:
-        image: mendersoftware/gui:3.6.x
+        image: mendersoftware/gui:3.6.2
 
     mender-device-auth:
-        image: mendersoftware/deviceauth:3.5.x
+        image: mendersoftware/deviceauth:3.5.0
 
     mender-inventory:
-        image: mendersoftware/inventory:4.3.x
+        image: mendersoftware/inventory:4.3.2
 
     mender-useradm:
-        image: mendersoftware/useradm:1.21.x
+        image: mendersoftware/useradm:1.21.4-build3
 
     mender-deviceconnect:
-        image: mendersoftware/deviceconnect:1.4.x
+        image: mendersoftware/deviceconnect:1.4.1
 
     mender-deviceconfig:
-        image: mendersoftware/deviceconfig:1.3.x
+        image: mendersoftware/deviceconfig:1.3.2
 
     mender-reporting:
         image: mendersoftware/reporting:1.1.x
 
     mender-workflows-server:
-        image: mendersoftware/workflows:2.5.x
+        image: mendersoftware/workflows:2.5.2-build3
 
     mender-workflows-worker:
         image: mendersoftware/workflows-worker:master
 
     mender-create-artifact-worker:
-        image: mendersoftware/create-artifact-worker:1.3.x
+        image: mendersoftware/create-artifact-worker:1.3.2
 
     #
     # client repositories - container and image names are placeholders
     #
     mender:
-        image: mendersoftware/mender:3.5.x
+        image: mendersoftware/mender:3.5.3-build3
 
     mender-connect:
-        image: mendersoftware/mender-connect:2.1.x
+        image: mendersoftware/mender-connect:2.1.2-build3
 
     mender-configure-module:
-        image: mendersoftware/mender-configure-module:1.1.x
+        image: mendersoftware/mender-configure-module:1.1.2
 
     monitor-client:
-        image: mendersoftware/monitor-client:1.3.x
+        image: mendersoftware/monitor-client:1.3.0
 
     mender-gateway:
-        image: mendersoftware/mender-gateway:1.1.x
+        image: mendersoftware/mender-gateway:1.1.0
 
     mender-ci-workflows:
         image: mendersoftware/mender-ci-workflows:master

--- a/other-components-docker.yml
+++ b/other-components-docker.yml
@@ -3,8 +3,8 @@
 # installation (have no docker-compose file).
 services:
     mtls-ambassador:
-        image: registry.mender.io/mendersoftware/mtls-ambassador:mender-3.6.x
+        image: registry.mender.io/mendersoftware/mtls-ambassador:mender-3.6.5-build3
     mender-ci-workflows:
         image: mendersoftware/mender-ci-tools:mender-master
     mender-client:
-        image: registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:mender-3.6.x
+        image: registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:mender-3.6.5-build3

--- a/other-components.yml
+++ b/other-components.yml
@@ -5,16 +5,16 @@
 # 'services' tag.
 services:
     mender-artifact:
-        image: mendersoftware/mender-artifact:3.10.x
+        image: mendersoftware/mender-artifact:3.11.2
 
     mender-cli:
-        image: mendersoftware/mender-cli:1.11.x
+        image: mendersoftware/mender-cli:1.11.1
 
     mender-binary-delta:
-        image: mendersoftware/mender-binary-delta:1.4.x
+        image: mendersoftware/mender-binary-delta:1.4.1
 
     mender-convert:
-        image: mendersoftware/mender-convert:4.0.x
+        image: mendersoftware/mender-convert:4.2.2-build3
 
     meta-mender:
         image: mendersoftware/meta-mender:dunfell


### PR DESCRIPTION
Changelog: Upgrade integration to 3.6.5-build3.
Changelog: Upgrade mender-artifact to 3.11.2.
Changelog: Upgrade mender-configure-module to 1.1.2.
Changelog: Upgrade mender-connect to 2.1.2-build3.
Changelog: Upgrade mender-convert to 4.2.2-build3.
Changelog: Upgrade mender to 3.5.3-build3.
Changelog: Upgrade useradm-enterprise to 1.21.4-build3.
Changelog: Upgrade useradm to 1.21.4-build3.
Changelog: Upgrade workflows-enterprise to 2.5.2-build3.
Changelog: Upgrade workflows to 2.5.2-build3.