### PR TITLE
chore(integration): native docker healthchecks for all services

### DIFF
--- a/docker-compose.client-dev.yml
+++ b/docker-compose.client-dev.yml
@@ -6,5 +6,3 @@ services:
     mender-client:
         volumes:
             - ${BUILDDIR}:/mnt/build:ro
-        blkio_config:
-            weight: 100

--- a/docker-compose.client.demo.yml
+++ b/docker-compose.client.demo.yml
@@ -6,5 +6,3 @@ services:
     mender-client:
         ports:
             - "85:85"
-        blkio_config:
-            weight: 100

--- a/docker-compose.client.extended.yml
+++ b/docker-compose.client.extended.yml
@@ -13,8 +13,6 @@ services:
       SERVER_URL:
       TENANT_TOKEN:
       QEMU_MEMORY: 512M
-    blkio_config:
-      weight: 100
 
 networks:
   mender: {}

--- a/docker-compose.client.rofs.commercial.yml
+++ b/docker-compose.client.rofs.commercial.yml
@@ -5,5 +5,3 @@ services:
     #
     mender-client:
         image: ${MENDER_CLIENT_ENTERPRISE_REGISTRY}/${MENDER_CLIENT_REPOSITORY}/${MENDER_QEMU_ROFS_COMMERCIAL_IMAGE}:${MENDER_QEMU_ROFS_COMMERCIAL_TAG}
-        blkio_config:
-            weight: 100

--- a/docker-compose.client.rofs.yml
+++ b/docker-compose.client.rofs.yml
@@ -5,5 +5,3 @@ services:
     #
     mender-client:
         image: ${MENDER_CLIENT_REGISTRY}/${MENDER_CLIENT_REPOSITORY}/${MENDER_CLIENT_QEMU_ROFS_IMAGE}:${MENDER_CLIENT_QEMU_ROFS_TAG}
-        blkio_config:
-            weight: 100

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -12,8 +12,6 @@ services:
     environment:
       SERVER_URL:
       TENANT_TOKEN:
-    blkio_config:
-      weight: 100
 
 networks:
   mender: {}

--- a/docker-compose.docker-client.addons.yml
+++ b/docker-compose.docker-client.addons.yml
@@ -7,8 +7,6 @@ services:
         privileged: true
         networks:
             - mender
-        blkio_config:
-            weight: 100
 
 networks:
     mender:

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -8,6 +8,12 @@ services:
             service: mender-base
         networks:
             - mender
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 10s
+            timeout: 3s
+            retries: 5
+            start_period: 5s
 
     mender-create-artifact-worker:
         image: ${MENDER_SERVER_ENTERPRISE_REGISTRY}/${MENDER_SERVER_ENTERPRISE_REPOSITORY}/create-artifact-worker:${MENDER_SERVER_TAG}
@@ -49,7 +55,8 @@ services:
         networks:
             - mender
         depends_on:
-            - mender-mongo
+            mender-mongo:
+                condition: service_healthy
 
     # configure the rest
     mender-device-auth:
@@ -78,10 +85,9 @@ services:
         networks:
             - mender
         depends_on:
-            - mender-mongo
+            mender-mongo:
+                condition: service_healthy
         command: server --automigrate
-        labels:
-            mender.healthcheck.path: "/api/internal/v1/auditlogs/health"
 
     mender-api-gateway:
         volumes:
@@ -117,8 +123,10 @@ services:
         networks:
             - mender
         depends_on:
-            - mender-mongo
-            - mender-nats
+            mender-mongo:
+                condition: service_healthy
+            mender-nats:
+                condition: service_healthy
 
     mender-devicemonitor:
         image: ${MENDER_SERVER_ENTERPRISE_REGISTRY}/${MENDER_SERVER_ENTERPRISE_REPOSITORY}/devicemonitor:${MENDER_SERVER_TAG}
@@ -129,9 +137,8 @@ services:
         networks:
             - mender
         depends_on:
-            - mender-mongo
-        labels:
-            mender.healthcheck.path: "/api/internal/v1/devicemonitor/health"
+            mender-mongo:
+                condition: service_healthy
 
 networks:
     mender: null

