### PR TITLE
QA-970: Send a separate status to GitHub for the integration tests run

### DIFF
--- a/.gitlab-ci-full-integration-generator.yml
+++ b/.gitlab-ci-full-integration-generator.yml
@@ -33,3 +33,41 @@ test:integration:trigger:
         job: test:integration:generator
     forward:
       pipeline_variables: true
+
+# GitHub status reports: send a separate one for the integration tests
+# pending after the generation is completed, success/failure after the child pipeline finishes
+
+test:integration:start:
+  extends: .github_status_template
+  variables:
+    GITHUB_STATUS_API_JSON_F: '{"state": "%s", "context": "ci/gitlab/integ-tests", "target_url": "%s", "description": "%s"}'
+  stage: test
+  needs:
+    - job: test:integration:generator
+      artifacts: false
+  script:
+    - send_status success "Pipeline passed on Gitlab"
+
+test:integration:success:
+  extends: .github_status_template
+  variables:
+    GITHUB_STATUS_API_JSON_F: '{"state": "%s", "context": "ci/gitlab/integ-tests", "target_url": "%s", "description": "%s"}'
+  stage: test
+  needs:
+    - job: test:integration:trigger
+      artifacts: false
+  when: on_success
+  script:
+    - send_status success "Pipeline passed on Gitlab"
+
+test:integration:failure:
+  extends: .github_status_template
+  variables:
+    GITHUB_STATUS_API_JSON_F: '{"state": "%s", "context": "ci/gitlab/integ-tests", "target_url": "%s", "description": "%s"}'
+  stage: test
+  needs:
+    - job: test:integration:trigger
+      artifacts: false
+  when: on_failure
+  script:
+    - send_status failure "Pipeline failed on Gitlab"


### PR DESCRIPTION
Running integration tests is an opt-in decision when doing a PR in `integration` repository. But to be able to differentiate from the "regular" pipeline with no actual tests is best to send a separate status pending + success/failure to the PR.