### PR TITLE
ci: Control parallelization parameters from CI variables

### DIFF
--- a/.gitlab-ci-full-integration-generator.yml
+++ b/.gitlab-ci-full-integration-generator.yml
@@ -1,0 +1,35 @@
+#
+# Ideally we would have used "parallel: $CI_JOBS_IN_PARALLEL_INTEGRATION" to run the tests, but it
+# is not supported to use an integer variable here. Do a blame on these lines for more context.
+#
+# To workaround this issue, we set up "Dynamic child pipelines" to control how many CI jobs to
+# run tests (iow how many child pipelines) to launch. For an overview of this features see:
+# https://docs.gitlab.com/ee/ci/pipelines/downstream_pipelines.html#dynamic-child-pipelines
+#
+# And how is really implemented? Using envsubst to set the values of CI_NODE_TOTAL and CI_NODE_INDEX
+# in the template pipeline file for each desired child job, and concatenate all of them.
+#
+test:integration:generator:
+  image: debian:12-slim
+  stage: test-gen
+  script:
+  - apt-get update && apt-get install -y gettext-base
+  - touch gitlab-ci-full-integration-jobs.yml
+  - CI_NODE_TOTAL=$CI_JOBS_IN_PARALLEL_INTEGRATION
+  - export CI_NODE_TOTAL CI_NODE_INDEX
+  - for CI_NODE_INDEX in $(seq $CI_JOBS_IN_PARALLEL_INTEGRATION); do
+  -   envsubst '$CI_NODE_TOTAL,$CI_NODE_INDEX' < .gitlab-ci-full-integration-template.yml >> gitlab-ci-full-integration-jobs.yml
+  - done
+  artifacts:
+    paths:
+      - gitlab-ci-full-integration-jobs.yml
+
+test:integration:trigger:
+  stage: test
+  trigger:
+    strategy: depend
+    include:
+      - artifact: gitlab-ci-full-integration-jobs.yml
+        job: test:integration:generator
+    forward:
+      pipeline_variables: true

--- a/.gitlab-ci-full-integration-template.yml
+++ b/.gitlab-ci-full-integration-template.yml
@@ -1,4 +1,5 @@
-test:integration:
+# The CI job name will be unique after substitution from the generator.
+test:integration:$CI_NODE_INDEX:
   rules:
     - if: $RUN_TESTS_FULL_INTEGRATION == "true"
   image: docker:${DOCKER_VERSION}-dind
@@ -6,10 +7,11 @@ test:integration:
   tags:
     - mender-qa-worker-integration-tests
   timeout: 10h
-  parallel: 4
-  variables:
-    PYTEST_XDIST_AUTO_NUM_WORKERS: "4"
   before_script:
+    # These two variables would be set by GitLab CI "parallel" feature, and are used by our Pytest
+    # plugin to split the tests among the CI jobs. They get substituted by the generator.
+    - export CI_NODE_INDEX=$CI_NODE_INDEX
+    - export CI_NODE_TOTAL=$CI_NODE_TOTAL
     - |
       docker login registry.mender.io \
       --username $REGISTRY_MENDER_IO_USERNAME \

--- a/.gitlab-ci-staging-tests.yml
+++ b/.gitlab-ci-staging-tests.yml
@@ -77,7 +77,7 @@ test:staging:integration-tests:
     DOCKER_CLIENT_TIMEOUT: 300
     COMPOSE_HTTP_TIMEOUT: 300
     SPECIFIC_INTEGRATION_TEST: "Enterprise"
-    TESTS_IN_PARALLEL_INTEGRATION: "2"
+    XDIST_JOBS_IN_PARALLEL_INTEGRATION: "2"
   id_tokens:
     AWS_OIDC_TOKEN:
       aud: https://gitlab.com

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,11 +11,12 @@ include:
       - if: $RUN_TESTS_FULL_INTEGRATION == "true"
         when: never
       - when: always
-  - local: .gitlab-ci-full-integration.yml
+  - local: .gitlab-ci-full-integration-generator.yml
     rules:
       - if: $RUN_TESTS_FULL_INTEGRATION == "true"
 
 stages:
+  - test-gen
   - test
   - build
   - publish
@@ -34,11 +35,17 @@ variables:
       - "false"
       - "true"
 
-  TESTS_IN_PARALLEL_INTEGRATION:
+  CI_JOBS_IN_PARALLEL_INTEGRATION:
     description: |
-      Number of parallel tests per CI job.
-      NOTE: We run 4 CI jobs in parallel, so the default is 4x4=16 parallel tests
-    value: "4"
+      Number of parallel CI jobs for integration tests.
+      Tests in parallel = CI_JOBS_IN_PARALLEL_INTEGRATION x XDIST_JOBS_IN_PARALLEL_INTEGRATION
+    value: 4
+
+  XDIST_JOBS_IN_PARALLEL_INTEGRATION:
+    description: |
+      Number of parallel xdist jobs per CI job for integration tests.
+      Tests in parallel = CI_JOBS_IN_PARALLEL_INTEGRATION x XDIST_JOBS_IN_PARALLEL_INTEGRATION
+    value: 4
 
   DOCKER_VERSION:
     description: "Docker version to use in jobs"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -33,7 +33,7 @@ usage() {
     echo
     echo "Recognized Environment Variables:"
     echo
-    echo "TESTS_IN_PARALLEL_INTEGRATION        The number of parallel jobs for pytest-xdist"
+    echo "XDIST_JOBS_IN_PARALLEL_INTEGRATION   The number of parallel jobs for pytest-xdist"
     exit 0
 }
 
@@ -147,7 +147,7 @@ if ! python3 -m pip show pytest-xdist >/dev/null; then
     echo "WARNING: install pytest-xdist for running tests in parallel"
 else
     # run all tests when running in parallel
-    EXTRA_TEST_ARGS="${XDIST_ARGS:--n ${TESTS_IN_PARALLEL_INTEGRATION:-auto}}"
+    EXTRA_TEST_ARGS="${XDIST_ARGS:--n ${XDIST_JOBS_IN_PARALLEL_INTEGRATION:-auto}}"
 fi
 
 if ! python3 -m pip show pytest-html >/dev/null; then


### PR DESCRIPTION
Rework a bit the parallelization parameters and expose both as CI environment variables, allowing now for a user (or another pipeline trigger) to fully customize the parallelization.

For simplification, remove `PYTEST_XDIST_AUTO_NUM_WORKERS` and use instead the already existing CI variable.

Ideally, we would have done this with just setting `parallel` to the variable (iow `parallel: $CI_JOBS_IN_PARALLEL_INTEGRATION`), but this won't correctly work in GitLab CI due to some parsing issues.

See:
* https://gitlab.com/gitlab-org/gitlab/-/issues/11549
* https://gitlab.com/gitlab-org/gitlab/-/issues/426904

And our previous naive attempt at:
* https://github.com/mendersoftware/integration/pull/2686