### PR TITLE
ci: make the renovate schedule produce a renovate-only pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,13 +5,22 @@ include:
       - qa-common/retry.yml
   - project: "Northern.tech/Mender/mendertesting"
     file: ".gitlab-ci-github-status-updates.yml"
+    rules:
+      # A renovate schedule should produce a renovate-only pipeline.
+      - if: $RENOVATE_SCHEDULED_RUN == "true"
+        when: never
+      - when: always
   - local: .gitlab-ci-default-pipeline.yml
     rules:
+      - if: $RENOVATE_SCHEDULED_RUN == "true"
+        when: never
       - if: $RUN_TESTS_FULL_INTEGRATION == "true"
         when: never
       - when: always
   - local: .gitlab-ci-full-integration-generator.yml
     rules:
+      - if: $RENOVATE_SCHEDULED_RUN == "true"
+        when: never
       - if: $RUN_TESTS_FULL_INTEGRATION == "true"
   - component: gitlab.com/Northern.tech/Mender/mendertesting/renovate@master
     inputs:


### PR DESCRIPTION
Part of QA-1734

The renovate schedule was firing a full pipeline, so one weekly renovate run dragged every other job along with it

This repo is the easy case - all the jobs already live behind local includes, so the fix is include level rules rather than touching individual jobs. `rules` is supported on every include type and scheduled pipeline variables are available there, which is the same mechanism this repo already uses for RUN_TESTS_FULL_INTEGRATION

What stays unconditional
- qa-common/runner.yml and retry.yml, because `default:` references their anchors with !reference and the config will not compile without them
- the renovate component itself, which decides for itself via its own rules

Note $CI_COMMIT_REF_PROTECTED is not available in include rules, only in job rules, so the include gate keys on RENOVATE_SCHEDULED_RUN alone. The renovate job still checks the protected ref itself

Side effect worth having - github:start, github:success and github:failure no longer fire on renovate schedules. The mendertesting template already has a comment about hitting GitHub's maximum number of statuses for a single SHA and context, and a weekly no-op pipeline on the same main SHA was contributing to that

Suggested as the pilot for this change. If it looks right here the same shape applies to mender-cli and sre-tools, and the two monorepos need their inline jobs moved into a local include first