--- a/docker-compose.monitor-client.commercial.yml
+++ b/docker-compose.monitor-client.commercial.yml
@@ -12,7 +12,5 @@ services:
     environment:
       - SERVER_URL=$SERVER_URL
       - TENANT_TOKEN=$TENANT_TOKEN
-    blkio_config:
-      weight: 100
 networks:
   mender: {}

--- a/docker-compose.mt.client.yml
+++ b/docker-compose.mt.client.yml
@@ -9,5 +9,3 @@ services:
         environment:
             - SERVER_URL=$SERVER_URL
             - TENANT_TOKEN=$TENANT_TOKEN
-        blkio_config:
-            weight: 100

--- a/docker-compose.reporting.yml
+++ b/docker-compose.reporting.yml
@@ -43,9 +43,8 @@ services:
         networks:
             - mender
         depends_on:
-            - mender-opensearch
-        labels:
-            mender.healthcheck.path: "/api/internal/v1/reporting/health"
+            mender-opensearch:
+                condition: service_healthy
 
     #
     # mender-reporting-indexer
@@ -61,7 +60,8 @@ services:
         networks:
             - mender
         depends_on:
-            - mender-opensearch
+            mender-opensearch:
+                condition: service_healthy
 
     #
     # mender-opensearch
@@ -77,3 +77,9 @@ services:
             - "discovery.type=single-node"
             - "plugins.security.disabled=true"
             - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        healthcheck:
+            test: ["CMD-SHELL", "curl -fsS http://localhost:9200/_cluster/health | grep -Eq '\"status\":\"(green|yellow)\"'"]
+            interval: 15s
+            timeout: 5s
+            retries: 10
+            start_period: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,8 @@ services:
     networks:
       - mender
     depends_on:
-      - mender-mongo
-    labels:
-      mender.healthcheck.path: "/api/internal/v1/iot-manager/health"
+      mender-mongo:
+        condition: service_healthy
 
   #
   # mender-deployments
@@ -25,9 +24,8 @@ services:
     networks:
       - mender
     depends_on:
-      - mender-mongo
-    labels:
-      mender.healthcheck.path: "/api/internal/v1/deployments/health"
+      mender-mongo:
+        condition: service_healthy
 
   #
   # mender-gui
@@ -47,6 +45,12 @@ services:
       - MENDER_DEB_PACKAGE_VERSION
       - HAVE_DEVICECONNECT=1
       - HAVE_DEVICECONFIG=1
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8090/ui/ || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
 
   #
   # mender-api-gateway
@@ -64,6 +68,7 @@ services:
     # Enables the web UI and tells Traefik to listen to docker
     command:
       - --accesslog=true
+      - --ping=true
       - --entrypoints.http.address=:80
       - --entrypoints.http.http.redirections.entryPoint.scheme=https
       - --entrypoints.http.http.redirections.entryPoint.to=https
@@ -79,6 +84,12 @@ services:
       - ./config/traefik/traefik.yaml:/etc/traefik/config/traefik.yaml:ro
       - ./config/traefik/traefik.middlewares.yaml:/etc/traefik/config/traefik.middlewares.yaml:ro
 
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/ping | grep -q 'OK'"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
     networks:
       - mender
     # critical - otherwise nginx may not detect
@@ -102,10 +113,10 @@ services:
     networks:
       - mender
     depends_on:
-      - mender-mongo
-      - mender-workflows-server
-    labels:
-      mender.healthcheck.path: "/api/internal/v1/devauth/health"
+      mender-mongo:
+        condition: service_healthy
+      mender-workflows-server:
+        condition: service_started
 
   #
   # mender-inventory
@@ -120,9 +131,8 @@ services:
     networks:
       - mender
     depends_on:
-      - mender-mongo
-    labels:
-      mender.healthcheck.path: "/api/internal/v1/inventory/health"
+      mender-mongo:
+        condition: service_healthy
 
   #
   # mender-useradm
