### PR TITLE
fix: reduce tcp_retries2 to 8 and remove limits (ulimit -a)

### DIFF
--- a/.gitlab-ci-full-integration-template.yml
+++ b/.gitlab-ci-full-integration-template.yml
@@ -51,7 +51,8 @@ test:integration:$CI_NODE_INDEX:
     # running with high parallelism on a single VM
     - sysctl -w fs.inotify.max_user_instances=1024
     - sysctl -w fs.file-max=600000
-    - ulimit -n 524288
+    - sysctl -w net.ipv4.tcp_retries2=8
+    - ulimit -a unlimited
 
   script:
     - cd tests

--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -404,6 +404,7 @@ class TestRemoteTerminalEnterprise(
 
         yield env
 
+    @flaky(max_runs=3)
     def test_in_poor_network_environment(self, docker_env):
         self.assert_env(docker_env)
 


### PR DESCRIPTION
fix: reduce tcp_retries2 to 8

some of the tests in the mender_connect and among them test_in_poor*
expect the TCP/IP stack to react in a given time. This is not the case
as things are implemented in the linux kernel at the moment.

in order to make the test pass every time we have to influence the kernel
to calculate lower retransmission timeouts (RTO), so the TCP stack
notices that the connectivity has been broken and assumes the mender-connect
link to the deviceconnect is broken in the times hardcoded in the test.
one way of doing that is to lover the tcp_retries2 from default 15, which
may (and does as the failures of this test prove) reach even more
than 10 mintues, to new turbo sensitive 8.

Refs:
https://docs.kernel.org/networking/ip-sysctl.html

This change also brings the removal of ulimits and setting max_runs of the test_in_poor
to 3 via flaky.

A note to reviewers @danielskinstad  @kjaskiewiczz: I started 3 pipelines for supported branches [listed below](https://github.com/mendersoftware/integration/pull/2912#issuecomment-4583093876). @oldgiova do you agree that there is not much point in having the limits in those jobs on the runners we have (please take a look at the ulimit -a part)?

Changelog: Title
Ticket: QA-1625
Signed-off-by: Peter Grzybowski <peter@northern.tech>