### PR TITLE
chore: Update auth code for PyGithub

### DIFF
--- a/extra/changelog-generator/changelog-generator
+++ b/extra/changelog-generator/changelog-generator
@@ -218,10 +218,10 @@ class GitHubQuerier(GitQueryInterface):
         # class.
         import github
 
+        auth = None
         if os.getenv("GITHUB_TOKEN"):
-            self.github = github.Github(os.getenv("GITHUB_TOKEN"))
-        else:
-            self.github = github.Github()
+            auth = github.Auth.Token(os.getenv("GITHUB_TOKEN"))
+        self.github = github.Github(auth=auth)
 
     def get_commits_for_range(self, repo, range):
         base, head = range.split("..", 1)


### PR DESCRIPTION
The deprecated form of using auth is trowing warnings and triggering test failures in `integration-test-runner` (funny, right?)

Example of a failing pipeline:
* https://gitlab.com/Northern.tech/Mender/integration-test-runner/-/jobs/11378535759