### PR TITLE
ci: Document the `TESTS_IN_PARALLEL_INTEGRATION` behaviour

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,12 @@ variables:
       - "false"
       - "true"
 
+  TESTS_IN_PARALLEL_INTEGRATION:
+    description: |
+      Number of parallel tests per CI job.
+      NOTE: We run 4 CI jobs in parallel, so the default is 4x4=16 parallel tests
+    value: "4"
+
   DOCKER_VERSION:
     description: "Docker version to use in jobs"
     value: "27"


### PR DESCRIPTION
Since moving into this repository this test suite, this variable was only set for staging tests, leaving the full integration tests run with "auto", which as per today runners translated to 4 jobs.

Documenting it clearly in the main variables so that it can easily be customize when launching pipelines.