### PR TITLE
ci: fix off-by-one indexing and underflow in pytest parallel script

### DIFF
--- a/tests/ci-parallel-pytest-plugin.py
+++ b/tests/ci-parallel-pytest-plugin.py
@@ -40,8 +40,8 @@ n_rest = len(classes) % TOTAL
 offset = n_batch * (INDEX - 1)
 if INDEX <= n_rest:
     n_batch += 1
-    offset += INDEX
+    offset += INDEX - 1
 else:
     offset += n_rest
 
-print(" or ".join(classes[offset : offset + n_batch]))
+print(" or ".join(classes[offset : offset + n_batch]), end="")

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -159,7 +159,12 @@ if [ -n "$K8S" ]; then
     aws eks update-kubeconfig --region $AWS_DEFAULT_REGION --name $AWS_EKS_CLUSTER_NAME --kubeconfig ${HOME}/kubeconfig.${K8S}
 fi
 if test ${CI_NODE_TOTAL:-1} -gt 1; then
-  export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -k '$(python ci-parallel-pytest-plugin.py $@)'"
+  PYTEST_FILTER="$(python ci-parallel-pytest-plugin.py $@)"
+  if test -z "$PYTEST_FILTER"; then
+    echo "No tests to run for current node"
+    exit 0
+  fi
+  export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -k '$PYTEST_FILTER'"
 fi
 python3 -m pytest \
     $EXTRA_TEST_ARGS \


### PR DESCRIPTION
When adding the rest to the first batches, the first test class was skipped.
If there are no tests to execute, the script will return an impossible condition.