### PR TITLE
chore: Update mender-artifact arguments to match latest version

### DIFF
--- a/tests/MenderAPI/artifacts.py
+++ b/tests/MenderAPI/artifacts.py
@@ -49,7 +49,7 @@ class Artifacts:
             assert os.path.exists(private_key), "private key for testing doesn't exist"
             signed_arg = "-k %s" % (private_key)
 
-        cmd = "%s %s  write rootfs-image -f %s -t %s -n %s -o %s %s %s" % (
+        cmd = "%s %s  write rootfs-image -f %s -c %s -n %s -o %s %s %s" % (
             self.artifacts_tool_path,
             global_flags,
             image,
@@ -98,7 +98,7 @@ class Artifacts:
             assert os.path.exists(private_key), "private key for testing doesn't exist"
             signed_arg = "-k %s" % (private_key)
 
-        cmd = "%s %s  write module-image -T %s -t %s -n %s -o %s %s %s %s" % (
+        cmd = "%s %s  write module-image -T %s -c %s -n %s -o %s %s %s %s" % (
             self.artifacts_tool_path,
             global_flags,
             module_type,

--- a/tests/tests/common_artifact.py
+++ b/tests/tests/common_artifact.py
@@ -28,7 +28,7 @@ def get_script_artifact(
         logger.info(f"Script: {out}")
         script_path = tf.name
 
-        cmd = f"mender-artifact write module-image -T script -n {artifact_name} -t {device_type} -o {output_path} -f {script_path}"
+        cmd = f"mender-artifact write module-image -T script -n {artifact_name} -c {device_type} -o {output_path} -f {script_path}"
         if extra_args is not None:
             cmd += f" {extra_args}"
 

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -395,7 +395,7 @@ def get_mender_artifact(
         filename,
     ]
     for device_type in device_types:
-        args.extend(["-t", device_type])
+        args.extend(["-c", device_type])
     for depend in depends:
         args.extend(["--depends", depend])
     for provide in provides:


### PR DESCRIPTION
In the latest version of mender-artifact parameter `--device-type` has been replaced with `--compatible-types`. This requires update all mender-artifact calls which still use old version of argument name.

Ticket: MEN-9344