### PR TITLE
test(integration): Add failure context when extractfs fails

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def _extract_fs_from_image(request, client_compose_file, filename):
         .split("\n")[0]
     )
 
-    subprocess.run(
+    ret = subprocess.run(
         [
             "docker",
             "run",
@@ -89,8 +89,14 @@ def _extract_fs_from_image(request, client_compose_file, filename):
             "--volume",
             d + ":/output",
             image,
-        ]
+        ],
+        capture_output=True,
     )
+    try:
+        ret.check_returncode()
+    except subprocess.CalledProcessError as ex:
+        logger.error(ex.stderr)
+        raise ex
 
     if not os.path.exists(os.path.join(THIS_DIR, filename)):
         shutil.move(os.path.join(d, filename), THIS_DIR)


### PR DESCRIPTION
If the command fails, it will fail on the next "move" statement which is misleading and does not say anything about why the fixture failed.