### PR TITLE
MEN-7634: Update image used in tests using Docker client

### DIFF
--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -45,7 +45,7 @@ class BaseTestUpdateModules(MenderTesting):
             def make_artifact(artifact_file, artifact_id):
                 cmd = (
                     "mender-artifact write module-image "
-                    + "-o %s -n %s -t docker-client -T nonexisting-module -f %s"
+                    + "-o %s -n %s -t generic-x86_64 -T nonexisting-module -f %s"
                     % (artifact_file, artifact_id, file1)
                 )
                 logger.info("Executing: " + cmd)

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -51,7 +51,7 @@ class DockerComposeNamespace(DockerComposeBaseNamespace):
         COMPOSE_FILES_PATH + "/docker-compose.client.rofs.commercial.yml",
     ]
     DOCKER_CLIENT_FILES = [
-        COMPOSE_FILES_PATH + "/docker-compose.docker-client.yml",
+        COMPOSE_FILES_PATH + "/docker-compose.docker-client.addons.yml",
     ]
     LEGACY_V1_CLIENT_FILES = [
         COMPOSE_FILES_PATH + "/docker-compose.client.yml",
@@ -83,7 +83,7 @@ class DockerComposeNamespace(DockerComposeBaseNamespace):
         COMPOSE_FILES_PATH + "/docker-compose.mt.client.yml",
     ]
     MT_DOCKER_CLIENT_FILES = [
-        COMPOSE_FILES_PATH + "/docker-compose.docker-client.yml",
+        COMPOSE_FILES_PATH + "/docker-compose.docker-client.addons.yml",
         COMPOSE_FILES_PATH + "/docker-compose.mt.client.yml",
     ]
     MTLS_FILES = [


### PR DESCRIPTION
To use the image that we will soon promote to "Virtual Device" for our Get Started guides in the docs.

For the purpose of the tests, it should not really matter if the virtual device is client only or also has the add-ons. By repurposing these tests to use the image with add-ons we indirectly check that this image is healthy.