### PR TITLE
ci: cap integration job at 2h + timeout for hanging poor_network test

### DIFF
--- a/.gitlab-ci-full-integration-template.yml
+++ b/.gitlab-ci-full-integration-template.yml
@@ -11,7 +11,10 @@ test:integration:$CI_NODE_INDEX:
   stage: test
   tags:
     - mender-qa-worker-integration-tests
-  timeout: 10h
+  # Healthy nodes finish in well under an hour (max observed ~77 min); cap hung
+  # jobs (e.g. a test that blocks forever) at 2h instead of burning the full
+  # default budget.
+  timeout: 2h
   before_script:
     # These two variables would be set by GitLab CI "parallel" feature, and are used by our Pytest
     # plugin to split the tests among the CI jobs. They get substituted by the generator.

--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -171,6 +171,7 @@ class _TestRemoteTerminalBase:
             assert prot.typ == "bogusmessage"
 
     @flaky(max_runs=3)
+    @pytest.mark.timeout(1200)
     def test_in_poor_network_environment(self, docker_env):
         self.assert_env(docker_env)
 


### PR DESCRIPTION
## Problem
On the 4.1.x nightly, `test_in_poor_network_environment` **hangs** (rather than failing) and takes the whole integration node to the **10h job timeout** — recurring across 6+ pipelines (node 3: 565/591/600 min, while healthy nodes finish in 18–77 min). `@flaky` can't help because it only retries on failures, not hangs, and there was no per-test timeout.

## Changes
- **Per-test timeout (surgical):** `@pytest.mark.timeout(1200)` on `test_in_poor_network_environment`. Healthy runs take 262–394s and the test's internal wait is ~15 min, so 20 min fails a hang fast while leaving headroom — and `@flaky` can then retry it.
- **Job timeout (backstop):** full-integration job `10h → 2h`. Healthy nodes finish in 18–77 min (median ~50), so 2h is generous headroom and caps any future hang.

## Data (recent master nightlies)
| Metric | Healthy | Slowest healthy | Hung (4.1.x) |
|---|---|---|---|
| `poor_network` test | 262–394s | ~6.6 min | (10h hang) |
| full job (per node) | 18–77 min | 77 min | 591–600 min |
