### PR TITLE
fix(tests): fix polling logic and retry coverage in API helpers

### DIFF
--- a/tests/MenderAPI/deployments.py
+++ b/tests/MenderAPI/deployments.py
@@ -210,16 +210,14 @@ class Deployments:
         while time.time() <= timeout:
             data = self.get_status(status=expected_status)
 
-            for deployment in data:
-                if deployment["id"] == deployment_id:
-                    time.sleep(polling_frequency)
-                    continue
-            else:
+            found = any(d["id"] == deployment_id for d in data)
+            if not found:
                 logger.info(
                     "left deployment status (%s) as expected for: %s"
                     % (expected_status, deployment_id)
                 )
                 return
+            time.sleep(polling_frequency)
 
         pytest.fail(
             "Never left status: %s for %s after %d seconds"
@@ -238,8 +236,6 @@ class Deployments:
         seen = set()
 
         while time.time() <= timeout:
-            time.sleep(polling_frequency)
-
             data = self.get_statistics(deployment_id)
             seen.add(str(data))
 
@@ -260,13 +256,12 @@ class Deployments:
 
             if data[expected_status] == expected_count:
                 return
-            continue
+            time.sleep(polling_frequency)
 
-        if time.time() > timeout:
-            pytest.fail(
-                "Never found: %s:%s, only seen: %s after %d seconds"
-                % (expected_status, expected_count, str(seen), max_wait)
-            )
+        pytest.fail(
+            "Never found: %s:%s, only seen: %s after %d seconds"
+            % (expected_status, expected_count, str(seen), max_wait)
+        )
 
     def get_deployment_overview(self, deployment_id):
         deployments_overview_url = (
@@ -326,7 +321,6 @@ class Deployments:
             headers=self.auth.get_auth_token(),
             json={"status": "aborted"},
         )
-        time.sleep(5)
         assert r.status_code == requests.status_codes.codes.no_content
 
     def abort_finished_deployment(self, deployment_id):
@@ -339,7 +333,6 @@ class Deployments:
             headers=self.auth.get_auth_token(),
             json={"status": "aborted"},
         )
-        time.sleep(5)
         assert r.status_code == requests.status_codes.codes.unprocessable_entity
 
     def patch_deployment(self, deployment_id, update_control_map):

