### PR TITLE
chore: Remove redundant version definition for `mender-gateway`

### DIFF
--- a/git-versions.yml
+++ b/git-versions.yml
@@ -64,8 +64,5 @@ services:
     monitor-client:
         image: mendersoftware/monitor-client:master
 
-    mender-gateway:
-        image: mendersoftware/mender-gateway:master
-
     mender-ci-workflows:
         image: mendersoftware/mender-ci-workflows:master


### PR DESCRIPTION
It was already (wrong) defined in `git-versions.yml` and then re-introduced in `git-versions-enterprise.yml` without removing the former one. See 408078aa9c1ffbfdef9c76f6210f482a9ba89fc9