### PR TITLE
fix(tests): restore flaky decorator on test_in_poor_network_environment

### DIFF
--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -170,6 +170,7 @@ class _TestRemoteTerminalBase:
             assert prot.protoType == proto_shell.PROTO_TYPE_SHELL
             assert prot.typ == "bogusmessage"
 
+    @flaky(max_runs=3)
     def test_in_poor_network_environment(self, docker_env):
         self.assert_env(docker_env)
 


### PR DESCRIPTION
## Summary
Re-adds `@flaky(max_runs=3)` to `test_in_poor_network_environment`, which was dropped in 539f51d4 (#2918) when the test was migrated from fixed sleeps to an internal `@retriable` poll.

## Why
QA-1625 (commit 1f0f0936) stabilized this test with `@flaky(max_runs=3)`, which re-runs the **whole** test (network drop → restore → mender-connect restart → reconnect) up to 3 times. The #2918 rewrite replaced it with an internal `@retriable` that only re-attempts the websocket connect/open-shell step (~240s). After a simulated outage the device can take longer than that window to reconnect, so the test started failing again — reported by Peter on QA-1638 (job 14869385473).

This keeps the sleep→poll improvement from #2918 and restores the whole-test retry net on top of it.

Ticket: QA-1638