--- a/tests/MenderAPI/requests_helpers.py
+++ b/tests/MenderAPI/requests_helpers.py
@@ -17,8 +17,8 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 
-# Will retry on 500 Server error
-def requests_retry(status_forcelist=[500, 502]):
+# Will retry on server errors (5xx)
+def requests_retry(status_forcelist=[500, 502, 503, 504]):
     s = requests.Session()
     retries = Retry(
         total=5,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -16,6 +16,8 @@ import logging
 import json
 import time
 
+import pytest
+
 from .MenderAPI import devauth
 
 logger = logging.getLogger()
@@ -68,9 +70,11 @@ class Helpers:
             # entries since the last service restart.
             cmd = f"systemctl status --no-pager --full --lines 100000 mender-authd"
 
-        sleepsec = 0
+        sleeptime = 2
+        max_sleeptime = 10
         timeout = 600
-        while sleepsec < timeout:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
             out = device.run(
                 cmd + "| grep '" + message + "'",
                 warn=True,
@@ -78,15 +82,16 @@ class Helpers:
             if out != "":
                 return
 
-            time.sleep(10)
-            sleepsec += 10
+            waited = int(timeout - (deadline - time.time()))
             logger.info(
-                f"waiting for message '{message}' in mender-authd log, waited for: {sleepsec}"
+                f"waiting for message '{message}' in mender-authd log, waited for: {waited}s"
             )
+            time.sleep(sleeptime)
+            sleeptime = min(sleeptime * 2, max_sleeptime)
 
-        assert (
-            sleepsec <= timeout
-        ), f"timeout for waiting for message '{message}' in mender-authd log"
+        pytest.fail(
+            f"timeout ({timeout}s) waiting for message '{message}' in mender-authd log"
+        )
 
     @staticmethod
     def check_log_is_authenticated(device, since=None):

--- a/tests/tests/test_configuration.py
+++ b/tests/tests/test_configuration.py
@@ -49,20 +49,19 @@ class TestConfiguration(MenderTesting):
         # accept the device
         devauth.accept_devices(1)
 
-        # list of devices
-        devices = list(
-            set([device["id"] for device in devauth.get_devices_status("accepted")])
-        )
+        devices = devauth.get_devices_status("accepted")
         assert 1 == len(devices)
 
         auth = authentication.Authentication()
 
-        wait_for_connect(auth, devices[0])
+        wait_for_connect(auth, devices[0]["id"])
 
         # set and verify the device's configuration
         # retry to skip possible race conditions between update poll and update trigger
         for _ in redo.retrier(attempts=3, sleeptime=1):
-            set_and_verify_config({"key": "value"}, devices[0], auth.get_auth_token())
+            set_and_verify_config(
+                {"key": "value"}, devices[0]["id"], auth.get_auth_token()
+            )
 
             forced = was_update_forced(standard_setup_one_client.device)
             if forced:
@@ -122,23 +121,17 @@ class TestConfigurationEnterprise(MenderTesting):
 
         devauth_tenant.accept_devices(1)
 
-        # list of devices
-        devices = list(
-            set(
-                [
-                    device["id"]
-                    for device in devauth_tenant.get_devices_status("accepted")
-                ]
-            )
-        )
+        devices = devauth_tenant.get_devices_status("accepted")
         assert 1 == len(devices)
 
-        wait_for_connect(auth, devices[0])
+        wait_for_connect(auth, devices[0]["id"])
 
         # set and verify the device's configuration
         # retry to skip possible race conditions between update poll and update trigger
         for _ in redo.retrier(attempts=3, sleeptime=1):
-            set_and_verify_config({"key": "value"}, devices[0], auth.get_auth_token())
+            set_and_verify_config(
+                {"key": "value"}, devices[0]["id"], auth.get_auth_token()
+            )
 
             forced = was_update_forced(mender_device)
             if forced:
@@ -186,7 +179,7 @@ def set_and_verify_config(config, devid, authtoken):
 
     # loop and verify the reported configuration
     reported = None
-    for i in range(180):
+    for i in range(300):
         r = requests_retry().get(configuration_url, verify=False, headers=authtoken)
         assert r.status_code == 200
         reported = r.json().get("reported")

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -427,19 +427,13 @@ def _run(conn, cmd, **kw):
     result = None
     start_time = time.time()
     sleeptime = 1
+    max_sleeptime = 30  # cap to avoid multi-minute gaps between retries
     while time.time() < start_time + wait:
-        # Back off exponentially to save SSH handshakes in QEMU, which
-        # are quite expensive.
-        time.sleep(sleeptime)
-        sleeptime *= 2
-
         try:
             result = conn.run(cmd, **kw)
             break
         except ConnectionError as e:
             logger.info(f"Got SSH exception while connecting to host {conn.host}: {e}")
-            time.sleep(60)
-            continue
         except OSError as e:
             # The OSError is happening while there is no QEMU instance initialized
             logger.info(
@@ -449,12 +443,17 @@ def _run(conn, cmd, **kw):
             )
             if "Cannot assign requested address" not in str(e):
                 raise e
-            continue
         except Exception as e:
             logger.exception(
                 f"Generic exception happened while connecting to host {conn.host}"
             )
             raise e
+
+        # Back off exponentially to save SSH handshakes in QEMU, which
+        # are quite expensive.  Capped so we never wait longer than
+        # max_sleeptime between attempts.
+        time.sleep(sleeptime)
+        sleeptime = min(sleeptime * 2, max_sleeptime)
     else:
         raise RuntimeError(
             f"Could not successfully run command after {wait} seconds on host {conn.host}: {cmd}"


### PR DESCRIPTION
## Summary
- Fix broken `for/else` logic in `check_not_in_status` in `deployments.py`
- Move `time.sleep` to after-check in `check_expected_statistics`, remove dead `continue`
- Add `503` and `504` to retry status list in `requests_helpers.py`
- Convert deadline-based loop in `helpers.py` with exponential backoff, use `pytest.fail`
- Remove dead preauth test methods and convert waits to `redo.retrier` in `test_preauth.py`
- Remove `list(set(...))` wrapping and fix device ID access in `test_configuration.py`

Ticket: QA-1638