### PR TITLE
test(infra): replace qemu with docker client in integration tests

### DIFF
--- a/tests/MenderAPI/devauth.py
+++ b/tests/MenderAPI/devauth.py
@@ -149,7 +149,8 @@ class DeviceAuthV2:
             )
 
         # block until devices are actually accepted
-        timeout = time.time() + 30
+        accept_timeout = 120
+        timeout = time.time() + accept_timeout
         while time.time() <= timeout:
             time.sleep(1)
             if (
@@ -163,7 +164,7 @@ class DeviceAuthV2:
                 break
 
         if time.time() > timeout:
-            pytest.fail("wasn't able to accept device after 30 seconds")
+            pytest.fail(f"wasn't able to accept device after {accept_timeout} seconds")
 
         logger.info("Successfully bootstrap all clients")
 

--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -44,6 +44,21 @@ def standard_setup_one_client():
 
 
 @pytest.fixture(scope="function")
+def standard_setup_one_docker_client():
+    env = container_factory.get_docker_client_setup()
+    env.setup()
+
+    env.device = MenderDevice(env.get_mender_clients()[0])
+    env.device.ssh_is_opened()
+
+    reset_mender_api(env)
+
+    env.auth = auth
+    yield env
+    env.teardown()
+
+
+@pytest.fixture(scope="function")
 def standard_setup_extended():
     env = container_factory.get_extended_setup(num_clients=1)
     env.setup()
@@ -323,6 +338,20 @@ def enterprise_one_docker_client_bootstrapped_impl():
     devauth_tenant.accept_devices(1)
     devices = devauth_tenant.get_devices_status("accepted")
     assert 1 == len(devices)
+
+    yield env
+    env.teardown()
+
+
+@pytest.fixture(scope="function")
+def enterprise_one_docker_client():
+    env = container_factory.get_enterprise_docker_client_setup(num_clients=0)
+    env.setup()
+    reset_mender_api(env)
+
+    tenant = create_tenant(env)
+    new_tenant_client(env, "mender-client", tenant["tenant_token"], docker=True)
+    env.device_group.ssh_is_opened()
 
     yield env
     env.teardown()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,6 +14,7 @@
 
 import logging
 import json
+import re
 import time
 
 import pytest
@@ -63,6 +64,47 @@ class Helpers:
 
     @staticmethod
     def _check_log_for_message(device, message, since=None):
+        # Docker client has no systemd — check auth state via D-Bus instead.
+        # Detect the running init system, not just the presence of the
+        # systemctl binary (which exists in the Docker client image too).
+        has_systemd = (
+            device.run(
+                "test -d /run/systemd/system && echo yes",
+                warn=True,
+                hide=True,
+            ).strip()
+            == "yes"
+        )
+        if not has_systemd:
+            if "Successfully received new authorization data" in message:
+                sleepsec = 0
+                timeout = 600
+                while sleepsec < timeout:
+                    out = device.run(
+                        "dbus-send --system --print-reply "
+                        "--dest=io.mender.AuthenticationManager "
+                        "/io/mender/AuthenticationManager "
+                        "io.mender.Authentication1.GetJwtToken 2>/dev/null",
+                        warn=True,
+                        hide=True,
+                    )
+                    # GetJwtToken replies with the JWT as the first 'string'
+                    # value; it is empty until the device has authenticated.
+                    token = re.search(r'string "([^"]*)"', out or "")
+                    if token and token.group(1):
+                        return
+                    time.sleep(10)
+                    sleepsec += 10
+                    logger.info(
+                        f"waiting for device to authenticate via D-Bus, waited {sleepsec}s"
+                    )
+                assert False, "timeout waiting for device to authenticate via D-Bus"
+            # Only the "authenticated" check is implemented over D-Bus. Fail
+            # loudly rather than silently passing for any other log message.
+            raise NotImplementedError(
+                "log message check not implemented for docker client: %r" % message
+            )
+
         if since:
             cmd = f"journalctl --unit mender-authd --full --since '{since}'"
         else:

--- a/tests/tests/test_bootstrapping.py
+++ b/tests/tests/test_bootstrapping.py
@@ -19,8 +19,10 @@ import pytest
 from ..common_setup import (
     standard_setup_one_client,
     standard_setup_one_client_bootstrapped,
+    standard_setup_one_docker_client,
     enterprise_one_client,
     enterprise_one_client_bootstrapped,
+    enterprise_one_docker_client,
 )
 from .common_update import common_update_procedure
 from ..MenderAPI import DeviceAuthV2, Deployments, logger
@@ -102,8 +104,8 @@ class BaseTestBootstrapping(MenderTesting):
 
 class TestBootstrappingOpenSource(BaseTestBootstrapping):
     @MenderTesting.fast
-    def test_bootstrap(self, standard_setup_one_client):
-        self.do_test_bootstrap(standard_setup_one_client)
+    def test_bootstrap(self, standard_setup_one_docker_client):
+        self.do_test_bootstrap(standard_setup_one_docker_client)
 
     @MenderTesting.slow
     def test_reject_bootstrap(
@@ -116,8 +118,8 @@ class TestBootstrappingOpenSource(BaseTestBootstrapping):
 
 class TestBootstrappingEnterprise(BaseTestBootstrapping):
     @MenderTesting.fast
-    def test_bootstrap(self, enterprise_one_client):
-        self.do_test_bootstrap(enterprise_one_client)
+    def test_bootstrap(self, enterprise_one_docker_client):
+        self.do_test_bootstrap(enterprise_one_docker_client)
 
     @MenderTesting.slow
     def test_reject_bootstrap(self, enterprise_one_client_bootstrapped, valid_image):

--- a/tests/tests/test_preauth.py
+++ b/tests/tests/test_preauth.py
@@ -18,7 +18,7 @@ import uuid
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
-from ..common_setup import standard_setup_one_client, enterprise_no_client
+from ..common_setup import standard_setup_one_docker_client, enterprise_no_client
 from .mendertesting import MenderTesting
 from ..MenderAPI import auth, devauth, inv, logger
 from ..helpers import Helpers
@@ -154,13 +154,13 @@ UwIDAQAB
 
 
 class TestPreauth(TestPreauthBase):
-    def test_ok_preauth_and_bootstrap(self, standard_setup_one_client):
-        self.do_test_ok_preauth_and_bootstrap(standard_setup_one_client)
+    def test_ok_preauth_and_bootstrap(self, standard_setup_one_docker_client):
+        self.do_test_ok_preauth_and_bootstrap(standard_setup_one_docker_client)
 
-    def test_ok_preauth_and_remove(self, standard_setup_one_client):
+    def test_ok_preauth_and_remove(self, standard_setup_one_docker_client):
         self.do_test_ok_preauth_and_remove()
 
-    def test_fail_preauth_existing(self, standard_setup_one_client):
+    def test_fail_preauth_existing(self, standard_setup_one_docker_client):
         self.do_test_fail_preauth_existing()
 
 
@@ -196,7 +196,8 @@ class Client:
     """Wraps various actions on the client, performed via SSH (inside fabric.execute())."""
 
     ID_HELPER = "/usr/share/mender/identity/mender-device-identity"
-    PRIV_KEY = "/data/mender/mender-agent.pem"
+    # /var/lib/mender works for both the docker client and qemu (symlinked to /data).
+    PRIV_KEY = "/var/lib/mender/mender-agent.pem"
 
     KEYGEN_TIMEOUT = 300
 

--- a/testutils/infra/container_manager/docker_compose_manager.py
+++ b/testutils/infra/container_manager/docker_compose_manager.py
@@ -178,11 +178,12 @@ class DockerComposeMonitorCommercialSetup(DockerComposeNamespace):
 
 
 class DockerComposeDockerClientSetup(DockerComposeNamespace):
-    def __init__(
-        self,
-        name,
-    ):
+    def __init__(self, name, num_clients=1):
+        self.num_clients = num_clients
         DockerComposeNamespace.__init__(self, name, self.DOCKER_CLIENT_FILES)
+
+    def setup(self):
+        self._docker_compose_up(f"--scale mender-client={self.num_clients}")
 
 
 class DockerComposeRofsClientSetup(DockerComposeNamespace):

--- a/testutils/infra/container_manager/factory.py
+++ b/testutils/infra/container_manager/factory.py
@@ -39,7 +39,7 @@ class ContainerManagerFactory:
     def get_standard_setup(self, name=None, num_clients=1):
         """Standard setup consisting on all core backend services and optionally clients
 
-        The num_clients define how many QEMU Mender clients will be spawn.
+        The num_clients define how many Mender clients will be spawned.
         """
         pass
 
@@ -50,12 +50,12 @@ class ContainerManagerFactory:
         """
         pass
 
-    def get_docker_client_setup(self, name=None):
-        """Standard setup with one Docker client instead of QEMU one"""
+    def get_docker_client_setup(self, name=None, num_clients=1):
+        """Standard setup with Docker client(s) instead of QEMU"""
         pass
 
     def get_rofs_client_setup(self, name=None):
-        """Standard setup with one QEMU Read-Only FS client instead of standard R/W"""
+        """Standard setup with one QEMU Read-Only FS client (QEMU required for ROFS behavior)"""
         pass
 
     def get_legacy_v3_client_setup(self, name=None):
@@ -99,7 +99,7 @@ class ContainerManagerFactory:
         pass
 
     def get_enterprise_rofs_client_setup(self, name=None, num_clients=0):
-        """Enterprise setup with one Mender QEMU Read-Only FS client"""
+        """Enterprise setup with one QEMU Read-Only FS client (QEMU required for ROFS behavior)"""
         pass
 
     def get_enterprise_rofs_commercial_client_setup(self, name=None, num_clients=0):
@@ -129,8 +129,8 @@ class DockerComposeManagerFactory(ContainerManagerFactory):
     def get_monitor_commercial_setup(self, name=None, num_clients=0):
         return DockerComposeMonitorCommercialSetup(name, num_clients)
 
-    def get_docker_client_setup(self, name=None):
-        return DockerComposeDockerClientSetup(name)
+    def get_docker_client_setup(self, name=None, num_clients=1):
+        return DockerComposeDockerClientSetup(name, num_clients)
 
     def get_rofs_client_setup(self, name=None):
         return DockerComposeRofsClientSetup(name)


### PR DESCRIPTION
Qemu clients boot a full Yocto OS (~45s and a lot of memory). This moves the integration tests that don't need A/B rootfs behaviour onto the lightweight docker-native client, and keeps qemu for the ones that do.

## What changes

- `test_bootstrap` (open source and enterprise) and `test_preauth` now run on the docker client instead of qemu, via new `standard_setup_one_docker_client` / `enterprise_one_docker_client` fixtures.
- `helpers._check_log_for_message` can now verify auth on the docker client. The docker client has no systemd/journald, so instead of reading the journal it asks mender-auth over D-Bus (`GetJwtToken`) and waits for a non-empty token. Any other log-message check raises `NotImplementedError` on the docker client rather than silently passing.

## Scope

A full qemu removal isn't possible. Roughly 60% of the tests do real rootfs-image updates (partition swaps, reboots, rollback) that the docker client can't perform, so qemu stays for those. This PR converts the safe subset only; `DockerComposeStandardSetup` (used by the rootfs tests) remains qemu-based.

This branch also merges current master; `test_basic_groups` was dropped because master removed it as dead infrastructure (QA-1616).

## Fixes made while getting CI green

- Detect systemd by the running init (`/run/systemd/system`) rather than the presence of the `systemctl` binary, which exists in the docker image too. Without this the docker client wrongly took the `systemctl status` path and timed out after 600s.
- Require a non-empty JWT in the docker auth check. The D-Bus reply always contains the word `string` (the token field is just empty until the device authenticates), so the previous check passed even for an unauthenticated device.
- Keep enterprise `new_tenant_docker_client` at `--scale mender-client=1` (per tenant), matching master. An earlier incremental-scale attempt spawned a second container for the second tenant, so `get_mender_clients()` returned 2 while the test expected 1 and acceptance timed out.
- Raise the `accept_devices` post-accept wait to 120s to give device acceptance more headroom under heavy parallel load.

## Verification

Full integration was run on this branch. Results match master's nightly: the converted bootstrap/preauth tests pass, and the only failure is `test_fault_tolerance.py::TestFaultToleranceOpenSource::test_update_image_breaks_networking` (`Device never rebooted`) — a pre-existing flaky qemu rootfs test that is not touched by this PR and also flaps on master.

Ticket: QA-1639
