### PR TITLE
QA-794: Update `meta-mender` version to latest LTS

### DIFF
--- a/other-components.yml
+++ b/other-components.yml
@@ -17,4 +17,4 @@ services:
         image: mendersoftware/mender-convert:master
 
     meta-mender:
-        image: mendersoftware/meta-mender:kirkstone
+        image: mendersoftware/meta-mender:scarthgap


### PR DESCRIPTION
To be honest I don't know what is this one used for nowadays, but it makes sense to use the latest.