### PR TITLE
ci: drop the leftover renovate stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,6 @@ default:
       - stuck_or_timeout_failure
 
 stages:
-  - renovate
   - test-gen
   - test
   - build


### PR DESCRIPTION
Follow up to dropping the per repo renovate job. The job is gone but the stage it declared was left in the stages list, so it sits there empty.