### PR TITLE
fix: fine-tune docker images priorities to fix failing test:integrati…

### DIFF
--- a/docker-compose.client-dev.yml
+++ b/docker-compose.client-dev.yml
@@ -6,3 +6,5 @@ services:
     mender-client:
         volumes:
             - ${BUILDDIR}:/mnt/build:ro
+        blkio_config:
+            weight: 100

--- a/docker-compose.client.demo.yml
+++ b/docker-compose.client.demo.yml
@@ -6,3 +6,5 @@ services:
     mender-client:
         ports:
             - "85:85"
+        blkio_config:
+            weight: 100

--- a/docker-compose.client.rofs.commercial.yml
+++ b/docker-compose.client.rofs.commercial.yml
@@ -5,3 +5,5 @@ services:
     #
     mender-client:
         image: ${MENDER_CLIENT_ENTERPRISE_REGISTRY}/${MENDER_CLIENT_REPOSITORY}/${MENDER_QEMU_ROFS_COMMERCIAL_IMAGE}:${MENDER_QEMU_ROFS_COMMERCIAL_TAG}
+        blkio_config:
+            weight: 100

--- a/docker-compose.client.rofs.yml
+++ b/docker-compose.client.rofs.yml
@@ -5,3 +5,5 @@ services:
     #
     mender-client:
         image: ${MENDER_CLIENT_REGISTRY}/${MENDER_CLIENT_REPOSITORY}/${MENDER_CLIENT_QEMU_ROFS_IMAGE}:${MENDER_CLIENT_QEMU_ROFS_TAG}
+        blkio_config:
+            weight: 100

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -12,6 +12,8 @@ services:
     environment:
       SERVER_URL:
       TENANT_TOKEN:
+    blkio_config:
+      weight: 100
 
 networks:
   mender: {}

--- a/docker-compose.docker-client.addons.yml
+++ b/docker-compose.docker-client.addons.yml
@@ -5,6 +5,8 @@ services:
         image: ${MENDER_CLIENT_REGISTRY}/${MENDER_CLIENT_REPOSITORY}/${MENDER_CLIENT_DOCKER_ADDONS_IMAGE}:${MENDER_CLIENT_DOCKER_ADDONS_TAG}
         networks:
             - mender
+        blkio_config:
+            weight: 100
 
 networks:
     mender:

--- a/docker-compose.docker-client.yml
+++ b/docker-compose.docker-client.yml
@@ -4,6 +4,8 @@ services:
     image: ${MENDER_CLIENT_REGISTRY}/${MENDER_CLIENT_REPOSITORY}/${MENDER_CLIENT_DOCKER_IMAGE}:${MENDER_CLIENT_DOCKER_TAG}
     networks:
       - mender
+    blkio_config:
+      weight: 100
 
 networks:
   mender: {}

--- a/docker-compose.monitor-client.commercial.yml
+++ b/docker-compose.monitor-client.commercial.yml
@@ -12,5 +12,7 @@ services:
     environment:
       - SERVER_URL=$SERVER_URL
       - TENANT_TOKEN=$TENANT_TOKEN
+    blkio_config:
+      weight: 100
 networks:
   mender: {}

--- a/docker-compose.mt.client.yml
+++ b/docker-compose.mt.client.yml
@@ -9,3 +9,5 @@ services:
         environment:
             - SERVER_URL=$SERVER_URL
             - TENANT_TOKEN=$TENANT_TOKEN
+        blkio_config:
+            weight: 100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,6 +238,8 @@ services:
     extends:
       file: common.yml
       service: mender-base
+    tmpfs:
+      - /data/db:size=1G
     networks:
       mender:
         aliases:


### PR DESCRIPTION
…on:1 pipeline

A lot of tests manipulate artifacts and make rootfs updates, which is very heavy on disk I/O. This caused tenantadm to time out on creating organization sometimes. Changed docker containers I/O priorities and moved mongodb database directory to RAM. This made some operations much faster, and the error almost dissapeared. Unfortunately, not 100% of issues were possible to fix. For example, sometimes mender-workflows-server gets a "no route to host" error when dispatching a job to workflows-worker. This is unrelated to the disk I/O issue but results in tenantadm failing in the same way.

Ticket: QA-1108
Changelog: Title