### PR TITLE
feat: add `SERVER_IP` arg to mender-client-docker-addons

### DIFF
--- a/extra/mender-client-docker-addons/entrypoint.sh
+++ b/extra/mender-client-docker-addons/entrypoint.sh
@@ -21,6 +21,9 @@ fi
 if [ -n "$TENANT_TOKEN" ]; then
     sed -i -e "s/\"TenantToken\": *\"[^\"]*\"/\"TenantToken\": \"$TENANT_TOKEN\"/" /etc/mender/mender.conf
 fi
+if [ -n "$SERVER_URL" ] && [ -n "$SERVER_IP" ];  then
+    echo "$SERVER_IP ${SERVER_URL#*//}" >> /etc/hosts
+fi
 
 /etc/init.d/ssh start
 cp /usr/share/dbus-1/system.d/io.mender.AuthenticationManager.conf /etc/dbus-1/system-local.conf


### PR DESCRIPTION
This will allow us to use this as virtual device for testing mender-gateway, e.g.:

```
docker run -it -p 85:85  \
    -e SERVER_IP="$SERVER_IP" \
    -e SERVER_URL="https://gateway.docker.mender.io" \
    -e TENANT_TOKEN="$TENANT_TOKEN" \
    mendersoftware/mender-client-docker-addons
```

It will add an entry to /etc/hosts so we can map SERVER_URL to SERVER_IP

Ticket: None
Changelog: Title