### PR TITLE
ci: move renovate job to k8s runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ include:
   - component: gitlab.com/Northern.tech/Mender/mendertesting/renovate@master
     inputs:
       stage: "renovate"
+      runner: "k8s"
 
 default:
   tags: !reference [.qa-common-default-runner, tags]


### PR DESCRIPTION
Renovate keeps crashing with a Node heap OOM on the k8s-small runner (confirmed same crash on 2026-08-13 and twice today). Moving it to the k8s runner tag per Roberto's suggestion.