### PR TITLE
test(tcp-teardown): stop counting TIME_WAIT sockets as open (flaky assert 1==0)

### DIFF
--- a/tests/tests/test_tcp_teardown.py
+++ b/tests/tests/test_tcp_teardown.py
@@ -40,16 +40,39 @@ def set_long_poll_intervals(mender_device):
 
 
 def get_opened_tcp_connections(mender_device, binary_name):
-    # First probe that a process for binary_name exists
+    # Count only ESTABLISHED (state 01 in /proc/net/tcp) connections to the
+    # server's HTTPS port (:01BB == 443). A connection that mender has already
+    # closed lingers briefly in TIME_WAIT (state 06) and other post-close states;
+    # those are NOT a leaked/open socket, so counting them would make this test
+    # race the kernel's normal connection teardown and fail spuriously.
     mender_device.run(f"pidof {binary_name}")
     output = mender_device.run(
         f"for pid in `pidof {binary_name}`;"
         + "do cat /proc/$pid/net/tcp;"
         + "done"
-        + "| grep -E '[^:]+: [^ ]+ [^ ]+:01BB'"
+        + "| grep -E '[^:]+: [^ ]+ [^ ]+:01BB 01'"
         + "| wc -l"
     )
     return int(output)
+
+
+def assert_no_open_tcp_connections(mender_device, binary_name, timeout=30):
+    """Wait until binary_name has no ESTABLISHED connection to the server.
+
+    The socket close happens asynchronously after the HTTP request finishes, so
+    poll instead of asserting once after a fixed sleep (which races the close).
+    """
+    deadline = time.time() + timeout
+    while True:
+        count = get_opened_tcp_connections(mender_device, binary_name)
+        if count == 0:
+            return
+        if time.time() >= deadline:
+            assert count == 0, (
+                f"{binary_name} still has {count} ESTABLISHED connection(s) "
+                f"to the server after {timeout}s"
+            )
+        time.sleep(1)
 
 
 class BaseTestTcpTeardown:
@@ -67,9 +90,8 @@ class BaseTestTcpTeardown:
               --dest=io.mender.AuthenticationManager \\
               /io/mender/AuthenticationManager \\
               io.mender.Authentication1.FetchJwtToken""")
-        # The fetch is done async, give it some time to finish
-        time.sleep(1)
-        assert get_opened_tcp_connections(mender_device, "mender-auth") == 0
+        # The fetch is done async; poll until the socket is torn down.
+        assert_no_open_tcp_connections(mender_device, "mender-auth")
 
         # Accept the device and repeat the test. It should not make a difference
         devauth.accept_devices(1)
@@ -77,25 +99,23 @@ class BaseTestTcpTeardown:
               --dest=io.mender.AuthenticationManager \\
               /io/mender/AuthenticationManager \\
               io.mender.Authentication1.FetchJwtToken""")
-        time.sleep(1)
-        assert get_opened_tcp_connections(mender_device, "mender-auth") == 0
+        assert_no_open_tcp_connections(mender_device, "mender-auth")
 
         # To test mender-update, set long intervals and manually trigger operations
         set_long_poll_intervals(mender_device)
         mender_device.run("systemctl start mender-updated")
+        # let mender-updated come up before checking it is idle (long poll intervals)
         time.sleep(5)
-        assert get_opened_tcp_connections(mender_device, "mender-update") == 0
-        assert get_opened_tcp_connections(mender_device, "mender-auth") == 0
+        assert_no_open_tcp_connections(mender_device, "mender-update")
+        assert_no_open_tcp_connections(mender_device, "mender-auth")
 
         mender_device.run("mender-update check-update")
-        time.sleep(1)
-        assert get_opened_tcp_connections(mender_device, "mender-update") == 0
-        assert get_opened_tcp_connections(mender_device, "mender-auth") == 0
+        assert_no_open_tcp_connections(mender_device, "mender-update")
+        assert_no_open_tcp_connections(mender_device, "mender-auth")
 
         mender_device.run("mender-update send-inventory")
-        time.sleep(1)
-        assert get_opened_tcp_connections(mender_device, "mender-update") == 0
-        assert get_opened_tcp_connections(mender_device, "mender-auth") == 0
+        assert_no_open_tcp_connections(mender_device, "mender-update")
+        assert_no_open_tcp_connections(mender_device, "mender-auth")
 
 
 class TestTcpTeardownOpenSource(BaseTestTcpTeardown):


### PR DESCRIPTION
## What
Fixes the intermittent `test_tcp_teardown` failure `AssertionError: assert 1 == 0`.

## Why it's flaky
The test counted **every** entry in `/proc/$pid/net/tcp` whose remote port is `:01BB` (443), in **any TCP state**, and asserted `== 0` once after a fixed `time.sleep(1)`. After mender finishes an HTTP request and closes the socket, the connection lingers in **TIME_WAIT** (and briefly other post-close states) — that is the kernel's normal teardown, not a leaked/open socket. If a just-closed connection was still in TIME_WAIT when the 1s sleep elapsed, the count was `1` and the assert failed.

## Fix
- `get_opened_tcp_connections` now counts only **ESTABLISHED** connections (state `01`) to the server port, so post-close states (TIME_WAIT etc.) are not mistaken for "not torn down".
- Replaced the `sleep(1)` + one-shot assert with `assert_no_open_tcp_connections`, which **polls** until the established count drains (default 30s) — the socket close is async. A genuinely leaked/held-open socket still fails (it stays ESTABLISHED).

Keeps the real intent (mender must close sockets after requests) while removing the race.

## Changelog
None
