### PR TITLE
test: prevent enterprise fixture from spawning unecessary qemu

### DIFF
--- a/tests/tests/test_filetransfer.py
+++ b/tests/tests/test_filetransfer.py
@@ -769,7 +769,11 @@ class TestFileTransferLimitsEnterprise(BaseTestFileTransferLimits):
     @pytest.fixture(scope="function")
     def mender_device_setup(self, request, enterprise_one_docker_client_bootstrapped):
         env = enterprise_one_docker_client_bootstrapped
-        devid, auth_token, auth, mender_device = prepare_env_for_connect(env)
+        devid, auth_token, auth, mender_device = prepare_env_for_connect(
+            env,
+            docker=True,
+            ignore_existing=True,
+        )
         request.cls.devid = devid
         request.cls.auth_token = auth_token
         request.cls.auth = auth


### PR DESCRIPTION
The fixture would start a mender-client-docker-addons virtual device and a mender-client-qemu virtual device, when only mender-client-docker-addons is needed

```
mendersoftware/mender-client-qemu:client-main             "./entrypoint.sh"        53 seconds ago       Up 52 seconds                 8822/tcp                       mender386344_mender-client
mendersoftware/mender-client-docker-addons:client-main    "/entrypoint.sh"         About a minute ago   Up About a minute (healthy)                                  mender386344-mender-client-1
```