### PR TITLE
test: Fix unintentional inclusion of quotes in environment variable.

### DIFF
--- a/extra/mender-gateway/docker-compose.test.yml
+++ b/extra/mender-gateway/docker-compose.test.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - "./extra/mender-gateway/mender-gateway.conf:/mender-gateway.conf:ro"
     environment:
-      - MENDER_GATEWAY_CONFFILE="/mender-gateway.conf"
+      - MENDER_GATEWAY_CONFFILE=/mender-gateway.conf
 
 networks:
     mender:


### PR DESCRIPTION
When quotes are specified inline in Yaml variable values, they are interpreted as verbatim strings, not as quotation. So the filename ended up including quotes. This does not work anymore after 4d36b45511f4788d in meta-mender. Why it has worked until now is a good question; most likely shell commands accept the extra quotes, while they are not accepted in Python operations (where the new check is).