### PR TITLE
ci: fix various`build:docker` issues

### DIFF
--- a/.gitlab-ci-default-pipeline.yml
+++ b/.gitlab-ci-default-pipeline.yml
@@ -63,6 +63,8 @@ test:integration-tests:requirements:
     - pip install -r tests/requirements-python/python-requirements.txt
 
 build:docker:
+  tags:
+    - hetzner-amd-beefy
   variables:
     DOCKER_REPOSITORY: mendersoftware/mender-client-docker-addons
     DOCKER_DIR: extra/mender-client-docker-addons

--- a/.gitlab-ci-staging-tests.yml
+++ b/.gitlab-ci-staging-tests.yml
@@ -27,7 +27,8 @@ test:staging:backend-tests:
   timeout: 4h
 
   services:
-    - docker:dind
+    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+      alias: docker
 
   variables:
     K8S: "staging"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ variables:
 
   DOCKER_VERSION:
     description: "Docker version to use in jobs"
-    value: "27"
+    value: "27.3"
 
   MENDER_SERVER_TAG:
     description: "Mender Server Docker tag for running integration tests"


### PR DESCRIPTION
Pin the docker version to 27.3 to avoid runc issues, and set the default runner tag to `hetzner-amd-beefy`

Example of a failing pipeline: https://gitlab.com/Northern.tech/Mender/integration/-/jobs/8605004802