### PR TITLE
ci: Fix rules for manual job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,4 +118,5 @@ publish:versions:manual:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
+    - when: manual
   extends: .publish:versions


### PR DESCRIPTION
When in combination with `rules` keyword, it needs to be an explicit rule to add the job into the pipeline.