### PR TITLE
test(state-scripts): fix intermittent test_set10 failure caused by systemd start-limit on simulated reboots

### DIFF
--- a/tests/module-state-scripts-test
+++ b/tests/module-state-scripts-test
@@ -18,6 +18,13 @@ case "$STATE" in
         ;;
 
     ArtifactReboot|ArtifactRollbackReboot)
+        # This simulated reboot restarts the service in milliseconds. A failed
+        # corrupt-version rollback fires ArtifactReboot and ArtifactRollbackReboot
+        # back-to-back, which together with restarts from earlier deployments on the
+        # same device trips systemd's default start rate-limit (5 starts / 10s) and
+        # leaves mender-updated dead, so the deployment failure is never reported.
+        # A real reboot never hits this; reset the counter so each one behaves like it.
+        systemctl reset-failed mender-updated
         systemctl restart mender-updated
         ;;
 


### PR DESCRIPTION
## Problem
`test_state_scripts[Corrupted_script_version_in_data-test_set10]` fails intermittently (~50% of nightlies since ~2026-06-26) with `Failed: Never found: failure:1 ... after 600 seconds`. The deployment fails correctly on-device, but the server never receives the `failure` status, so the test times out.

## Root cause (test-side, not a client bug)
`state_scripts` runs on the QEMU/systemd client, where reboots are simulated by this module via `systemctl restart mender-updated`. In the corrupted-version case the bad version file makes every rollback state script fail instantly, so the client fires **ArtifactReboot and ArtifactRollbackReboot restarts ~60 ms apart**. `mender-updated.service` ships with `Restart=always` and systemd's default start rate-limit (**5 starts / 10 s**, no override). Stacked with restarts from earlier deployments on the same device, that trips the limit — systemd logs `Start request repeated too quickly` / `start-limit-hit` (journal only) and leaves `mender-updated` **dead**, so the failure is never reported.

**Evidence:** across 8/8 genuine failures the client's last log line is always the `ArtifactRollbackRebootEnter` version error + `Termination signal received`, then silence — it never resumes, never runs `ArtifactFailure`, never pushes status, with zero retry/backoff logs. Reproduced in a minimal systemd container with the real unit file: the 6th rapid `systemctl restart` hits `start-limit-hit` and the service stays down (`Restart=always` does not recover it); `reset-failed` before each restart (this fix) survives 12× the load. Real hardware never hits this because real reboots are tens of seconds apart.

## Fix
`systemctl reset-failed mender-updated` before the restart, so each simulated reboot behaves like a rate-limit-free real reboot.

## Not the cause
This is **not** `RetryPollIntervalSeconds` — the client dies at the reboot before ever reaching the status push. PR #2942 (RetryPollInterval) does not fix this and should be reconsidered.
