### PR TITLE
test: Revert "test: mark test_tcp_teardown with xfail"

### DIFF
--- a/tests/tests/test_tcp_teardown.py
+++ b/tests/tests/test_tcp_teardown.py
@@ -14,7 +14,6 @@
 #
 
 import json
-import pytest
 import os.path
 import tempfile
 import time
@@ -103,11 +102,9 @@ class BaseTestTcpTeardown:
         assert get_opened_tcp_connections(mender_device, "mender-auth") == 0
 
 
-@pytest.mark.xfail(reason="QA-1076 and QA-1056")
 class TestTcpTeardownOpenSource(BaseTestTcpTeardown):
     pass
 
 
-@pytest.mark.xfail(reason="QA-1076 and QA-1056")
 class TestTcpTeardownEnterprise(BaseTestTcpTeardown):
     pass


### PR DESCRIPTION
The tests were marked with xfail due to failures when triggering the integration test pipeline. They seem the be passing with xpassed now, so it looks like we can re-enable the tests.

This reverts commit d8c33fe8fb65aa8bdef8732f361900f4c3b7ca85.

Ticket: QA-1076