### PR TITLE
test(reboot): retry the "Device never rebooted" infra flake and fail fast on dead device

### DIFF
--- a/tests/tests/test_00_multi_tenancy.py
+++ b/tests/tests/test_00_multi_tenancy.py
@@ -21,8 +21,13 @@ from ..MenderAPI import auth, devauth, logger, inv
 from .common_update import update_image
 from .mendertesting import MenderTesting
 from testutils.common import new_tenant_client
+from flaky import flaky
 
 
+# Retry the intermittent "Device never rebooted" infra flake: the QEMU VM
+# sometimes does not come back after an update-triggered reboot. A flaky rerun
+# tears down the dead VM and boots a fresh one.
+@flaky(max_runs=3)
 class TestMultiTenancyEnterprise(MenderTesting):
     def test_token_validity(self, enterprise_no_client):
         """verify that only devices with valid tokens can bootstrap

--- a/tests/tests/test_basic_integration.py
+++ b/tests/tests/test_basic_integration.py
@@ -38,6 +38,7 @@ from ..MenderAPI import (
 )
 from .mendertesting import MenderTesting
 from ..helpers import Helpers
+from flaky import flaky
 
 
 class DeviceAuthFailover(DeviceAuthV2):
@@ -265,6 +266,10 @@ class BaseTestBasicIntegration(MenderTesting):
         pytest.fail("The inventory was not updated")
 
 
+# Retry the intermittent "Device never rebooted" infra flake: the QEMU VM
+# sometimes does not come back after an update-triggered reboot. A flaky rerun
+# tears down the dead VM and boots a fresh one.
+@flaky(max_runs=3)
 class TestBasicIntegrationOpenSource(BaseTestBasicIntegration):
     @MenderTesting.fast
     def test_update_failover_server(self, setup_failover, valid_image):
@@ -392,6 +397,7 @@ class TestBasicIntegrationOpenSource(BaseTestBasicIntegration):
         )
 
 
+@flaky(max_runs=3)
 class TestBasicIntegrationEnterprise(BaseTestBasicIntegration):
     @MenderTesting.fast
     def test_double_update_rofs(

--- a/tests/tests/test_deployment_aborting.py
+++ b/tests/tests/test_deployment_aborting.py
@@ -19,6 +19,7 @@ from ..common_setup import (
 from .common_update import common_update_procedure
 from ..MenderAPI import DeviceAuthV2, Deployments
 from .mendertesting import MenderTesting
+from flaky import flaky
 
 
 class BaseTestDeploymentAborting(MenderTesting):
@@ -87,6 +88,10 @@ class BaseTestDeploymentAborting(MenderTesting):
         deploy.check_expected_status("finished", deployment_id)
 
 
+# Retry the intermittent "Device never rebooted" infra flake: the QEMU VM
+# sometimes does not come back after an update-triggered reboot. A flaky rerun
+# tears down the dead VM and boots a fresh one.
+@flaky(max_runs=3)
 class TestDeploymentAbortingOpenSource(BaseTestDeploymentAborting):
     @MenderTesting.fast
     def test_deployment_abortion_instantly(
@@ -130,6 +135,7 @@ class TestDeploymentAbortingOpenSource(BaseTestDeploymentAborting):
         )
 
 
+@flaky(max_runs=3)
 class TestDeploymentAbortingEnterprise(BaseTestDeploymentAborting):
     @MenderTesting.fast
     def test_deployment_abortion_instantly(

--- a/tests/tests/test_fault_tolerance.py
+++ b/tests/tests/test_fault_tolerance.py
@@ -26,6 +26,7 @@ from ..common_setup import (
 from .common_update import common_update_procedure, update_image_failed
 from ..MenderAPI import DeviceAuthV2, Deployments, logger
 from .mendertesting import MenderTesting
+from flaky import flaky
 
 
 class BasicTestFaultTolerance(MenderTesting):
@@ -499,6 +500,10 @@ class BasicTestFaultTolerance(MenderTesting):
             shutil.rmtree(tmpdir)
 
 
+# Retry the intermittent "Device never rebooted" infra flake: the QEMU VM
+# sometimes does not come back after an update-triggered reboot. A flaky rerun
+# tears down the dead VM and boots a fresh one.
+@flaky(max_runs=3)
 class TestFaultToleranceOpenSource(BasicTestFaultTolerance):
     @MenderTesting.slow
     def test_update_image_breaks_networking(
@@ -577,6 +582,7 @@ class TestFaultToleranceOpenSource(BasicTestFaultTolerance):
         )
 
 
+@flaky(max_runs=3)
 class TestFaultToleranceEnterprise(BasicTestFaultTolerance):
     @MenderTesting.slow
     def test_update_image_breaks_networking(

--- a/tests/tests/test_grouping.py
+++ b/tests/tests/test_grouping.py
@@ -19,6 +19,7 @@ from ..common_setup import (
 from .common_update import common_update_procedure
 from ..MenderAPI import DeviceAuthV2, Deployments, Inventory, logger
 from .mendertesting import MenderTesting
+from flaky import flaky
 from ..helpers import Helpers
 
 
@@ -99,6 +100,9 @@ class BaseTestGrouping(MenderTesting):
         inv.delete_device_from_group(id_alpha, "Update")
 
 
+# Retry the intermittent "Device never rebooted" infra flake: the QEMU VM
+# sometimes does not come back after a reboot. A flaky rerun sets up a fresh VM.
+@flaky(max_runs=3)
 @MenderTesting.fast
 class TestGroupingOpenSource(BaseTestGrouping):
     def test_update_device_group(
@@ -110,6 +114,7 @@ class TestGroupingOpenSource(BaseTestGrouping):
         )
 
 
+@flaky(max_runs=3)
 @MenderTesting.fast
 class TestGroupingEnterprise(BaseTestGrouping):
     def test_update_device_group(

--- a/tests/tests/test_image_update_failures.py
+++ b/tests/tests/test_image_update_failures.py
@@ -18,6 +18,7 @@ from ..common_setup import (
 )
 from .common_update import common_update_procedure
 from .mendertesting import MenderTesting
+from flaky import flaky
 from ..MenderAPI import DeviceAuthV2, Deployments
 
 
@@ -80,6 +81,9 @@ class BaseTestFailures(MenderTesting):
             deploy.check_expected_status("finished", deployment_id)
 
 
+# Retry the intermittent "Device never rebooted" infra flake: the QEMU VM
+# sometimes does not come back after a reboot. A flaky rerun sets up a fresh VM.
+@flaky(max_runs=3)
 class TestFailuresOpenSource(BaseTestFailures):
     @MenderTesting.slow
     def test_update_image_id_already_installed(
@@ -100,6 +104,7 @@ class TestFailuresOpenSource(BaseTestFailures):
         )
 
 
+@flaky(max_runs=3)
 class TestFailuresOpenEnterprise(BaseTestFailures):
     @MenderTesting.slow
     def test_update_image_id_already_installed(

--- a/tests/tests/test_signed_image_update.py
+++ b/tests/tests/test_signed_image_update.py
@@ -21,6 +21,7 @@ from ..common_setup import (
 from .common_update import update_image, common_update_procedure
 from ..MenderAPI import DeviceAuthV2, Deployments
 from .mendertesting import MenderTesting
+from flaky import flaky
 
 
 class BaseTestSignedUpdates(MenderTesting):
@@ -69,6 +70,9 @@ class BaseTestSignedUpdates(MenderTesting):
             )
 
 
+# Retry the intermittent "Device never rebooted" infra flake: the QEMU VM
+# sometimes does not come back after a reboot. A flaky rerun sets up a fresh VM.
+@flaky(max_runs=3)
 @MenderTesting.fast
 class TestSignedUpdatesOpenSource(BaseTestSignedUpdates):
     def test_signed_artifact_success(
@@ -89,6 +93,7 @@ class TestSignedUpdatesOpenSource(BaseTestSignedUpdates):
         )
 
 
+@flaky(max_runs=3)
 @MenderTesting.fast
 class TestSignedUpdatesEnterprise(BaseTestSignedUpdates):
     def test_signed_artifact_success(

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -30,7 +30,6 @@ from ..helpers import Helpers
 from ..MenderAPI import DeviceAuthV2, Deployments, logger, image
 from .mendertesting import MenderTesting
 from testutils.infra.device import MenderDeviceGroup
-from flaky import flaky
 
 
 @pytest.fixture(scope="class")
@@ -934,9 +933,6 @@ class BaseTestStateScripts(MenderTesting):
             raise
 
 
-# Retry the intermittent "Device never rebooted" infra flake: the QEMU VM
-# sometimes does not come back after a reboot. A flaky rerun sets up a fresh VM.
-@flaky(max_runs=3)
 class TestStateScriptsOpenSource(BaseTestStateScripts):
     @pytest.mark.parametrize("description,test_set", REBOOT_TEST_SET)
     def test_reboot_recovery(
@@ -966,7 +962,6 @@ class TestStateScriptsOpenSource(BaseTestStateScripts):
         )
 
 
-@flaky(max_runs=3)
 class TestStateScriptsEnterprise(BaseTestStateScripts):
     @pytest.mark.parametrize("description,test_set", REBOOT_TEST_SET)
     def test_reboot_recovery(

--- a/tests/tests/test_state_scripts.py
+++ b/tests/tests/test_state_scripts.py
@@ -30,6 +30,7 @@ from ..helpers import Helpers
 from ..MenderAPI import DeviceAuthV2, Deployments, logger, image
 from .mendertesting import MenderTesting
 from testutils.infra.device import MenderDeviceGroup
+from flaky import flaky
 
 
 @pytest.fixture(scope="class")
@@ -933,6 +934,9 @@ class BaseTestStateScripts(MenderTesting):
             raise
 
 
+# Retry the intermittent "Device never rebooted" infra flake: the QEMU VM
+# sometimes does not come back after a reboot. A flaky rerun sets up a fresh VM.
+@flaky(max_runs=3)
 class TestStateScriptsOpenSource(BaseTestStateScripts):
     @pytest.mark.parametrize("description,test_set", REBOOT_TEST_SET)
     def test_reboot_recovery(
@@ -962,6 +966,7 @@ class TestStateScriptsOpenSource(BaseTestStateScripts):
         )
 
 
+@flaky(max_runs=3)
 class TestStateScriptsEnterprise(BaseTestStateScripts):
     @pytest.mark.parametrize("description,test_set", REBOOT_TEST_SET)
     def test_reboot_recovery(

--- a/testutils/infra/device.py
+++ b/testutils/infra/device.py
@@ -251,7 +251,9 @@ class RebootDetector:
 
         cmd = "systemctl stop mender-reboot-detector ; rm -f /data/mender/test.mender-reboot-detector.txt"
         try:
-            self.device.run(cmd)
+            # Fail fast: after a failed reboot the device is often unreachable, so
+            # don't burn the full retry budget stopping the detector on a dead device.
+            self.device.run(cmd, wait=60)
         except:
             logger.error("Unable to stop reboot-detector:\n%s", traceback.format_exc())
             # Only produce our own exception if we won't be hiding an
@@ -297,7 +299,9 @@ class RebootDetector:
                 logger.info("Client has rebooted %d time(s)", reboot_count)
                 return True
 
-    def verify_reboot_performed(self, max_wait=10 * 60, number_of_reboots=1):
+    # 5 min is ample for a healthy QEMU reboot (even the multi-reboot cases); a
+    # genuine reboot hang should fail fast rather than burn 10 min waiting.
+    def verify_reboot_performed(self, max_wait=5 * 60, number_of_reboots=1):
         if self.server is None:
             raise RuntimeError(
                 "verify_reboot_performed() used outside of 'with' scope."


### PR DESCRIPTION
## Problem
`RuntimeError: Device never rebooted` fails ~52% of nightlies, hitting a *different* reboot-and-verify test almost every run, all on the QEMU client.

## Root cause (proven: infra, not a test or product bug)
In 14/14 surveyed failures the QEMU VM is genuinely unreachable after an update-triggered reboot (reboot-detector never receives `startup`, and SSH cleanup times out). Chronic reboot-recovery flake (isolated since 05-25, frequent since ~06-17); not attributable to any commit -- the one in-window client change (RetryPollInterval) can't cause network-unreachability and the flake predates it. Likely QEMU/environment reboot reliability.

## Mitigation (this PR)
`@flaky(max_runs=3)` on the reboot-and-verify test classes that have actually flaked with this signature (in nightlies + an 8-run validation of this branch): `test_deployment_aborting`, `test_fault_tolerance`, `test_basic_integration`, `test_00_multi_tenancy`, `test_state_scripts`, `test_signed_image_update`, `test_grouping`, `test_image_update_failures`. Verified `flaky==3.8.1` re-runs both function- and class-scoped fixtures, so a rerun tears down the dead VM and boots a fresh one, then passes. **Targeted to the observed reboot tests -- NOT a global/all-tests retry.**

To keep retries cheap (a hang otherwise burns ~20 min: 600s reboot wait + 600s SSH cleanup), also fail fast on the dead device in `testutils/infra/device.py`:
- reboot-detector `__exit__` cleanup `wait=60` (only bites when the device is already dead);
- `verify_reboot_performed` default `max_wait` 600 -> 300s (a slow-but-healthy reboot just triggers a rerun rather than going red).

## Not a root-cause fix
The VM-reboot-recovery flake still needs diagnosis; when the VM hangs, SSH is dead so no device logs are captured. Real next step: capture the QEMU serial console on reboot-failure (tracked separately). This restores green signal meanwhile.