@@ -135,9 +145,8 @@ services:
     networks:
       - mender
     depends_on:
-      - mender-mongo
-    labels:
-      mender.healthcheck.path: "/api/internal/v1/useradm/health"
+      mender-mongo:
+        condition: service_healthy
 
   #
   # mender-workflows-server
@@ -152,10 +161,10 @@ services:
     networks:
       - mender
     depends_on:
-      - mender-mongo
-      - mender-nats
-    labels:
-      mender.healthcheck.path: "/health"
+      mender-mongo:
+        condition: service_healthy
+      mender-nats:
+        condition: service_healthy
 
   #
   # mender-workflows-worker
@@ -178,8 +187,10 @@ services:
     networks:
       - mender
     depends_on:
-      - mender-mongo
-      - mender-nats
+      mender-mongo:
+        condition: service_healthy
+      mender-nats:
+        condition: service_healthy
 
   #
   # mender-create-artifact-worker
@@ -194,8 +205,10 @@ services:
     networks:
       - mender
     depends_on:
-      - mender-mongo
-      - mender-nats
+      mender-mongo:
+        condition: service_healthy
+      mender-nats:
+        condition: service_healthy
 
   #
   # mender-deviceconnect
@@ -208,14 +221,14 @@ services:
       service: mender-base
     networks:
       - mender
-    depends_on:
-      - mender-mongo
-      - mender-nats
     environment:
       DEVICECONNECT_MONGO_URL: "mongodb://mender-mongo"
       DEVICECONNECT_NATS_URI: "nats://mender-nats:4222"
-    labels:
-      mender.healthcheck.path: "/api/internal/v1/deviceconnect/health"
+    depends_on:
+      mender-mongo:
+        condition: service_healthy
+      mender-nats:
+        condition: service_healthy
 
   #
   # mender-deviceconfig
@@ -227,11 +240,10 @@ services:
       service: mender-base
     networks:
       - mender
-    depends_on:
-      - mender-mongo
     command: server --automigrate
-    labels:
-      mender.healthcheck.path: "/api/internal/v1/deviceconfig/health"
+    depends_on:
+      mender-mongo:
+        condition: service_healthy
 
   mender-mongo:
     image: mongo:8.0
@@ -240,6 +252,12 @@ services:
       service: mender-base
     tmpfs:
       - /data/db:size=1G
