### PR TITLE
test: Fix unintentional inclusion of quotes in environment variable.

### DIFF
--- a/.gitlab-ci-default-pipeline.yml
+++ b/.gitlab-ci-default-pipeline.yml
@@ -120,10 +120,6 @@ publish:image:mender:
     DOCKER_REPOSITORY: mendersoftware/mender-client-docker-addons
     DOCKER_DIR: extra/mender-client-docker-addons
 
-trigger:saas:sync-staging-component:
-  rules:
-    - when: never
-
 publish:image:saas:
   rules:
     - when: never

--- a/extra/mender-gateway/docker-compose.test.yml
+++ b/extra/mender-gateway/docker-compose.test.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - "./extra/mender-gateway/mender-gateway.conf:/mender-gateway.conf:ro"
     environment:
-      - MENDER_GATEWAY_CONFFILE="/mender-gateway.conf"
+      - MENDER_GATEWAY_CONFFILE=/mender-gateway.conf
 
 networks:
     mender:


### PR DESCRIPTION
When quotes are specified inline in Yaml variable values, they are interpreted as verbatim strings, not as quotation. So the filename ended up including quotes. This does not work anymore after 4d36b45511f4788d in meta-mender. Why it has worked until now is a good question; most likely shell commands accept the extra quotes, while they are not accepted in Python operations (where the new check is).

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 7715452fdf108a12df882cc0317d827edc3f9080)