### PR TITLE
fix: Add package to the Virtual Device image to fix inventory script

### DIFF
--- a/extra/mender-client-docker-addons/Dockerfile
+++ b/extra/mender-client-docker-addons/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir -p /mender-install/var/lib/mender && echo device_type=generic-x86_64 >
 FROM ubuntu:24.04
 
 RUN mkdir -p /run/dbus && apt-get update && apt-get install -y \
-    liblzma5 dbus openssh-server sudo liblmdb0 libarchive13 libboost-log1.83.0
+    liblzma5 dbus openssh-server sudo liblmdb0 libarchive13 libboost-log1.83.0 iproute2
 
 # Set no password
 RUN sed -ie 's/^root:[^:]*:/root::/' /etc/shadow


### PR DESCRIPTION
The network inventory script depends on `ip` command.