### PR TITLE
ci: Log in into GitLab container registry for integration tests

### DIFF
--- a/.gitlab-ci-full-integration.yml
+++ b/.gitlab-ci-full-integration.yml
@@ -18,6 +18,10 @@ test:integration:
       docker login docker.io \
       --username $DOCKER_HUB_USERNAME \
       --password $DOCKER_HUB_PASSWORD
+    - |
+      docker login $CI_REGISTRY \
+      --username $CI_REGISTRY_USER \
+      --password $CI_REGISTRY_PASSWORD
     - apk add $(cat ./tests/requirements-system/apk-requirements.txt)
     - apk add py3-virtualenv screen
     - python -m virtualenv /.venv


### PR DESCRIPTION
This enables running the tests with release candidates or in general build artifacts from other pipelines.