### PR TITLE
ci: Control parallelization parameters from CI variables

### DIFF
--- a/.gitlab-ci-full-integration.yml
+++ b/.gitlab-ci-full-integration.yml
@@ -6,9 +6,7 @@ test:integration:
   tags:
     - mender-qa-worker-integration-tests
   timeout: 10h
-  parallel: 4
-  variables:
-    PYTEST_XDIST_AUTO_NUM_WORKERS: "4"
+  parallel: $CI_JOBS_IN_PARALLEL_INTEGRATION
   before_script:
     - |
       docker login registry.mender.io \

--- a/.gitlab-ci-staging-tests.yml
+++ b/.gitlab-ci-staging-tests.yml
@@ -77,7 +77,7 @@ test:staging:integration-tests:
     DOCKER_CLIENT_TIMEOUT: 300
     COMPOSE_HTTP_TIMEOUT: 300
     SPECIFIC_INTEGRATION_TEST: "Enterprise"
-    TESTS_IN_PARALLEL_INTEGRATION: "2"
+    XDIST_JOBS_IN_PARALLEL_INTEGRATION: "2"
   id_tokens:
     AWS_OIDC_TOKEN:
       aud: https://gitlab.com

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,11 +34,17 @@ variables:
       - "false"
       - "true"
 
-  TESTS_IN_PARALLEL_INTEGRATION:
+  CI_JOBS_IN_PARALLEL_INTEGRATION:
     description: |
-      Number of parallel tests per CI job.
-      NOTE: We run 4 CI jobs in parallel, so the default is 4x4=16 parallel tests
-    value: "4"
+      Number of parallel CI jobs for integration tests.
+      Tests in parallel = CI_JOBS_IN_PARALLEL_INTEGRATION x XDIST_JOBS_IN_PARALLEL_INTEGRATION
+    value: 4
+
+  XDIST_JOBS_IN_PARALLEL_INTEGRATION:
+    description: |
+      Number of parallel xdist jobs per CI job for integration tests.
+      Tests in parallel = CI_JOBS_IN_PARALLEL_INTEGRATION x XDIST_JOBS_IN_PARALLEL_INTEGRATION
+    value: 4
 
   DOCKER_VERSION:
     description: "Docker version to use in jobs"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -33,7 +33,7 @@ usage() {
     echo
     echo "Recognized Environment Variables:"
     echo
-    echo "TESTS_IN_PARALLEL_INTEGRATION        The number of parallel jobs for pytest-xdist"
+    echo "XDIST_JOBS_IN_PARALLEL_INTEGRATION   The number of parallel jobs for pytest-xdist"
     exit 0
 }
 
@@ -147,7 +147,7 @@ if ! python3 -m pip show pytest-xdist >/dev/null; then
     echo "WARNING: install pytest-xdist for running tests in parallel"
 else
     # run all tests when running in parallel
-    EXTRA_TEST_ARGS="${XDIST_ARGS:--n ${TESTS_IN_PARALLEL_INTEGRATION:-auto}}"
+    EXTRA_TEST_ARGS="${XDIST_ARGS:--n ${XDIST_JOBS_IN_PARALLEL_INTEGRATION:-auto}}"
 fi
 
 if ! python3 -m pip show pytest-html >/dev/null; then


### PR DESCRIPTION
Rework a bit the parallelization parameters and expose both as CI environment variables, allowing now for a user (or another pipeline trigger) to customize the parallelization.

For simplification, remove `PYTEST_XDIST_AUTO_NUM_WORKERS` and use instead the already existing CI variable.