### PR TITLE
3.8.x: QA-840: Set independent components as not releasable

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -17,7 +17,7 @@ git:
   mender-convert:
     docker_image: []
     docker_container: []
-    release_component: true
+    release_component: false
     independent_component: true
 
   mender-binary-delta:
@@ -138,13 +138,13 @@ git:
   mender-artifact:
     docker_image: []
     docker_container: []
-    release_component: true
+    release_component: false
     independent_component: true
 
   mender-cli:
     docker_image: []
     docker_container: []
-    release_component: true
+    release_component: false
     independent_component: true
 
   mender-conductor:
@@ -260,7 +260,7 @@ git:
     - mender-monitor-qemu-commercial
     docker_container:
       - mender-client
-    release_component: true
+    release_component: false
     independent_component: true
 
   mender-snapshot:
@@ -271,7 +271,7 @@ git:
     - mender-monitor-qemu-commercial
     docker_container:
       - mender-client
-    release_component: true
+    release_component: false
     independent_component: true
 
   deviceconfig:

--- a/git-versions.yml
+++ b/git-versions.yml
@@ -26,10 +26,10 @@ services:
     # Independent repositories
     #
     mender-setup:
-        image: mendersoftware/mender-setup:1.0.x
+        image: mendersoftware/mender-setup:master
 
     mender-snapshot:
-        image: mendersoftware/mender-snapshot:1.0.x
+        image: mendersoftware/mender-snapshot:master
 
     mender-ci-workflows:
         image: mendersoftware/mender-ci-workflows:master

--- a/other-components.yml
+++ b/other-components.yml
@@ -5,13 +5,13 @@
 # 'services' tag.
 services:
     mender-artifact:
-        image: mendersoftware/mender-artifact:4.0.x
+        image: mendersoftware/mender-artifact:master
 
     mender-cli:
-        image: mendersoftware/mender-cli:1.12.x
+        image: mendersoftware/mender-cli:master
 
     mender-convert:
-        image: mendersoftware/mender-convert:4.3.x
+        image: mendersoftware/mender-convert:master
 
     meta-mender:
         image: mendersoftware/meta-mender:scarthgap


### PR DESCRIPTION
This is specific for 3.8.x (Mender Client 5.0 and Mender Gateway 2.0) to let them use the latest versions of the independent components.

Ticket: QA-840