### PR TITLE
MEN-7299: Update legacy client images with enlarged versions

### DIFF
--- a/extra/legacy-clients-testing/legacy-v1-client.yml
+++ b/extra/legacy-clients-testing/legacy-v1-client.yml
@@ -4,7 +4,8 @@ services:
     # mender-legacy-client 
     #
     mender-client:
-        image: mendersoftware/mender-client-qemu:1.7.0
+        # Testing image based on 1.7.0 with enlarged partitions
+        image: mendersoftware/mender-client-qemu:1.7.0-large-rootfs
         volumes:
           # Provision demo certificate
           - ./cert/cert.crt:/mnt/config/server.crt

--- a/extra/legacy-clients-testing/legacy-v3-client.yml
+++ b/extra/legacy-clients-testing/legacy-v3-client.yml
@@ -1,0 +1,11 @@
+services:
+  mender-client-3-6:
+    # Testing image based on mender-3.6.3 with enlarged partitions
+    image: mendersoftware/mender-client-qemu:mender-3.6.3-large-rootfs
+    networks:
+       - mender
+    stdin_open: true
+    tty: true
+    privileged: true
+    environment:
+      - TENANT_TOKEN=$TENANT_TOKEN

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -56,13 +56,12 @@ class DockerComposeNamespace(DockerComposeBaseNamespace):
     ]
     LEGACY_V1_CLIENT_FILES = [
         COMPOSE_FILES_PATH + "/docker-compose.client.yml",
-        COMPOSE_FILES_PATH + "/tests/legacy-v1-client.yml",
+        COMPOSE_FILES_PATH + "/extra/legacy-clients-testing/legacy-v1-client.yml",
         COMPOSE_FILES_PATH + "/storage-proxy/docker-compose.storage-proxy.yml",
         COMPOSE_FILES_PATH + "/storage-proxy/docker-compose.storage-proxy.testing.yml",
     ]
     LEGACY_V3_CLIENT_FILES = [
-        COMPOSE_FILES_PATH
-        + "/extra/integration-testing/test-compat/docker-compose.compat-mender-3.6.yml",
+        COMPOSE_FILES_PATH + "/extra/legacy-clients-testing/legacy-v3-client.yml",
     ]
     SIGNED_ARTIFACT_CLIENT_FILES = [
         COMPOSE_FILES_PATH


### PR DESCRIPTION
The new images are based on the same tags and have been modified to have larger partitions so that they can fit latest yocto distributions.

The files have been moved/copied for consistency into a dedicated directory.