### PR TITLE
testing

### DIFF
--- a/.gitlab-ci-full-integration-template.yml
+++ b/.gitlab-ci-full-integration-template.yml
@@ -9,6 +9,7 @@ test:integration:$CI_NODE_INDEX:
   timeout: 10h
   before_script:
     - |
+      echo $CI_COMMIT_REF_PROTECTED
       if $CI_COMMIT_REF_PROTECTED == "false"; then
         echo "Tests can only be run on protected branches. This branch is not protected."
         exit 1

--- a/.gitlab-ci-full-integration-template.yml
+++ b/.gitlab-ci-full-integration-template.yml
@@ -8,6 +8,11 @@ test:integration:$CI_NODE_INDEX:
     - mender-qa-worker-integration-tests
   timeout: 10h
   before_script:
+    - |
+      if $CI_COMMIT_REF_PROTECTED == "false"; then
+        echo "Tests can only be run on protected branches. This branch is not protected."
+        exit 1
+      fi
     # These two variables would be set by GitLab CI "parallel" feature, and are used by our Pytest
     # plugin to split the tests among the CI jobs. They get substituted by the generator.
     - export CI_NODE_INDEX=$CI_NODE_INDEX


### PR DESCRIPTION
Instead of getting vague messages like
`Error: Cannot perform an interactive login from a non TTY device` because the secrets aren't available, we'll exit early and print a message explaining why.

The integration tests need to be run in a protected branch. We could add a rule and not run the job at all, but that could cause a pipeline with `RUN_TESTS_FULL_INTEGRATION=true` to be green even if the tests aren't run