### PR TITLE
ci: Enable test_bogus_proto_message

### DIFF
--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -355,7 +355,6 @@ class _TestRemoteTerminalBase:
 
 
 class _TestRemoteTerminalBaseBogusProtoMessage:
-    @pytest.mark.skip("QA-916")
     def test_bogus_proto_message(self, docker_env):
         with docker_env.devconnect.get_websocket() as ws:
             prot = protomsg.ProtoMsg(12345)


### PR DESCRIPTION
The test uncovered a race condition when connecting and provisioning a device concurrently.
The issue was addressed here:
https://github.com/mendersoftware/mender-server/pull/486