### PR TITLE
3.8.x cherry-picks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ variables:
 
   DOCKER_VERSION:
     description: "Docker version to use in jobs"
-    value: "27.3"
+    value: "28"
 
   MENDER_SERVER_TAG:
     description: "Mender Server Docker tag for running integration tests"


### PR DESCRIPTION
We got an error due to mismatch in between docker and docker client version. To unify this we moved to version 28 everywhere.


(cherry picked from commit 70fbf950a496bbe3a4df3d83aa89732add751bb5)