### PR TITLE
test: Poll instead of fixed sleep in test_websocket_reconnect

### DIFF
--- a/tests/tests/common_connect.py
+++ b/tests/tests/common_connect.py
@@ -72,14 +72,14 @@ def prepare_env_for_connect(env):
     return devid, authtoken, auth, mender_device
 
 
-def wait_for_connect(auth, devid):
+def wait_for_connect(auth, devid, attempts=12):
     devconn = ApiClient(
         host=get_container_manager().get_mender_gateway(),
         base_url=deviceconnect.URL_MGMT,
     )
 
     connected = 0
-    for _ in redo.retrier(attempts=12, sleeptime=5):
+    for _ in redo.retrier(attempts=attempts, sleeptime=5, sleepscale=1):
         logger.info("waiting for device in deviceconnect")
         res = devconn.call(
             "GET",

--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -18,6 +18,8 @@ import time
 import uuid
 
 from flaky import flaky
+from redo import retriable
+from websockets.exceptions import WebSocketException
 
 from testutils.api import proto_shell, protomsg
 from testutils.infra.cli import CliTenantadm
@@ -168,11 +170,23 @@ class _TestRemoteTerminalBase:
         # Test that mender-connect recovers if it loses the connection to deviceconnect.
         docker_env.restart_service("mender-deviceconnect")
 
-        time.sleep(10)
+        # mender-connect needs time to re-establish its session after
+        # deviceconnect restarts; until it does, the mgmt /connect endpoint
+        # returns HTTP 404 ("device disconnected"). Poll instead of a fixed
+        # sleep that races the reconnect. (QA-1527)
+        @retriable(
+            attempts=24,
+            sleeptime=5,
+            sleepscale=1,
+            jitter=0,
+            retry_exceptions=(WebSocketException,),
+        )
+        def assert_websocket_connects():
+            with docker_env.devconnect.get_websocket():
+                # Connecting successfully is enough.
+                pass
 
-        with docker_env.devconnect.get_websocket():
-            # Nothing to do, just connecting successfully is enough.
-            pass
+        assert_websocket_connects()
 
     def test_bogus_shell_message(self, docker_env):
         self.assert_env(docker_env)

--- a/testutils/util/websockets.py
+++ b/testutils/util/websockets.py
@@ -48,15 +48,15 @@ class Websocket:
             try:
                 asyncio.get_event_loop().run_until_complete(connect())
                 break
-            except websockets.InvalidStatusCode:
+            except websockets.exceptions.InvalidHandshake:
                 if self.retry_connect and attempts > 0:
                     attempts -= 1
                     logger.info(
-                        "websockets: %d retrying on InvalidStatusCode" % attempts
+                        "websockets: %d retrying on InvalidHandshake" % attempts
                     )
                     time.sleep(sleep_seconds)
                 else:
-                    logger.info("websockets: out of retries on InvalidStatusCode")
+                    logger.info("websockets: out of retries on InvalidHandshake")
                     raise
 
         return self


### PR DESCRIPTION
Ported the necessary changes from 539f51d4. The rest of that commit is docker-client specific and does not apply to 3.8.x.

Ticket: QA-1638