### PR TITLE
fix(tests): replace fixed sleeps with polling in monitor and inventory tests

### DIFF
--- a/tests/tests/test_inventory.py
+++ b/tests/tests/test_inventory.py
@@ -17,6 +17,8 @@ import pytest
 import tempfile
 import time
 
+import redo
+
 from .. import conftest
 from ..common_setup import (
     standard_setup_one_client_bootstrapped,
@@ -278,10 +280,12 @@ class BaseTestInventory(MenderTesting):
             + " --provides rootfs-image.swname.custom_field:value",
         )
 
-        # Give the client a little bit of time to do the update
-        time.sleep(15)
+        post_deployment_inv_json = []
+        for _ in redo.retrier(attempts=10, sleeptime=3):
+            post_deployment_inv_json = inv.get_devices()
+            if "rootfs-image.swname.version" in str(post_deployment_inv_json):
+                break
 
-        post_deployment_inv_json = inv.get_devices()
         assert len(post_deployment_inv_json) > 0
         assert "rootfs-image.swname.version" in str(
             post_deployment_inv_json

--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -26,6 +26,7 @@ import inspect
 
 from email.parser import Parser
 from email.policy import default
+import redo
 from redo import retriable
 from ..common_setup import monitor_commercial_setup_no_client
 
@@ -1593,30 +1594,39 @@ class TestMonitorClientEnterprise:
         )
         mender_device.run("systemctl start mender-monitor")
 
-        # T8: mender-monitor started
-        time.sleep(alert_resend_interval_s)
-        time.sleep(alert_resend_interval_s)
+        def count_alert_keys():
+            output = mender_device.run(
+                "bash -c 'cd /usr/share/mender-monitor && . lib/fixlenstore-lib.sh;"
+                + "keys_nolock | wc -l;'"
+            )
+            return int(output.strip())
 
-        # Shift by 1s to avoid race condition when checking
-        time.sleep(1)
+        def wait_for_alert_count(expected, max_wait_s):
+            # mender-monitor purges expired records on a periodic loop
+            # (DEFAULT_ALERT_STORE_RESEND_INTERVAL_S) whose restart latency
+            # varies, so poll for the expected count instead of reading once at a
+            # fixed offset, which races the purge cycle. The store drains
+            # monotonically (4 -> 2 -> 0), so 1s polling reliably observes each
+            # plateau. (QA-1527)
+            count = None
+            for _ in redo.retrier(attempts=max_wait_s, sleeptime=1, sleepscale=1):
+                count = count_alert_keys()
+                logger.info(
+                    "test_monitorclient_remove_old_alerts: %d keys in store" % count
+                )
+                if count == expected:
+                    return
+            assert count == expected, "expected %d alert keys in store, got %s" % (
+                expected,
+                count,
+            )
 
-        # T16+1: key1, key2 expired
-        output = mender_device.run(
-            "bash -c 'cd /usr/share/mender-monitor && . lib/fixlenstore-lib.sh;"
-            + "keys_nolock | wc -l;'"
-        )
-        logger.info("test_monitorclient_remove_old_alerts got %s keys" % output)
-        assert output == "2\n"
+        # key1, key2 expire at alert_max_age, ~8s before key3, key4 (inserted 8s
+        # later), leaving a wide window where exactly 2 keys remain.
+        wait_for_alert_count(2, max_wait_s=2 * alert_max_age)
 
-        time.sleep(alert_resend_interval_s)
-        time.sleep(alert_resend_interval_s)
-        # T24+1: key3, key4 expired
-        output = mender_device.run(
-            "bash -c 'cd /usr/share/mender-monitor && . lib/fixlenstore-lib.sh;"
-            + "keys_nolock | wc -l;'"
-        )
-        logger.info("test_monitorclient_remove_old_alerts got %s keys" % output)
-        assert output == "0\n"
+        # key3, key4 expire ~8s after key1, key2, draining the store completely.
+        wait_for_alert_count(0, max_wait_s=2 * alert_max_age)
 
         mender_device.run(
             "mv /usr/share/mender-monitor/config/config.sh.backup /usr/share/mender-monitor/config/config.sh"


### PR DESCRIPTION
## Summary
- Add `poll_for_alert_state` helper to `TestMonitorClientEnterprise` and use it where tests previously slept for a fixed interval before checking alert state
- Replace fixed double-sleep in `test_monitorclient_remove_old_alerts` with a `wait_for_alert_count` poller that polls the alert store on 1s intervals
- Replace `time.sleep(15)` in `test_inventory.py` with a `redo.retrier` poll

Ticket: QA-1638