### PR TITLE
ci: Revert to hard-coded repository for mender-gateway QEMU image

### DIFF
--- a/.env
+++ b/.env
@@ -3,16 +3,14 @@ MENDER_SERVER_ENTERPRISE_REGISTRY=registry.mender.io
 MENDER_SERVER_REPOSITORY=mendersoftware
 MENDER_SERVER_ENTERPRISE_REPOSITORY=mender-server-enterprise
 MENDER_SERVER_TAG=main
-MENDER_CLIENT_TAG=mender-master
 
 # Artifacts from mender-gateway
 MENDER_GATEWAY_REGISTRY=registry.mender.io
 MENDER_GATEWAY_REPOSITORY=mendersoftware
 MENDER_GATEWAY_TAG=master
 
-# Artifacts from meta-mender
-MENDER_GATEWAY_QEMU_REGISTRY=registry.mender.io
-MENDER_GATEWAY_QEMU_REPOSITORY=mendersoftware
+# Virtual devices, built from mender-qa
+MENDER_CLIENT_TAG=mender-master
 MENDER_GATEWAY_QEMU_TAG=mender-master
 
 MENDER_ARTIFACT_VERSION=3.11.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,9 +41,6 @@ variables:
   MENDER_SERVER_TAG:
     description: "Mender Server Docker tag for running integration tests"
     value: main
-  MENDER_CLIENT_TAG:
-    description: "Mender Client Docker tag for running integration tests"
-    value: mender-master
 
   # Artifacts from mender-gateway
   MENDER_GATEWAY_REGISTRY:
@@ -56,13 +53,10 @@ variables:
     description: "Mender Gateway Docker tag for running integration tests"
     value: master
 
-  # Artifacts from meta-mender
-  MENDER_GATEWAY_QEMU_REGISTRY:
-    description: "Mender Gateway (QEMU) Docker registry for running integration tests"
-    value: registry.mender.io
-  MENDER_GATEWAY_QEMU_REPOSITORY:
-    description: "Mender Gateway (QEMU) Docker repository for running integration tests"
-    value: mendersoftware
+  # Virtual devices, built from mender-qa
+  MENDER_CLIENT_TAG:
+    description: "Mender Client (all) Docker tag for running integration tests"
+    value: mender-master
   MENDER_GATEWAY_QEMU_TAG:
     description: "Mender Gateway (QEMU) Docker tag for running integration tests"
     value: mender-master

--- a/docker-compose.mender-gateway.commercial.yml
+++ b/docker-compose.mender-gateway.commercial.yml
@@ -3,7 +3,7 @@ services:
   # mender-gateway
   #
   mender-gateway:
-    image: ${MENDER_GATEWAY_QEMU_REGISTRY}/${MENDER_GATEWAY_QEMU_REPOSITORY}/mender-gateway-qemu-commercial:${MENDER_GATEWAY_QEMU_TAG}
+    image: registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:${MENDER_GATEWAY_QEMU_TAG}
     networks:
       - mender
     stdin_open: true


### PR DESCRIPTION
This image, together with all the client ones, is still built from mender-qa and parsed by the release_tool for the actual release.

As we want to limit the changes on the tool (and rather deprecate it soon) we need to revert to the hard-coded Docker repository so that it can be correctly parsed during release.

Moving also the existing client variable in the ci and env files to group the images that are built from mender-qa pipeline.