### PR TITLE
test: Revert "test: Mark `test_state_scripts` as flaky"

### DIFF
--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -18,8 +18,6 @@ import os
 import subprocess
 import pathlib
 
-from flaky import flaky
-
 import pytest
 
 from .. import conftest
@@ -939,7 +937,6 @@ class TestStateScriptsOpenSource(BaseTestStateScripts):
             test_set,
         )
 
-    @flaky(max_runs=3)
     @MenderTesting.slow
     @pytest.mark.parametrize("description,test_set", TEST_SETS)
     def test_state_scripts(
@@ -969,7 +966,6 @@ class TestStateScriptsEnterprise(BaseTestStateScripts):
             test_set,
         )
 
-    @flaky(max_runs=3)
     @MenderTesting.slow
     @pytest.mark.parametrize("description,test_set", TEST_SETS)
     def test_state_scripts(


### PR DESCRIPTION
The bug in MEN-7379 has been fixed now.

This reverts commit aca76958eac8a20908c1cabb4f8b7c8f3ea333ae.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit acfe4e68139644e2563e11343502fe836659d7df)