### PR TITLE
test(mender-connect): retry when a previous shell session is not reaped

### DIFF
--- a/tests/tests/test_mender_connect.py
+++ b/tests/tests/test_mender_connect.py
@@ -42,6 +42,21 @@ from .common_connect import wait_for_connect
 
 container_factory = factory.get_factory()
 
+# Errors mender-connect returns when a shell from an earlier attempt has not
+# been reaped yet, see session/shell.go in mender-connect. Both mean "try again
+# later", not "the protocol is broken".
+#
+# Which one you get depends on the session id: routeMessageSpawnShell looks the
+# session up by the id in the message, so a *new* websocket (new id) always goes
+# through NewMenderShellSession and hits the per-user limit ("too many open
+# sessions"), while reusing a websocket hits StartShell ("already running").
+# assert_working_shell opens a fresh websocket per attempt, so in practice only
+# the first is reachable there. (QA-1591)
+SHELL_NOT_REAPED_ERRORS = (
+    b"shell is already running",
+    b"user has too many open sessions",
+)
+
 
 class _TestRemoteTerminalBase:
     @flaky(max_runs=3)
@@ -228,13 +243,21 @@ class _TestRemoteTerminalBase:
                 if (
                     shell.protomsg.props["status"] != protomsg.PROP_STATUS_NORMAL
                     and body
-                    and b"already running" in body
+                    and any(err in body for err in SHELL_NOT_REAPED_ERRORS)
                 ):
-                    # A shell started by a previous attempt that flapped mid-use
-                    # may not be reaped yet (the shell limit is 1 per device).
-                    # Treat it as not-ready and let the retry wait for the device
-                    # to release it instead of failing on the assert below.
-                    raise TimeoutError("shell from a previous attempt is still running")
+                    # A shell started by a previous attempt may not be reaped
+                    # yet (the per-user session limit is 1). During the reconnect
+                    # churn below, deviceconnect closes a device connection as
+                    # soon as a newer one arrives for the same device, so a shell
+                    # started seconds earlier can lose its transport. We cannot
+                    # stop that shell ourselves - the websocket is already gone -
+                    # so mender-connect only releases the session once its health
+                    # check fails (60s+5s) and the next sweep runs (32s), i.e.
+                    # up to ~100s. Treat it as not-ready and let the retry wait
+                    # that out instead of failing on the assert below.
+                    raise TimeoutError(
+                        "shell from a previous attempt is still running: %s" % body
+                    )
                 assert (
                     shell.protomsg.props["status"] == protomsg.PROP_STATUS_NORMAL
                 ), f"unexpeted message status, received message: {shell.protomsg}"


### PR DESCRIPTION
`TestRemoteTerminalEnterprise::test_in_poor_network_environment` has been failing with `assert 2 == 1` since around Jul 9 ([example job](https://gitlab.com/Northern.tech/Mender/integration/-/jobs/15586709544)). This makes the existing retry loop actually retry, which it could not before.

## What was wrong

The loop already had a guard for "a shell from an earlier attempt is still running", but it matched an error that cannot occur there. Which error mender-connect returns depends on the session id (`app/daemon_shell.go:58-62`):

```go
s := session.MenderShellSessionGetById(message.Header.SessionID)
if s == nil { NewMenderShellSession(...) }   // → "user has too many open sessions"
// else → StartShell()                       // → "shell is already running"
```

`assert_working_shell` opens a **fresh websocket on every attempt**, so the session id is always new, so it always takes the `s == nil` branch and always gets the per-user session limit error. The guard matched `"already running"` — unreachable from there.

So the bare `assert` below the guard ran instead, and `retriable` deliberately does not retry `AssertionError`. One lost connection failed the test outright, with no retry, on all three `@flaky` attempts.

Confirmed in the container logs: `user has too many open sessions` appears 3×, `shell is already running` and `too many shells spawned` 0×.

## Why the connection is lost

Expected, and not something the test can avoid. Since [mender-server#2029](https://github.com/mendersoftware/mender-server/pull/2029) deviceconnect closes a device's connection as soon as a newer one arrives for that device, so a shell started seconds earlier can lose its transport during the reconnect churn after the outage:

```
ts=22:45:48.058  rt=4.058s   error="context canceled"           ← shell started on this at 22:45:51
ts=22:45:52.114  rt=2.103ms  error="close 1006 unexpected EOF"  ← the newcomer that evicted it
```

We cannot stop the orphaned shell ourselves — the websocket is already gone — so mender-connect releases the session only after its health check fails (60s+5s, `session/shell.go:73-74`) and the next sweep runs (32s, `app/daemon.go:40`): ~100s worst case, against the loop's existing 240s budget (48 × 5s). Replaying the failing timeline, recovery lands ~45–75s in.

## The change

Match both error strings, and include the response body in the message — the previous version discarded it, which is why this surfaced as a bare `assert 2 == 1` with no hint of the cause.

## Scope

This stops the test failing when a connection is lost, which is correct regardless of server behaviour. It does **not** fix the underlying problem: deviceconnect evicts a healthy connection in favour of a new one without checking the new one is alive, and in the log above the newcomer lived 2.1 ms. That kills live remote terminal sessions during network recovery and needs a fix in deviceconnect — raised separately with the backend team.

Note the same defect affects OS and Enterprise alike; only the Enterprise variant hits it reliably in CI (6 failures in 11 jobs vs 0), because that fixture provisions two tenants/devices per test where OS provisions one, biasing the timing into the ~3–4s eviction window.
