### PR TITLE
chore: add `-y` to `apt-get install`

### DIFF
--- a/extra/mender-client-docker-addons/Dockerfile
+++ b/extra/mender-client-docker-addons/Dockerfile
@@ -39,7 +39,7 @@ RUN jq ".ServerCertificate=\"/usr/share/doc/mender-auth/examples/demo.crt\" | .S
 RUN curl -fsSL https://downloads.mender.io/repos/debian/gpg > /etc/apt/trusted.gpg.d/mender.asc && \
     echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/debian ubuntu/$(. /etc/lsb-release && echo $DISTRIB_CODENAME)/experimental main" > \
         /etc/apt/sources.list.d/mender.list && \
-    apt-get update && apt-get install mender-artifact
+    apt-get update && apt-get install -y mender-artifact
 RUN mender-artifact write bootstrap-artifact \
         --artifact-name original \
         --device-type generic-x86_64 \


### PR DESCRIPTION
The docker build has started failing because it waits for `Do you want to continue? [Y/n] Abort.`

See:
https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/10382251689
https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/10396208639