### PR TITLE
fix: double start of mender-connect for filetransfer tests

### DIFF
--- a/tests/tests/test_filetransfer.py
+++ b/tests/tests/test_filetransfer.py
@@ -108,9 +108,7 @@ def set_limits(docker_env, mender_device, limits, auth, devid):
     finally:
         shutil.rmtree(tmpdir)
     mender_device.run("kill -TERM `pidof %s`" % connect_service_name)
-    docker_env._docker_compose_cmd(
-        "exec -d mender-client %s daemon" % connect_service_name
-    )
+    time.sleep(4)
     wait_for_connect(auth, devid)
     debugoutput = mender_device.run("cat /etc/mender/mender-connect.conf")
     logger.info("/etc/mender/mender-connect.conf:\n%s" % debugoutput)


### PR DESCRIPTION
Changelog: Title
Ticket: QA-1590