### PR TITLE
MEN-7302: Make large image larger

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,7 +181,7 @@ def large_image(request):
     return _special_image(
         request,
         "large_image.dat",
-        ["dd", "if=/dev/zero", "of=large_image.dat", "bs=300M", "count=1"],
+        ["dd", "if=/dev/zero", "of=large_image.dat", "bs=500M", "count=1"],
     )
 
 


### PR DESCRIPTION
For scarthgap we have increased the rootfs size to around 400M. This test image then needs to be even larger to guarantee that it does not fit.