### PR TITLE
cherry-pick: chore: add mender-flash to Client release bundle

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -38,6 +38,17 @@ git:
     release_component: true
     independent_component: true
 
+  mender-flash:
+    docker_image:
+    - mender-client-qemu
+    - mender-client-qemu-rofs
+    - mender-qemu-rofs-commercial
+    - mender-monitor-qemu-commercial
+    docker_container:
+    - mender-client
+    release_component: true
+    independent_component: true
+
   generate-delta-worker:
     docker_image:
     - generate-delta-worker
@@ -404,6 +415,7 @@ docker_image:
   mender-client-qemu:
     git:
     - mender
+    - mender-flash
     - mender-connect
     docker_container:
     - mender-client
@@ -413,6 +425,7 @@ docker_image:
   mender-client-qemu-rofs:
     git:
     - mender
+    - mender-flash
     - mender-connect
     docker_container:
     - mender-client
@@ -422,6 +435,7 @@ docker_image:
   mender-qemu-rofs-commercial:
     git:
     - mender
+    - mender-flash
     - mender-connect
     - mender-binary-delta
     docker_container:
@@ -560,6 +574,7 @@ docker_image:
     - monitor-client
     - mender
     - mender-connect
+    - mender-flash
     docker_container:
     - mender-client
     release_component: true
@@ -647,6 +662,7 @@ docker_container:
     - monitor-client
     - mender-connect
     - mender-binary-delta
+    - mender-flash
     docker_image:
     - mender-client-docker
     - mender-client-docker-addons

--- a/extra/license-overview-generator
+++ b/extra/license-overview-generator
@@ -13,6 +13,7 @@ OTHER_REPOS = [
     "mender-api-gateway-docker",
     "integration",
     "monitor-client",
+    "mender-flash",
     "mender-binary-delta",
     "mender-configure-module",
     "mender-convert",

--- a/extra/mender-client-docker-addons/Dockerfile
+++ b/extra/mender-client-docker-addons/Dockerfile
@@ -39,7 +39,7 @@ RUN jq ".ServerCertificate=\"/usr/share/doc/mender-auth/examples/demo.crt\" | .S
 RUN curl -fsSL https://downloads.mender.io/repos/debian/gpg > /etc/apt/trusted.gpg.d/mender.asc && \
     echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian ubuntu/$(. /etc/lsb-release && echo $DISTRIB_CODENAME)/experimental main" > \
         /etc/apt/sources.list.d/mender.list && \
-    apt-get update && apt-get install mender-artifact
+    apt-get update && apt-get install -y mender-artifact
 RUN mender-artifact write bootstrap-artifact \
         --artifact-name original \
         --device-type generic-x86_64 \

--- a/extra/release_tool.py
+++ b/extra/release_tool.py
@@ -270,6 +270,7 @@ BACKEND_SERVICES = (
 )
 CLIENT_SERVICES_ENT = {
     "mender-binary-delta",
+    "mender-flash",
     "monitor-client",
     "mender-gateway",
 }

--- a/extra/test_release_tool.py
+++ b/extra/test_release_tool.py
@@ -42,6 +42,7 @@ SAMPLE_REPOS_CLIENT = [
     "mender-configure-module",
     "monitor-client",
     "mender-binary-delta",
+    "mender-flash",
 ]
 SAMPLE_REPOS_DEPRECATED = [
     "deviceadm",
@@ -102,6 +103,17 @@ def test_version_of(capsys, is_master):
         run_main_assert_result(
             capsys,
             ["--version-of", "mender-connect", "--version-type", "docker"],
+            "mender-master",
+        )
+
+    run_main_assert_result(capsys, ["--version-of", "mender-flash"], "master")
+    run_main_assert_result(
+        capsys, ["--version-of", "mender-flash", "--version-type", "git"], "master"
+    )
+    with pytest.raises(Exception):
+        run_main_assert_result(
+            capsys,
+            ["--version-of", "mender-flash", "--version-type", "docker"],
             "mender-master",
         )
 
@@ -487,6 +499,7 @@ def test_git_to_buildparam():
         "deviceconfig": "DEVICECONFIG_REV",
         "devicemonitor": "DEVICEMONITOR_REV",
         "monitor-client": "MONITOR_CLIENT_REV",
+        "mender-flash": "MENDER_FLASH_REV",
         "reporting": "REPORTING_REV",
     }
 

--- a/git-versions.yml
+++ b/git-versions.yml
@@ -22,6 +22,9 @@ services:
     mender-binary-delta:
         image: mendersoftware/mender-binary-delta:1.5.x
 
+    mender-flash:
+        image: mendersoftware/mender-flash:master
+
     #
     # Independent repositories
     #

--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -356,6 +356,8 @@ class _TestRemoteTerminalBase:
 
 class _TestRemoteTerminalBaseBogusProtoMessage:
     def test_bogus_proto_message(self, docker_env):
+        self.assert_env(docker_env)
+
         with docker_env.devconnect.get_websocket() as ws:
             prot = protomsg.ProtoMsg(12345)
 

--- a/tests/tests/test_portforward.py
+++ b/tests/tests/test_portforward.py
@@ -102,13 +102,12 @@ class BaseTestPortForward(MenderTesting):
 
         # verify the TCP port-forward using scp to upload and download files
         try:
-            # create a 40MB random file
+            # create a 1KB random file
             f = NamedTemporaryFile(delete=False)
-            for i in range(40 * 1024):
-                f.write(os.urandom(1024))
+            f.write(os.urandom(1024))
             f.close()
 
-            logger.info("created a 40MB random file: " + f.name)
+            logger.info("created a 1KB random file: " + f.name)
 
             # upload the file using scp
             logger.info("uploading the file to the device using scp")

--- a/tests/tests/test_tcp_teardown.py
+++ b/tests/tests/test_tcp_teardown.py
@@ -14,6 +14,7 @@
 #
 
 import json
+import pytest
 import os.path
 import tempfile
 import time
@@ -102,9 +103,11 @@ class BaseTestTcpTeardown:
         assert get_opened_tcp_connections(mender_device, "mender-auth") == 0
 
 
+@pytest.mark.xfail(reason="QA-1076 and QA-1056")
 class TestTcpTeardownOpenSource(BaseTestTcpTeardown):
     pass
 
 
+@pytest.mark.xfail(reason="QA-1076 and QA-1056")
 class TestTcpTeardownEnterprise(BaseTestTcpTeardown):
     pass


### PR DESCRIPTION
Ticket: QA-993


(cherry picked from commit 62560182b924dc4099f4dd5945f01706069e1631)

https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/10343223633


We need this to make pipelines for 3.8.x pass, otherwise mender-qa will do:
`PREFERRED_VERSION:pn-mender-flash = "Unrecognized repository: mender-flash-git%"
IMAGE_INSTALL:append = " sqlite3 lsof"
}}}` (see https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/10343223633)