### PR TITLE
test(state_scripts): wait past the client reboot watchdog to de-flake

### DIFF
--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -838,8 +838,18 @@ class BaseTestStateScripts(MenderTesting):
                         'Waited too long for "Error" to appear in log:\n%s' % info
                     )
             else:
+                # The client's automatic-reboot watchdog waits up to 10 minutes
+                # (chrono::minutes(10) in update_module/v3/.../update_module_call.cpp
+                # AsyncSystemReboot) for the `reboot` to take effect before it
+                # gives up and reports a terminal status. The default 10-minute
+                # check_expected_statistics window is a dead heat with that
+                # watchdog: when a reboot is slow to fire (observed on the CI
+                # runners) the client reports the terminal status at ~600s, right
+                # as this poll gives up -> flaky "Never found <status>" timeout.
+                # Wait longer than the client watchdog so we observe the real
+                # outcome instead of racing it.
                 deploy.check_expected_statistics(
-                    deployment_id, test_set["ExpectedStatus"], 1
+                    deployment_id, test_set["ExpectedStatus"], 1, max_wait=15 * 60
                 )
 
             # Always give the client a little bit of time to settle in the base


### PR DESCRIPTION
The reboot-crossing failure cases (ArtifactReboot/ArtifactCommit failures and the Corrupted_script_version sets) drive the client through an automatic system reboot. That reboot is guarded by a 10-minute watchdog in the client (chrono::minutes(10) in update_module/v3/.../update_module_call.cpp, AsyncSystemReboot): when the `reboot` is slow to take effect, the client only reports a terminal deployment status after ~600s.

check_expected_statistics defaulted to a 10-minute (600s) poll window, an exact dead heat with that watchdog. When a reboot is slow to fire the client reports the terminal status right as the poll gives up, producing flaky "Never found <status>" timeouts in
test_state_scripts[*Reboot*/*Commit*/*Corrupted_script_version*].

Wait longer than the client watchdog (15 min) so the test observes the real deployment outcome instead of racing the reboot timer. This addresses the test flakiness only; the underlying slow-reboot behavior on the CI runners is tracked separately.

Changelog: None