### PR TITLE
chore(tests): remove dead helper functions and unused imports

### DIFF
--- a/tests/common_setup.py
+++ b/tests/common_setup.py
@@ -248,11 +248,6 @@ def enterprise_no_client():
     yield from enterprise_no_client_impl()
 
 
-@pytest.fixture(scope="class")
-def enterprise_no_client_class():
-    yield from enterprise_no_client_impl()
-
-
 @pytest.fixture(scope="function")
 def enterprise_one_client():
     env = container_factory.get_enterprise_setup(num_clients=0)

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -12,9 +12,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import os
-import pytest
-
 from ..common_setup import (
     standard_setup_one_client_bootstrapped,
     enterprise_one_client_bootstrapped,

--- a/tests/tests/test_deployment_retry.py
+++ b/tests/tests/test_deployment_retry.py
@@ -13,7 +13,6 @@
 #    limitations under the License.
 
 import json
-import os
 import pytest
 import tempfile
 import uuid
@@ -111,9 +110,7 @@ class TestDeploymentRetryEnterprise(MenderTesting):
 
             deploy.upload_image(artifact)
 
-            devices = list(
-                set([device["id"] for device in devauth.get_devices_status("accepted")])
-            )
+            devices = [d["id"] for d in devauth.get_devices_status("accepted")]
             assert len(devices) == 1
 
             deployment_id = deploy.trigger_deployment(

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -19,7 +19,6 @@ import shutil
 import tempfile
 import time
 
-from .. import conftest
 from ..common_setup import (
     standard_setup_one_client_bootstrapped,
     enterprise_one_client_bootstrapped,

--- a/tests/tests/test_legacy_golang_update.py
+++ b/tests/tests/test_legacy_golang_update.py
@@ -17,7 +17,7 @@ from ..common_setup import (
     enterprise_with_legacy_v3_client,
 )
 from .common_update import update_image, update_image_failed
-from ..MenderAPI import DeviceAuthV2, Deployments, logger
+from ..MenderAPI import DeviceAuthV2, Deployments
 from .mendertesting import MenderTesting
 
 

--- a/tests/tests/test_monitor_client.py
+++ b/tests/tests/test_monitor_client.py
@@ -42,7 +42,6 @@ from ..MenderAPI import (
 from testutils.api import useradm
 from testutils.api.client import ApiClient
 from testutils.infra.container_manager import factory
-from testutils.infra import smtpd_mock
 from testutils.common import User, new_tenant_client
 from testutils.infra.cli import CliTenantadm
 

--- a/tests/tests/test_mtls.py
+++ b/tests/tests/test_mtls.py
@@ -278,16 +278,12 @@ activate = 1
         while i > 0:
             i = i - 1
             time.sleep(1)
-            devices = list(
-                set([device["id"] for device in devauth.get_devices_status("accepted")])
-            )
+            devices = [d["id"] for d in devauth.get_devices_status("accepted")]
             if len(devices) > 0:
                 break
 
         # deploy the update to the device
-        devices = list(
-            set([device["id"] for device in devauth.get_devices_status("accepted")])
-        )
+        devices = [d["id"] for d in devauth.get_devices_status("accepted")]
         assert len(devices) == 1
         deployment_id = deploy.trigger_deployment(
             "mtls-test",

--- a/tests/tests/test_security.py
+++ b/tests/tests/test_security.py
@@ -12,21 +12,12 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import subprocess
-import contextlib
-import ssl
-import socket
-import time
-
-import pytest
-
 from ..common_setup import (
-    running_custom_production_setup,
     standard_setup_with_short_lived_token,
     enterprise_with_short_lived_token,
 )
 from ..helpers import Helpers
-from ..MenderAPI import DeviceAuthV2, Deployments, logger
+from ..MenderAPI import DeviceAuthV2, Deployments
 from .common_update import common_update_procedure
 from .mendertesting import MenderTesting
 

--- a/tests/tests/test_update_modules.py
+++ b/tests/tests/test_update_modules.py
@@ -17,7 +17,6 @@ import subprocess
 import tempfile
 import shutil
 
-from .. import conftest
 from ..common_setup import (
     standard_setup_one_docker_client_bootstrapped,
     enterprise_one_docker_client_bootstrapped,

--- a/testutils/api/client.py
+++ b/testutils/api/client.py
@@ -13,21 +13,13 @@
 #    limitations under the License.
 import os
 import os.path
-import socket
-import socketserver
 import warnings
 
 import requests
-import time
 
 from urllib3.exceptions import InsecureRequestWarning
 
 GATEWAY_HOSTNAME = os.environ.get("GATEWAY_HOSTNAME") or "mender-api-gateway"
-
-
-def get_free_tcp_port() -> int:
-    with socketserver.TCPServer(("localhost", 0), None) as s:
-        return s.server_address[1]
 
 
 class ApiClient:
@@ -85,26 +77,3 @@ class ApiClient:
 
     def __make_headers(self, headers):
         return dict(self.headers, **headers)
-
-
-def wait_for_port(port=8080, host="localhost", timeout=10.0):
-    """Wait until a port starts accepting TCP connections.
-    Args:
-        port (int): Port number.
-        host (str): Host address on which the port should exist.
-        timeout (float): In seconds. How long to wait before raising errors.
-    Raises:
-        TimeoutError: The port isn't accepting connection after time specified in `timeout`.
-    """
-    start_time = time.perf_counter()
-    while True:
-        try:
-            with socket.create_connection((host, port), timeout=timeout):
-                break
-        except OSError as ex:
-            time.sleep(0.50)
-            if time.perf_counter() - start_time >= timeout:
-                raise TimeoutError(
-                    "Waited too long for the port {} on host {} to start accepting "
-                    "connections.".format(port, host)
-                ) from ex

--- a/testutils/common.py
+++ b/testutils/common.py
@@ -18,7 +18,6 @@ import random
 import time
 import string
 import tempfile
-import uuid
 import os
 import subprocess
 from contextlib import contextmanager
@@ -311,60 +310,6 @@ def make_accepted_device(
     return dev
 
 
-def make_accepted_devices(devauthd, devauthm, utoken, tenant_token="", num_devices=1):
-    """Create accepted devices.
-    returns list of Device objects."""
-    devices = []
-
-    # some 'accepted' devices, single authset
-    for _ in range(num_devices):
-        dev = make_accepted_device(devauthd, devauthm, utoken, tenant_token)
-        devices.append(dev)
-
-    return devices
-
-
-def make_device_with_inventory(attributes, utoken, tenant_token):
-    devauthm = ApiClient(deviceauth.URL_MGMT)
-    devauthd = ApiClient(deviceauth.URL_DEVICES)
-    invm = ApiClient(inventory.URL_MGMT)
-
-    d = make_accepted_device(devauthd, devauthm, utoken, tenant_token)
-    """
-    verify that the status of the device in inventory is "accepted"
-    """
-    accepted = False
-    timeout = 10
-    for i in range(timeout):
-        r = invm.with_auth(utoken).call("GET", inventory.URL_DEVICE.format(id=d.id))
-        if r.status_code == 200:
-            dj = r.json()
-            for attr in dj["attributes"]:
-                if attr["name"] == "status" and attr["value"] == "accepted":
-                    accepted = True
-                    break
-        if accepted:
-            break
-        time.sleep(1)
-    if not accepted:
-        raise ValueError(
-            "status for device %s has not been propagated within %d seconds"
-            % (d.id, timeout)
-        )
-
-    submit_inventory(attributes, d.token)
-
-    d.attributes = attributes
-
-    return d
-
-
-def submit_inventory(attrs, token):
-    invd = ApiClient(inventory.URL_DEV)
-    r = invd.with_auth(token).call("PATCH", inventory.URL_DEVICE_ATTRIBUTES, attrs)
-    assert r.status_code == 200
-
-
 @contextmanager
 def get_mender_artifact(
     artifact_name="test",
@@ -471,91 +416,6 @@ def new_tenant_client(
             test_env.get_mender_clients(network=network)
         )
     return device
-
-
-def create_tenant_test_setup() -> Tenant:
-    """Creates a tenant and a user belonging to the tenant (both tenant and user are created with random names)."""
-    uuidv4 = str(uuid.uuid4())
-    tenant, username, password = (
-        "test.mender.io-" + uuidv4,
-        "some.user+" + uuidv4 + "@example.com",
-        "secretsecret",
-    )
-    tenant = create_org(tenant, username, password, "enterprise")
-    user = create_user(
-        "foo+" + uuidv4 + "@user.com", "correcthorsebatterystaple", tid=tenant.id
-    )
-
-    response = ApiClient(useradm.URL_MGMT).call(
-        "POST", useradm.URL_LOGIN, auth=(user.name, user.pwd)
-    )
-    assert response.status_code == 200
-    user.utoken = response.text
-    tenant.users = [user]
-    return tenant
-
-
-def create_user_test_setup() -> User:
-    """Create a user with random name, log user in."""
-    uuidv4 = str(uuid.uuid4())
-    user_name, password = (
-        "some.user+" + uuidv4 + "@example.com",
-        "secretsecret",
-    )
-
-    user = create_user(user_name, password)
-    useradmm = ApiClient(useradm.URL_MGMT)
-    # log in user
-    response = useradmm.call("POST", useradm.URL_LOGIN, auth=(user.name, user.pwd))
-    assert response.status_code == 200
-    user.utoken = response.text
-    return user
-
-
-def useExistingTenant() -> bool:
-    return bool(os.environ.get("USE_EXISTING_TENANT"))
-
-
-def setup_tenant_devices(tenant, device_groups):
-    """
-    setup_user_devices authenticates the user and creates devices
-    attached to (static) groups given by the proportion map from
-    the groups parameter.
-    :param users:     Users to setup devices for (list).
-    :param n_devices: Number of accepted devices created for each
-                      user (int).
-    :param groups:    Map of group names to device proportions, the
-                      sum of proportion must be less than or equal
-                      to 1 (dict[str] = float)
-    :return: Dict mapping group_name -> list(devices)
-    """
-    devauth_DEV = ApiClient(deviceauth.URL_DEVICES)
-    devauth_MGMT = ApiClient(deviceauth.URL_MGMT)
-    invtry_MGMT = ApiClient(inventory.URL_MGMT)
-    user = tenant.users[0]
-    grouped_devices = {}
-    group = None
-
-    tenant.devices = []
-    for group, dev_cnt in device_groups.items():
-        grouped_devices[group] = []
-        for i in range(dev_cnt):
-            device = make_accepted_device(
-                devauth_DEV, devauth_MGMT, user.token, tenant.tenant_token
-            )
-            if group is not None:
-                rsp = invtry_MGMT.with_auth(user.token).call(
-                    "PUT",
-                    inventory.URL_DEVICE_GROUP.format(id=device.id),
-                    body={"group": group},
-                )
-                assert rsp.status_code == 204
-
-            device.group = group
-            grouped_devices[group].append(device)
-            tenant.devices.append(device)
-
-    return grouped_devices
 
 
 @redo.retriable(sleeptime=5, attempts=3)

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -19,7 +19,6 @@ import os
 import redo
 import socket
 import subprocess
-import time
 from typing import Dict
 
 logger = logging.getLogger()


### PR DESCRIPTION
## Summary
- Remove 7 dead functions from `testutils/common.py` with no external callers: `make_accepted_devices`, `make_device_with_inventory`, `submit_inventory`, `create_tenant_test_setup`, `create_user_test_setup`, `useExistingTenant`, `setup_tenant_devices`
- Remove `get_free_tcp_port` and `wait_for_port` from `testutils/api/client.py`
- Remove duplicate `import time` in `testutils/infra/device.py`
- Remove unused `enterprise_no_client_class` fixture from `tests/common_setup.py`
- Remove unused imports across: `test_security.py` (6 imports), `test_deployment_aborting.py`, `test_deployment_retry.py`, `test_grouping.py`, `test_fault_tolerance.py`, `test_update_modules.py`, `test_monitor_client.py`
- Simplify `list(set([...]))` antipattern in `test_deployment_retry.py` and `test_mtls.py`

Ticket: QA-1616