### PR TITLE
ci: Run `publish:versions` only on final tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,7 +110,7 @@ publish:versions:tags:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
-    - if: $CI_COMMIT_TAG
+    - if: '$CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+$/'
   extends: .publish:versions
 
 publish:versions:manual:


### PR DESCRIPTION
The release candidate tags will end up in no versions update and failing the job, so let's save some CI time there.

Anyway, we have an additional manual job to trigger the update on demand.