### PR TITLE
test(infra): pin RetryPollIntervalSeconds in test images (fixes mid-June failure/rollback test regression)

### DIFF
--- a/tests/modify_ext4.sh
+++ b/tests/modify_ext4.sh
@@ -22,5 +22,18 @@ debugfs -R "dump $MENDER_CONF $TEMPFILE" "$IMAGE_TO_EDIT"
 sed -i 's/.*UpdatePollIntervalSeconds.*/\  "UpdatePollIntervalSeconds\": 2,/g' "$TEMPFILE"
 sed -i 's/.*InventoryPollIntervalSeconds.*/\  "InventoryPollIntervalSeconds\": 2,/g' "$TEMPFILE"
 
+# MEN-9719: the client now defaults RetryPollIntervalSeconds to 300s (changed from
+# 0 in mender PR #1971). With the default unlimited retry count the retry backoff
+# starts at 60s, doubles, and is capped at this value, so a transiently-failing
+# status/inventory push backs off for ~36 minutes before giving up (vs ~180s with the
+# old default). That far exceeds the test timeouts and makes failure/rollback tests
+# (e.g. test_state_scripts[Corrupted_script_version], test_rootfs_conf_missing_from_new_update)
+# never reach their terminal state in the test window. The test server is reliably
+# reachable, so pin a short retry interval like the other intervals above. Replace the
+# key if present, otherwise add it next to UpdatePollIntervalSeconds.
+sed -i 's/.*RetryPollIntervalSeconds.*/\  "RetryPollIntervalSeconds\": 0,/g' "$TEMPFILE"
+grep -q RetryPollIntervalSeconds "$TEMPFILE" \
+    || sed -i '/"UpdatePollIntervalSeconds"/a\  "RetryPollIntervalSeconds\": 0,' "$TEMPFILE"
+
 debugfs -w -R "rm $MENDER_CONF" "$IMAGE_TO_EDIT"
 printf 'cd %s\nwrite %s %s\n' `dirname $MENDER_CONF` "$TEMPFILE" `basename $MENDER_CONF` | debugfs -w "$IMAGE_TO_EDIT"


### PR DESCRIPTION
## What
Fixes the mid-June regression where update **failure/rollback** tests stopped reaching their terminal state across **all** server versions (4.0.x / 4.1.x / main):
- `test_state_scripts[Corrupted_script_version_in_data]` — `Failed: Never found: failure:1 after 600s`
- `test_fault_tolerance.py::...::test_rootfs_conf_missing_from_new_update` — `RuntimeError: Device never rebooted`

Both started failing on the **2026-06-16/17** nightlies and span every server version (same `mender:master` client).

## Root cause (validated)
mender **PR #1971 / MEN-9719** (`c47b44b1`, merged ~June 14) changed the client default:
```
- int retry_poll_interval_seconds = 0;
+ int retry_poll_interval_seconds = 300;
```
The retry backoff (`ExponentialBackoff`) has a 60s floor, doubles, and is capped at `RetryPollIntervalSeconds`, with the default **unlimited** retry count. So:
- old default `0` → clamped to 60s floor → 3 retries → **~180s** then give up;
- new default `300` → 60→120→240→300 → **~36 minutes** before giving up.

`send_final_status_state_` and `send_commit_status_state_` use `RetryThenFail`. When the final `failure`/commit status push hits a transient error, the client now backs off for ~36 min — far longer than the test windows — so the deployment never reaches `failure` / never does the rollback reboot in time.

The test images (`tests/modify_ext4.sh`) set `UpdatePollIntervalSeconds`/`InventoryPollIntervalSeconds` to 2 but **never** `RetryPollIntervalSeconds`, so they inherited the new 300s default.

## Fix
Set `RetryPollIntervalSeconds` low in the test client image config (alongside the existing poll-interval patches), restoring the pre-regression fast give-up. `0` clamps to the 60s backoff floor → ~180s, well within the test windows. Replace-or-append so it works whether or not the key is already present.

## Notes for reviewers
- This is a **test-environment config** fix (the production 300s default is reasonable); it does not change client behavior.
- `tests/modify_ext4.sh` has no caller inside this repo — it's invoked by the image build (mender-qa). Please confirm that path uses this script so the change takes effect; if QEMU client images are configured elsewhere, the same `RetryPollIntervalSeconds` setting belongs there too.
- Possible separate **client** follow-up (MEN-9719): the interaction of the 300s default with the *unlimited* default retry count yields a ~36-min wait on a failed status push — worth confirming that's intended for production.

## Changelog
None
