### PR TITLE
chore: mark mender-gateway as non-releasable

### DIFF
--- a/component-maps.yml
+++ b/component-maps.yml
@@ -11,7 +11,7 @@ git:
       - mender-gateway-qemu-commercial
     docker_container:
       - mender-gateway
-    release_component: true
+    release_component: false
     independent_component: true
 
   mender-convert:
@@ -798,7 +798,7 @@ docker_container:
     - mender-gateway
     docker_image:
     - mender-gateway-qemu-commercial
-    release_component: true
+    release_component: false
 
   mender-ci-workflows:
     git:

--- a/git-versions-enterprise.yml
+++ b/git-versions-enterprise.yml
@@ -3,16 +3,10 @@
 # therefore point to the internal Git tags/branches. We keep this information as a
 # docker-compose YAML file for parsing purposes.
 services:
-
-    #
-    # Mender Gateway LTS
-    #
+    # DEPRECATED: these are not released with release_tool anymore
     mender-gateway:
         image: registry.mender.io/mendersoftware/mender-gateway:master
 
-    #
-    # DEPRECATED: these are not released with release_tool anymore
-    #
     mender-deployments:
         image: registry.mender.io/mendersoftware/deployments-enterprise:master
 


### PR DESCRIPTION
The mender-gateway release process has been split from the client release process and is therefore not a part of the release_tool.