### PR TITLE
test(mender-connect): stop poor-network reconnect poll hanging the integration job

### DIFF
--- a/tests/MenderAPI/deviceconnect.py
+++ b/tests/MenderAPI/deviceconnect.py
@@ -37,12 +37,15 @@ class DeviceConnect:
         host_uri = "wss://" + get_container_manager().get_mender_gateway()
         return host_uri + url_path
 
-    def get_websocket(self):
+    def get_websocket(self, retry_connect=True):
         headers = {}
         headers.update(self.auth.get_auth_token())
 
         ws = websockets.Websocket(
-            self.get_websocket_url(), headers=headers, insecure=True
+            self.get_websocket_url(),
+            headers=headers,
+            insecure=True,
+            retry_connect=retry_connect,
         )
 
         return ws

--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -210,6 +210,14 @@ class _TestRemoteTerminalBase:
         # drop below; retriable re-raises the last error if it never recovers.
         # AssertionErrors are not retried, so a genuine protocol failure still
         # fails fast. (QA-1527)
+        #
+        # retry_connect=False is essential here: Websocket.__enter__ otherwise
+        # retries InvalidHandshake on its own (15 * 15s = 225s) on every 404
+        # while the device is disconnected. Nested inside this 48-attempt loop
+        # that compounds to ~3h, so when the device never reconnects the test
+        # hangs until the CI job timeout instead of failing in 240s. Disabling
+        # the inner retry makes each 404 fail immediately and lets this loop be
+        # the single source of timing. (QA-1639)
         @retriable(
             attempts=48,
             sleeptime=5,
@@ -218,7 +226,7 @@ class _TestRemoteTerminalBase:
             retry_exceptions=(WebSocketException, TimeoutError),
         )
         def assert_working_shell():
-            with docker_env.devconnect.get_websocket() as ws:
+            with docker_env.devconnect.get_websocket(retry_connect=False) as ws:
                 shell = proto_shell.ProtoShell(ws)
                 body = shell.startShell()
                 if (


### PR DESCRIPTION
## What

Stops `test_in_poor_network_environment` from hanging the integration job until the 2h `job_execution_timeout` (seen nightly on mender-server 4.1.x — shard `test:integration:3`, 7215s).

## Why it hangs

The reconnect poll nests two retry layers:

- `Websocket.__enter__` retries `InvalidHandshake` / HTTP 404 on its own — 15 × 15s = 225s per connect while the device is disconnected.
- The test wraps that connect in `retriable(attempts=48, sleeptime=5)`.

Nested, one `assert_working_shell()` call compounds to ~3h, and `@flaky` retrying it blows past the runner's 2h cap.

The existing `@pytest.mark.timeout(1200)` does **not** save us here — the last nightly ran on a commit that already has it and still hung for 2h (the timeout isn't enforced through the `@flaky` re-run wrapper). So the hang has to be bounded at the source.

## The fix

`DeviceConnect.get_websocket(retry_connect=False)` in the reconnect poll: each 404 now fails immediately, so the 48-attempt `retriable` is the single source of timing and the poll is bounded to ~240s instead of ~3h. Other `get_websocket()` callers keep the default `retry_connect=True`.

A healthy server passes as before. On 4.1.x the test now fails fast and cleanly instead of hanging — the underlying 4.1.x reconnect failure is tracked separately.

## Changelog
None
