### PR TITLE
QA-951: Capture junit reports in GitLab CI

### DIFF
--- a/.gitlab-ci-full-integration-template.yml
+++ b/.gitlab-ci-full-integration-template.yml
@@ -64,7 +64,7 @@ test:integration:$CI_NODE_INDEX:
     when: always
     paths:
       - tests/mender_test_logs
-      - tests/results_full_integration.xml
-      - tests/report_full_integration.html
+      - tests/results.xml
+      - tests/report.html
     reports:
-      junit: results_full_integration.xml
+      junit: tests/results.xml


### PR DESCRIPTION
The old pipeline used to rename the reports to distinguish between different CI jobs.