### PR TITLE
QA-743: fix: Demo Artifact is now uploaded unconditionally on Enterprise setups

### DIFF
--- a/demo
+++ b/demo
@@ -322,7 +322,9 @@ maybe_launch_enterprise_client() {
 }
 
 maybe_upload_artifact() {
-    if [[ $UPLOAD_ARTIFACT -eq 1 ]]; then
+    if [[ $UPLOAD_ARTIFACT -eq 1 ]] && [[ $ENTERPRISE -eq 0 ]]; then
+        # For Enterprise setup, the demo Artifact uploaded by workflows-enterprise unconditionally
+        echo "Uploading demo Artifact..."
 
         local RETRIES=0
         local retval=0


### PR DESCRIPTION
Since the rework of workflows-enteprise, the demo Artifact is automatically and unconditionally uploaded when creating a new organization. See:
* https://github.com/mendersoftware/workflows-enterprise/pull/673

No changelog as the issue has not yet been released.

Changelog: None
Ticket: QA-743