### PR TITLE
ci: Try with `parallel: 1`

### DIFF
--- a/.gitlab-ci-full-integration.yml
+++ b/.gitlab-ci-full-integration.yml
@@ -6,7 +6,7 @@ test:integration:
   tags:
     - mender-qa-worker-integration-tests
   timeout: 10h
-  parallel: 4
+  parallel: 1
   variables:
     PYTEST_XDIST_AUTO_NUM_WORKERS: "4"
   before_script:


### PR DESCRIPTION
Keeping the parallel tests to 4 per CI job, but in a single CI job.