### PR TITLE
ci: drop the per repo renovate job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,10 +13,6 @@ include:
   - local: .gitlab-ci-full-integration-generator.yml
     rules:
       - if: $RUN_TESTS_FULL_INTEGRATION == "true"
-  - component: gitlab.com/Northern.tech/Mender/mendertesting/renovate@master
-    inputs:
-      stage: "renovate"
-      runner: "k8s"
 
 default:
   tags: !reference [.qa-common-default-runner, tags]


### PR DESCRIPTION
Renovate now runs centrally from NorthernTechHQ/renovate-ring, which reads this repo's renovate.json5 straight from GitHub. Nothing about grouping or managers changes.

The job only ever triggered on a pipeline schedule and that schedule is already deleted, so this removes config that can no longer run.