### PR TITLE
chore: Remove `mender-gateway` Docker image from release_tool

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -8,7 +8,6 @@ git:
 
   mender-gateway:
     docker_image:
-      - mender-gateway
       - mender-gateway-qemu-commercial
     docker_container:
       - mender-gateway
@@ -565,13 +564,6 @@ docker_image:
     - mender-client
     release_component: true
     independent_component: false
-
-  mender-gateway:
-    git:
-    - mender-gateway
-    docker_container:
-    - mender-gateway
-    release_component: true
 
   mender-gateway-qemu-commercial:
     git:


### PR DESCRIPTION
We introduced the image in 408078aa and has not yet been released. We need to remove it because the build and publish of it is happening already on its own repository, and involving the release_tool for it will conflict (namely: it will override the multiplatform image with a x86 only image).