+    healthcheck:
+      test: ["CMD", "mongosh", "mongodb://localhost:27017/test", "--quiet", "--eval", "db.runCommand('ping').ok"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
     networks:
       mender:
         aliases:
@@ -251,8 +269,14 @@ services:
           - mongo-workflows
 
   mender-nats:
-    image: nats:2.10.24-scratch
-    command: -js
+    image: nats:2.10.24-alpine
+    command: ["-js", "-m", "8222"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz | grep -q 'ok'"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
     networks:
       - mender
 

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -24,7 +24,6 @@ import subprocess
 from contextlib import contextmanager
 from typing import List
 
-import docker
 import redo
 import requests
 
@@ -407,121 +406,6 @@ def get_mender_artifact(
     finally:
         os.unlink(filename)
         os.path.exists(artifact) and os.unlink(artifact)
-
-
-def wait_for_api_gateway(
-    api_gateway_ip: str,
-    api_gateway_port: int = 8080,
-    router_to_check: str = "useradm@file",  # one of the routers loaded from dynamic configuration
-    delay_seconds: int = 5,
-    timeout_seconds: int = 180,
-):
-    api_gateway_url = f"http://{api_gateway_ip}:{api_gateway_port}/api/http/routers"
-    start_time = time.time()
-
-    logger.debug(
-        f"Waiting for mender-api-gateway to be ready. Polling {api_gateway_url} for router '{router_to_check}'..."
-    )
-    attempt = 0
-    while True:
-        attempt += 1
-        if time.time() - start_time > timeout_seconds:
-            raise TimeoutError(
-                f"Timeout ({timeout_seconds}s) reached while waiting for mender-api-gateway. Giving up."
-            )
-
-        try:
-            rsp = requests.get(api_gateway_url, timeout=delay_seconds)
-            rsp.raise_for_status()
-            routers_data = rsp.json()
-            router_names = [router.get("name") for router in routers_data]
-
-            if router_to_check in router_names:
-                logger.info(
-                    f"mender-api-gateway is ready. Router '{router_to_check}' found after {attempt} attempts."
-                )
-                break
-            else:
-                logger.debug(
-                    f"Attempt {attempt}: Router '{router_to_check}' not yet found. Current routers: {router_names}"
-                )
-        except Exception as e:
-            logger.warning(
-                f"Attempt {attempt}: An unexpected error occurred: {e}. Retrying in {delay_seconds}s..."
-            )
-
-        time.sleep(delay_seconds)
-
-
-def wait_until_healthy(compose_project: str = "", timeout: int = 60):
-    """
-    wait_until_healthy polls all running containers health check
-    endpoints until they return a non-error status code.
-    :param compose_project: the docker-compose project ID, if empty it
-                            checks all running containers.
-    :param timeout: timeout in seconds.
-    """
-    client = docker.from_env()
-    kwargs = {}
-    if compose_project != "":
-        kwargs["filters"] = {"label": f"com.docker.compose.project={compose_project}"}
-
-    path_map = {
-        "mender-api-gateway": "/ping",
-        "mender-auditlogs": "/api/internal/v1/auditlogs/health",
-        "mender-deviceconnect": "/api/internal/v1/deviceconnect/health",
-        "mender-deviceconfig": "/api/internal/v1/deviceconfig/health",
-        "mender-device-auth": "/api/internal/v1/devauth/health",
-        "mender-deployments": "/api/internal/v1/deployments/health",
-        "mender-inventory": "/api/internal/v1/inventory/health",
-        "mender-tenantadm": "/api/internal/v1/tenantadm/health",
-        "mender-useradm": "/api/internal/v1/useradm/health",
-        "mender-workflows": "/api/v1/health",
-        "minio": "/minio/health/live",
-    }
-
-    containers = client.containers.list(all=True, **kwargs)
-    for container in containers:
-
-        container_ip = None
-        for _, net in container.attrs["NetworkSettings"]["Networks"].items():
-            container_ip = net["IPAddress"]
-            break
-        if container_ip is None or container_ip == "":
-            continue
-
-        service = container.labels.get(
-            "com.docker.compose.service", container.name
-        ).split("-enterprise")[0]
-        if service.startswith("mender-workflows-server"):
-            service = "mender-workflows"
-
-        path = path_map.get(service)
-        if path is None:
-            continue
-        port = 8080 if service != "minio" else 9000
-
-        for _ in redo.retrier(attempts=timeout, sleeptime=1):
-            try:
-                rsp = requests.request("GET", f"http://{container_ip}:{port}{path}")
-            except requests.exceptions.ConnectionError:
-                # A ConnectionError is expected if the service is not running yet
-                continue
-            if rsp.status_code < 300:
-                break
-        else:
-            raise TimeoutError(
-                f"Timed out waiting for service '{service}' to become healthy"
-            )
-
-        # Additional handling for mender-api-gateway initialization: Make sure we have routings from
-        # dynamic configuration in mender-api-gateway loaded before starting any tests.
-        # Without it, we can have mender-api-gateway not initialized fully and see errors e.g. on
-        # connecting to /useradm/auth/login, which is unintuitive. In the past, if starting too many
-        # containers simultaneously, mender-api-gateway has run out of limit on open files, which
-        # caused configuration not to be loaded.
-        if service.startswith("mender-api-gateway"):
-            wait_for_api_gateway(container_ip, router_to_check="useradm@file")
 
 
 def update_tenant(tid, addons=None, plan=None, container_manager=None):

--- a/testutils/infra/container_manager/base.py
+++ b/testutils/infra/container_manager/base.py
@@ -19,6 +19,8 @@ import random
 class BaseContainerManagerNamespace:
     """Base class to define a containers namespace"""
 
+    wait_healthy_timeout = 300
+
     def __init__(self, name=None):
         """Creates instance
 

--- a/testutils/infra/container_manager/docker_compose_base_manager.py
+++ b/testutils/infra/container_manager/docker_compose_base_manager.py
@@ -125,10 +125,16 @@ class DockerComposeBaseNamespace(DockerNamespace):
                 len(gateway), self.name
             )
 
+    def _docker_compose_up(self, extra_args="", env=None):
+        cmd = f"up -d --wait --wait-timeout {self.wait_healthy_timeout}"
+        if extra_args:
+            cmd += f" {extra_args}"
+        return self._docker_compose_cmd(cmd, env=env)
+
     def restart_service(self, service):
         """Restarts a service."""
         self._docker_compose_cmd(f"up -d --scale {service}=0 {service}")
-        self._docker_compose_cmd(f"up -d --scale {service}=1 {service}")
+        self._docker_compose_up(f"--scale {service}=1 {service}")
 
     def get_file(self, container_name, path):
         container_id = super().getid([container_name])
@@ -175,22 +181,19 @@ class DockerComposeBaseNamespace(DockerNamespace):
         raise Exception("failed to start docker compose (called: %s)" % cmd)
 
     def _stop_docker_compose(self):
-        with docker_lock:
-            stop_sleep_seconds = 15
-            retry_attempts = 8
+        stop_sleep_seconds = 15
+        retry_attempts = 8
 
-            # Take down all docker instances in this namespace.
-            while retry_attempts > 0:
-                logger.info(
-                    "(attempts left: %d) trying to stop all containers in %s"
-                    % (retry_attempts, self.name)
-                )
-                try:
-                    self._docker_compose_cmd(
-                        "down -v --remove-orphans", fail_early=False
-                    )
-                    break
-                except Exception as e:
-                    time.sleep(stop_sleep_seconds)
-                    logger.error(e)
-                    retry_attempts = retry_attempts - 1
+        # Take down all docker instances in this namespace.
+        while retry_attempts > 0:
+            logger.info(
+                "(attempts left: %d) trying to stop all containers in %s"
+                % (retry_attempts, self.name)
+            )
+            try:
+                self._docker_compose_cmd("down -v --remove-orphans", fail_early=False)
+                break
+            except Exception as e:
+                time.sleep(stop_sleep_seconds)
+                logger.error(e)
+                retry_attempts = retry_attempts - 1

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -18,8 +18,6 @@ import socket
 import subprocess
 import time
 
-from testutils.common import wait_until_healthy
-
 from .docker_compose_base_manager import DockerComposeBaseNamespace, docker_lock
 
 logger = logging.getLogger("root")
@@ -102,11 +100,7 @@ class DockerComposeNamespace(DockerComposeBaseNamespace):
     ]
 
     def setup(self):
-        self._docker_compose_cmd("up -d")
-        self._wait_for_containers()
-
-    def _wait_for_containers(self):
-        wait_until_healthy(self.name, timeout=60 * 5)
+        self._docker_compose_up()
 
     def teardown_exclude(self, exclude=[]):
         """
@@ -135,8 +129,7 @@ class DockerComposeStandardSetup(DockerComposeNamespace):
         super().__init__(name, self.QEMU_CLIENT_FILES)
 
     def setup(self):
-        self._docker_compose_cmd("up -d --scale mender-client=%d" % self.num_clients)
-        self._wait_for_containers()
+        self._docker_compose_up(f"--scale mender-client={self.num_clients}")
 
 
 class DockerComposeExtendedSetup(DockerComposeNamespace):
@@ -145,8 +138,7 @@ class DockerComposeExtendedSetup(DockerComposeNamespace):
         super().__init__(name, self.QEMU_EXTENDED_FILES)
 
     def setup(self):
-        self._docker_compose_cmd("up -d --scale mender-client=%d" % self.num_clients)
-        self._wait_for_containers()
+        self._docker_compose_up(f"--scale mender-client={self.num_clients}")
 
     def get_mender_clients(self, network="mender"):
         return super().get_mender_clients(
@@ -167,11 +159,8 @@ class DockerComposeMonitorCommercialSetup(DockerComposeNamespace):
             )
 
     def setup(self, recreate=True, env=None):
-        cmd = "up -d"
-        if not recreate:
-            cmd += " --no-recreate"
-        self._docker_compose_cmd(cmd, env=env)
-        self._wait_for_containers()
+        args = "" if recreate else "--no-recreate"
+        self._docker_compose_up(args, env)
 
     def new_tenant_client(self, name, tenant):
         if not self.MONITOR_CLIENT_COMMERCIAL_FILES[0] in self.docker_compose_files:
@@ -276,15 +265,12 @@ class DockerComposeEnterpriseSetup(DockerComposeNamespace):
             DockerComposeNamespace.__init__(self, name, self.ENTERPRISE_FILES)
 
     def setup(self, recreate=True, env=None):
-        cmd = "up -d"
-        if any(
-            ["client" in compose_file for compose_file in self.docker_compose_files]
-        ):
-            cmd += " --scale mender-client=%d" % self.num_clients
+        args = ""
+        if any("client" in cf for cf in self.docker_compose_files):
+            args += f"--scale mender-client={self.num_clients}"
         if not recreate:
-            cmd += " --no-recreate"
-        self._docker_compose_cmd(cmd, env=env)
-        self._wait_for_containers()
+            args += " --no-recreate"
+        self._docker_compose_up(args, env)
 
     def new_tenant_client(self, name, tenant):
         if not self.MT_CLIENT_FILES[0] in self.docker_compose_files:
@@ -417,17 +403,14 @@ class DockerComposeEnterpriseDockerClientSetup(DockerComposeEnterpriseSetup):
             )
 
     def setup(self):
-        compose_args = "up -d --scale mender-client=0"
-        self._docker_compose_cmd(compose_args)
-        self._wait_for_containers()
+        self._docker_compose_up("--scale mender-client=0")
 
     def new_tenant_docker_client(self, name, tenant):
         logger.info("creating docker client connected to tenant: " + tenant)
-        self._docker_compose_cmd(
-            "up -d --scale mender-client=1",
-            env={"TENANT_TOKEN": "%s" % tenant},
+        self._docker_compose_up(
+            "--scale mender-client=1",
+            {"TENANT_TOKEN": "%s" % tenant},
         )
-        time.sleep(5)
 
 
 class DockerComposeMTLSSetup(DockerComposeNamespace):
@@ -437,11 +420,10 @@ class DockerComposeMTLSSetup(DockerComposeNamespace):
 
     def setup(self):
         host_ip = socket.gethostbyname(socket.gethostname())
-        self._docker_compose_cmd(
-            "up -d --scale mtls-gateway=0 --scale mender-client=0",
-            env={"HOST_IP": host_ip},
+        self._docker_compose_up(
+            "--scale mtls-gateway=0 --scale mender-client=0",
+            {"HOST_IP": host_ip},
         )
-        self._wait_for_containers()
 
     def start_api_gateway(self):
         self._docker_compose_cmd("start mender-api-gateway")
@@ -450,8 +432,7 @@ class DockerComposeMTLSSetup(DockerComposeNamespace):
         self._docker_compose_cmd("stop mender-api-gateway")
 
     def start_mtls_gateway(self):
-        self._docker_compose_cmd("up -d --scale mtls-gateway=1 mtls-gateway")
-        self._wait_for_containers()
+        self._docker_compose_up("--scale mtls-gateway=1 mtls-gateway")
 
     def new_mtls_client(self, name, tenant):
         self._docker_compose_cmd(


### PR DESCRIPTION
chore: Replaces custom Python container-readiness polling with docker-native HEALTHCHECK

Python cleanup:
- testutils/common.py: removes wait_until_healthy (obsolete HTTP-poll path_map) and its sole helper wait_for_api_gateway.
- docker_compose_manager.py: removes the _wait_for_containers method and its 8 call sites; --wait in _docker_compose_up is authoritative.

Ticket: QA-1581